### PR TITLE
Support create_generated_clock on internal pins

### DIFF
--- a/.claude/skills/llm-wiki/scripts/wiki-lint.py
+++ b/.claude/skills/llm-wiki/scripts/wiki-lint.py
@@ -58,7 +58,7 @@ def find_wiki_pages(wiki_root):
                         fm = {"_parse_error": parts[1][:80]}
 
             # Extract [[wikilinks]] (including [[page#anchor]] and [[page|alias]])
-            wikilinks = re.findall(r'\[\[([^\]|]+)(?:\|[^\]]+)?\]\]', content)
+            wikilinks = re.findall(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]", content)
             tags = fm.get("tags", []) if isinstance(fm.get("tags"), list) else []
 
             pages[rel_path] = {
@@ -103,7 +103,7 @@ def load_schema_tags(wiki_root):
             if line.strip().startswith("## "):
                 break
             # Match lines like `- Category: tag1, tag2, tag3`
-            match = re.match(r'\s*-\s+\w+\s*:\s*(.+)', line)
+            match = re.match(r"\s*-\s+\w+\s*:\s*(.+)", line)
             if match:
                 for t in match.group(1).split(","):
                     t = t.strip()
@@ -123,7 +123,6 @@ def lint_wiki(wiki_root):
     # Build inbound link map
     inbound = defaultdict(set)
     for rel_path, info in pages.items():
-        my_slug = os.path.splitext(os.path.basename(rel_path))[0]
         for link in info["wikilinks"]:
             # Separate [[page#anchor]] into page part and anchor part
             link_page = link.split("#")[0]
@@ -154,12 +153,12 @@ def lint_wiki(wiki_root):
 
         # --- 1. Orphans ---
         if len(inbound[rel_path]) == 0:
-            issues["orphan"].append((f"Zero inbound [[wikilinks]]", rel_path))
+            issues["orphan"].append(("Zero inbound [[wikilinks]]", rel_path))
 
         # --- 3. Index completeness ---
         if rel_path not in ("index.md", "SCHEMA.md", "log.md"):
             if f"[[{slug}" not in index_content:
-                issues["index"].append((f"Missing from index.md", rel_path))
+                issues["index"].append(("Missing from index.md", rel_path))
 
         # --- 4. Frontmatter validation ---
         required = ["title", "created", "updated", "type", "tags", "sources"]
@@ -200,9 +199,7 @@ def lint_wiki(wiki_root):
 
         # --- 6. Contradictions ---
         if fm.get("contested"):
-            issues["contradiction"].append(
-                (f"contested=true — needs review", rel_path)
-            )
+            issues["contradiction"].append(("contested=true — needs review", rel_path))
         if fm.get("contradictions"):
             issues["contradiction"].append(
                 (f"contradictions={fm['contradictions']}", rel_path)
@@ -212,12 +209,14 @@ def lint_wiki(wiki_root):
         confidence = fm.get("confidence")
         sources = fm.get("sources", [])
         if confidence == "low":
+            issues["quality"].append(("confidence=low (needs corroboration)", rel_path))
+        elif (
+            confidence is None
+            and not sources
+            and slug not in ("SCHEMA", "index", "log")
+        ):
             issues["quality"].append(
-                (f"confidence=low (needs corroboration)", rel_path)
-            )
-        elif confidence is None and not sources and slug not in ("SCHEMA", "index", "log"):
-            issues["quality"].append(
-                (f"Single-source page, no confidence field set", rel_path)
+                ("Single-source page, no confidence field set", rel_path)
             )
 
         # --- 9. Page size ---
@@ -260,7 +259,10 @@ def lint_wiki(wiki_root):
         unused = [t for t in sorted(schema_tags) if t not in used_tags]
         if unused:
             issues["tag-audit"].append(
-                (f"Tags in schema but never used: {', '.join(unused[:15])}", "SCHEMA.md")
+                (
+                    f"Tags in schema but never used: {', '.join(unused[:15])}",
+                    "SCHEMA.md",
+                )
             )
 
     # --- 11. Log rotation ---
@@ -268,7 +270,7 @@ def lint_wiki(wiki_root):
     if os.path.exists(log_path):
         with open(log_path, encoding="utf-8") as f:
             log_content = f.read()
-        entry_count = len(re.findall(r'^## \[', log_content, re.MULTILINE))
+        entry_count = len(re.findall(r"^## \[", log_content, re.MULTILINE))
         if entry_count > 500:
             issues["log-rotation"].append(
                 (f"{entry_count} entries — exceeds 500, needs rotation", "log.md")
@@ -295,7 +297,7 @@ def print_report(issues):
 
     total = sum(len(issues[key]) for key, _, _ in severity_order)
 
-    print(f"=== Wiki Lint Report ===\n")
+    print("=== Wiki Lint Report ===\n")
     print(f"Total issues: {total}\n")
 
     for key, title, _ in severity_order:

--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -251,7 +251,6 @@ def _analyze_and_report(
     violation. Waived findings are still reported but don't fail the
     run."""
     module = netlist.load(netlist_path)
-    domains = assign_domains(module)
 
     spec: sdc_mod.ClockSpec | None = None
     async_crossings: list[Crossing] = []
@@ -261,12 +260,16 @@ def _analyze_and_report(
         if spec.partial_warnings and fmt is OutputFormat.text:
             for w in spec.partial_warnings:
                 typer.echo(f"warning: {sdc_path}: {w}", err=True)
-        crossings = find_crossings(module, port_clock=spec.port_clock)
+        domains = assign_domains(module, pin_clocks=spec.pin_clocks)
+        crossings = find_crossings(
+            module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+        )
         async_crossings = _filter_async(crossings, spec)
         violations = run_all_rules(
             module, async_crossings, spec, required_depth=sync_depth
         )
     else:
+        domains = assign_domains(module)
         crossings = find_crossings(module)
 
     suppressed = []

--- a/src/rtl_buddy_cdc/domain.py
+++ b/src/rtl_buddy_cdc/domain.py
@@ -99,6 +99,7 @@ def trace_clock_root(
     bit: Bit,
     drivers: dict[Bit, tuple[str, str]] | None = None,
     max_depth: int = 16,
+    bit_to_clock: dict[Bit, str] | None = None,
 ) -> str | None:
     """Resolve a CLK net bit to the top-level port that ultimately drives it.
 
@@ -115,13 +116,20 @@ def trace_clock_root(
     - clock dividers — a flop's ``Q`` is followed back to the flop's
       own ``CLK`` pin, which is the upstream clock root.
 
+    When ``bit_to_clock`` is provided (typically derived from
+    ``ClockSpec.pin_clocks``), the walk *stops* at any bit that is part
+    of a net named as a ``create_generated_clock`` target and returns
+    that generated clock's name rather than continuing back to the top
+    input port. This is what models SoC clock-forwarding chains where
+    each block declares its forwarded clock at an internal pin.
+
     Returns ``None`` when no candidate root resolves within
     ``max_depth`` cells; the caller treats that as "domain unknown".
     """
     if drivers is None:
         drivers = _bit_drivers(module)
     seen: set[Bit] = set()
-    return _trace(module, bit, drivers, seen, max_depth)
+    return _trace(module, bit, drivers, seen, max_depth, bit_to_clock or {})
 
 
 def _trace(
@@ -130,10 +138,17 @@ def _trace(
     drivers: dict[Bit, tuple[str, str]],
     seen: set[Bit],
     depth: int,
+    bit_to_clock: dict[Bit, str],
 ) -> str | None:
     if not isinstance(bit, int) or depth <= 0 or bit in seen:
         return None
     seen.add(bit)
+
+    # Stop at a generated clock declared on an internal pin: this bit
+    # belongs to the net where the new clock identity takes over.
+    pin_clk = bit_to_clock.get(bit)
+    if pin_clk is not None:
+        return pin_clk
 
     port = module.port_of_bit(bit)
     if port is not None and port.direction == "input":
@@ -150,7 +165,7 @@ def _trace(
     if ctype in _BUFFER_TYPES:
         a = cell.connections.get("A", ())
         if a:
-            return _trace(module, a[0], drivers, seen, depth - 1)
+            return _trace(module, a[0], drivers, seen, depth - 1, bit_to_clock)
         return None
 
     # Clock gate — look at both inputs; if exactly one resolves to a
@@ -161,8 +176,16 @@ def _trace(
     if ctype in _GATE_TYPES:
         a = cell.connections.get("A", (None,))
         b = cell.connections.get("B", (None,))
-        a_root = _trace(module, a[0], drivers, set(seen), depth - 1) if a else None
-        b_root = _trace(module, b[0], drivers, set(seen), depth - 1) if b else None
+        a_root = (
+            _trace(module, a[0], drivers, set(seen), depth - 1, bit_to_clock)
+            if a
+            else None
+        )
+        b_root = (
+            _trace(module, b[0], drivers, set(seen), depth - 1, bit_to_clock)
+            if b
+            else None
+        )
         return a_root or b_root
 
     # Clock mux — return whichever side resolves.
@@ -170,7 +193,9 @@ def _trace(
         for in_port in ("A", "B"):
             in_bits = cell.connections.get(in_port, ())
             if in_bits:
-                root = _trace(module, in_bits[0], drivers, set(seen), depth - 1)
+                root = _trace(
+                    module, in_bits[0], drivers, set(seen), depth - 1, bit_to_clock
+                )
                 if root is not None:
                     return root
         return None
@@ -180,15 +205,48 @@ def _trace(
     if ctype in FF_CELL_TYPES and out_port == "Q":
         clk_bits = cell.connections.get("CLK", ())
         if clk_bits:
-            return _trace(module, clk_bits[0], drivers, seen, depth - 1)
+            return _trace(module, clk_bits[0], drivers, seen, depth - 1, bit_to_clock)
 
     return None
 
 
-def assign_domains(module: Module) -> list[FlopDomain]:
+def _build_bit_to_clock(
+    module: Module, pin_clocks: dict[str, str] | None
+) -> dict[Bit, str]:
+    """Expand SDC pin-target paths (``u_a/clk_out``) to a bit→clock map.
+
+    Yosys' flattened netlist preserves hierarchical wire names with
+    ``.`` as separator (e.g. ``u_a.clk_out``). The SDC convention is
+    ``/``. We normalise the SDC form to match before looking up the
+    netname and harvesting its bits.
+    """
+    out: dict[Bit, str] = {}
+    if not pin_clocks:
+        return out
+    for pin_path, clk_name in pin_clocks.items():
+        nn_key = pin_path.replace("/", ".")
+        nn = module.netnames.get(nn_key)
+        if nn is None:
+            continue
+        for b in nn.bits:
+            if isinstance(b, int):
+                # First writer wins. If two generated clocks target
+                # the same net, the SDC is internally inconsistent;
+                # we don't try to repair it here.
+                out.setdefault(b, clk_name)
+    return out
+
+
+def assign_domains(
+    module: Module, pin_clocks: dict[str, str] | None = None
+) -> list[FlopDomain]:
     drivers = _bit_drivers(module)
+    bit_to_clock = _build_bit_to_clock(module, pin_clocks)
     return [
-        FlopDomain(flop=f, clock=trace_clock_root(module, f.clk, drivers))
+        FlopDomain(
+            flop=f,
+            clock=trace_clock_root(module, f.clk, drivers, bit_to_clock=bit_to_clock),
+        )
         for f in find_flops(module)
     ]
 
@@ -216,6 +274,7 @@ def find_crossings(
     module: Module,
     max_hops: int = 4,
     port_clock: dict[str, str] | None = None,
+    pin_clocks: dict[str, str] | None = None,
 ) -> list[Crossing]:
     """Find every fanout path whose endpoints are in different domains.
 
@@ -233,7 +292,7 @@ def find_crossings(
     physical CLK domain; the port's clock is treated as the source
     domain for the async-pair check.
     """
-    domains = {fd.flop.cell.name: fd for fd in assign_domains(module)}
+    domains = {fd.flop.cell.name: fd for fd in assign_domains(module, pin_clocks)}
     consumers = _build_bit_consumers(module)
     flop_by_d_bit: dict[Bit, list[Flop]] = defaultdict(list)
     for fd in domains.values():

--- a/src/rtl_buddy_cdc/sdc.py
+++ b/src/rtl_buddy_cdc/sdc.py
@@ -70,6 +70,15 @@ class ClockSpec:
     # domain to data ports that aren't reached by any flop's CLK
     # tracing.
     port_clock: dict[str, str] = field(default_factory=dict)
+    # Internal pin path (e.g. ``"u_a/clk_out"``) → generated clock name,
+    # populated when a ``create_generated_clock`` target is a
+    # ``[get_pins …]`` expression rather than a top-level port. The
+    # clock-trace pass consults this to stop walking back through the
+    # netlist at the point where a generated clock takes over, instead
+    # of collapsing every flop to whichever top input port feeds the
+    # chain. The pin path uses SDC convention (``/`` separator); the
+    # consumer normalises to Yosys' flattened netname (``.`` separator).
+    pin_clocks: dict[str, str] = field(default_factory=dict)
     # Diagnostics accumulated during parse. Each entry is a single
     # human-readable sentence describing a CDC-relevant command the
     # parser couldn't fully understand. Surfaced once at the end of
@@ -296,6 +305,7 @@ def _handle_create_generated_clock(spec: ClockSpec, args: list[str]) -> None:
     multiply_by = 1
     period: float | None = None
     targets: list[str] = []
+    target_is_pin = False
     saw_filter = False
 
     i = 0
@@ -307,12 +317,18 @@ def _handle_create_generated_clock(spec: ClockSpec, args: list[str]) -> None:
         elif tok == "-master_clock" and i + 1 < len(args):
             master = _strip_get_clocks(args[i + 1])
             i += 2
-        elif tok == "-source" and i + 1 < len(args):
-            # Source can be a pin/port name, possibly bracketed; we
-            # only use it as a fallback for master clock identity if
-            # -master_clock is absent. Resolve later via clock_for_port
-            # in the consumer if needed; for now record the raw token.
-            i += 2
+        elif tok == "-source":
+            # The source expression is bracketed (``[get_ports ck_a]``
+            # or ``[get_pins u_a/clk_out]``) and shlex splits the
+            # opening bracket from the trailing ``]``-suffixed name —
+            # so we consume forward until the next ``-`` flag rather
+            # than a fixed token count. The source is currently used
+            # only as documentation; the master identity comes from
+            # ``-master_clock``.
+            j = i + 1
+            while j < len(args) and not args[j].startswith("-"):
+                j += 1
+            i = j
         elif tok == "-divide_by" and i + 1 < len(args):
             try:
                 divide_by = int(args[i + 1])
@@ -342,6 +358,8 @@ def _handle_create_generated_clock(spec: ClockSpec, args: list[str]) -> None:
             else:
                 i += 1
         else:
+            target_blob = " ".join(args[i:])
+            target_is_pin = "get_pins" in target_blob
             targets_chunk, saw_filter_chunk = _extract_ports_or_pins(args[i:])
             targets.extend(targets_chunk)
             saw_filter = saw_filter or saw_filter_chunk
@@ -369,10 +387,22 @@ def _handle_create_generated_clock(spec: ClockSpec, args: list[str]) -> None:
             f"create_generated_clock {name}: ignored unsupported -filter clause"
         )
 
+    # Pin-targeted generated clocks (e.g. ``[get_pins u_a/clk_out]``)
+    # don't belong in ``Clock.ports`` — that field is reserved for
+    # top-level port names so ``clock_for_port`` can do a clean port→
+    # clock lookup. Pin targets land in ``spec.pin_clocks`` instead,
+    # consumed by the clock-trace pass.
+    if target_is_pin:
+        clock_ports: tuple[str, ...] = ()
+        for t in targets:
+            spec.pin_clocks[t] = name
+    else:
+        clock_ports = tuple(targets)
+
     spec.clocks[name] = Clock(
         name=name,
         period=period,
-        ports=tuple(targets),
+        ports=clock_ports,
         master=master,
         is_generated=True,
     )

--- a/tests/fixtures/bad_source_sync_internal/bad_source_sync_internal.json
+++ b/tests/fixtures/bad_source_sync_internal/bad_source_sync_internal.json
@@ -1,0 +1,1007 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_source_sync_internal": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "bad_source_sync_internal.sv:68.1-95.10"
+      },
+      "ports": {
+        "ck_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "d_in": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "q_out_c0": {
+          "direction": "output",
+          "bits": [ 5 ]
+        },
+        "q_out_c1": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$flatten\\u_a.$auto$proc_dff.cc:220:proc_dff$17": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 7 ]
+          }
+        },
+        "$flatten\\u_a.$logic_not$bad_source_sync_internal.sv:17$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:17.13-17.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$flatten\\u_a.$procdff$21": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:16.5-19.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 2 ],
+            "D": [ 4 ],
+            "Q": [ 9 ]
+          }
+        },
+        "$flatten\\u_b0.$auto$proc_dff.cc:220:proc_dff$12": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 10 ]
+          }
+        },
+        "$flatten\\u_b0.$logic_not$bad_source_sync_internal.sv:44$4": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:44.13-44.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 11 ]
+          }
+        },
+        "$flatten\\u_b0.$procdff$16": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:43.5-46.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 12 ],
+            "D": [ 9 ],
+            "Q": [ 13 ]
+          }
+        },
+        "$flatten\\u_b1.$auto$proc_dff.cc:220:proc_dff$12": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 14 ]
+          }
+        },
+        "$flatten\\u_b1.$logic_not$bad_source_sync_internal.sv:44$4": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:44.13-44.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 15 ]
+          }
+        },
+        "$flatten\\u_b1.$procdff$16": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:43.5-46.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 16 ],
+            "D": [ 9 ],
+            "Q": [ 17 ]
+          }
+        },
+        "$flatten\\u_c0.$auto$proc_dff.cc:220:proc_dff$7": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 18 ]
+          }
+        },
+        "$flatten\\u_c0.$logic_not$bad_source_sync_internal.sv:62$6": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:62.13-62.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 19 ]
+          }
+        },
+        "$flatten\\u_c0.$procdff$11": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:61.5-64.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 20 ],
+            "D": [ 13 ],
+            "Q": [ 5 ]
+          }
+        },
+        "$flatten\\u_c1.$auto$proc_dff.cc:220:proc_dff$7": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 21 ]
+          }
+        },
+        "$flatten\\u_c1.$logic_not$bad_source_sync_internal.sv:62$6": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:62.13-62.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 22 ]
+          }
+        },
+        "$flatten\\u_c1.$procdff$11": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:61.5-64.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 23 ],
+            "D": [ 17 ],
+            "Q": [ 6 ]
+          }
+        },
+        "u_a": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "bad_source_sync_internal.sv:80.17-82.61",
+            "module": "block_a_bad",
+            "module_src": "bad_source_sync_internal.sv:7.1-33.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "u_a.u_buf_b0": {
+          "hide_name": 0,
+          "type": "\\$_BUF_",
+          "parameters": {
+          },
+          "attributes": {
+            "hdlname": "u_a u_buf_b0",
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:29.12-29.51"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "Y": [ 12 ]
+          }
+        },
+        "u_a.u_buf_b1": {
+          "hide_name": 0,
+          "type": "\\$_BUF_",
+          "parameters": {
+          },
+          "attributes": {
+            "hdlname": "u_a u_buf_b1",
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:30.12-30.51"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "Y": [ 16 ]
+          }
+        },
+        "u_b0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "bad_source_sync_internal.sv:83.17-84.62",
+            "module": "block_b_bad",
+            "module_src": "bad_source_sync_internal.sv:35.1-52.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "u_b0.u_buf": {
+          "hide_name": 0,
+          "type": "\\$_BUF_",
+          "parameters": {
+          },
+          "attributes": {
+            "hdlname": "u_b0 u_buf",
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:50.12-50.45"
+          },
+          "connections": {
+            "A": [ 12 ],
+            "Y": [ 20 ]
+          }
+        },
+        "u_b1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "bad_source_sync_internal.sv:85.17-86.62",
+            "module": "block_b_bad",
+            "module_src": "bad_source_sync_internal.sv:35.1-52.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "u_b1.u_buf": {
+          "hide_name": 0,
+          "type": "\\$_BUF_",
+          "parameters": {
+          },
+          "attributes": {
+            "hdlname": "u_b1 u_buf",
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:50.12-50.45"
+          },
+          "connections": {
+            "A": [ 16 ],
+            "Y": [ 23 ]
+          }
+        },
+        "u_c0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "bad_source_sync_internal.sv:87.17-88.62",
+            "module": "block_c_bad",
+            "module_src": "bad_source_sync_internal.sv:54.1-66.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "u_c1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "bad_source_sync_internal.sv:89.17-90.62",
+            "module": "block_c_bad",
+            "module_src": "bad_source_sync_internal.sv:54.1-66.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        }
+      },
+      "netnames": {
+        "$flatten\\u_a.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:16.5-19.8"
+          }
+        },
+        "$flatten\\u_a.$auto$rtlil.cc:3255:Not$18": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_a.$auto$rtlil.cc:3259:ReduceOr$20": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_a.$logic_not$bad_source_sync_internal.sv:17$2_Y": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:17.13-17.19"
+          }
+        },
+        "$flatten\\u_b0.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:43.5-46.8"
+          }
+        },
+        "$flatten\\u_b0.$auto$rtlil.cc:3255:Not$13": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_b0.$auto$rtlil.cc:3259:ReduceOr$15": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_b0.$logic_not$bad_source_sync_internal.sv:44$4_Y": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:44.13-44.19"
+          }
+        },
+        "$flatten\\u_b1.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:43.5-46.8"
+          }
+        },
+        "$flatten\\u_b1.$auto$rtlil.cc:3255:Not$13": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_b1.$auto$rtlil.cc:3259:ReduceOr$15": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_b1.$logic_not$bad_source_sync_internal.sv:44$4_Y": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:44.13-44.19"
+          }
+        },
+        "$flatten\\u_c0.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:61.5-64.8"
+          }
+        },
+        "$flatten\\u_c0.$auto$rtlil.cc:3255:Not$8": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_c0.$auto$rtlil.cc:3259:ReduceOr$10": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_c0.$logic_not$bad_source_sync_internal.sv:62$6_Y": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:62.13-62.19"
+          }
+        },
+        "$flatten\\u_c1.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:61.5-64.8"
+          }
+        },
+        "$flatten\\u_c1.$auto$rtlil.cc:3255:Not$8": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_c1.$auto$rtlil.cc:3259:ReduceOr$10": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_c1.$logic_not$bad_source_sync_internal.sv:62$6_Y": {
+          "hide_name": 1,
+          "bits": [ 22 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:62.13-62.19"
+          }
+        },
+        "a_q": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:76.11-76.14"
+          }
+        },
+        "b0_q": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:76.16-76.20"
+          }
+        },
+        "b1_q": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:76.22-76.26"
+          }
+        },
+        "c0_q": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:76.28-76.32"
+          }
+        },
+        "c1_q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:76.34-76.38"
+          }
+        },
+        "ck_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:69.18-69.22"
+          }
+        },
+        "ck_b0_int": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "keep": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:78.21-78.30"
+          }
+        },
+        "ck_b1_int": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "keep": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:78.32-78.41"
+          }
+        },
+        "ck_c0_int": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "keep": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:78.43-78.52"
+          }
+        },
+        "ck_c1_int": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "keep": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:78.54-78.63"
+          }
+        },
+        "d_in": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:71.18-71.22"
+          }
+        },
+        "q_out_c0": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:72.18-72.26"
+          }
+        },
+        "q_out_c1": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:73.18-73.26"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "bad_source_sync_internal.sv:70.18-70.23"
+          }
+        },
+        "u_a.a_q": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "u_a a_q",
+            "src": "bad_source_sync_internal.sv:13.18-13.21"
+          }
+        },
+        "u_a.clk_in": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "hdlname": "u_a clk_in",
+            "src": "bad_source_sync_internal.sv:8.18-8.24"
+          }
+        },
+        "u_a.clk_out_b0": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "hdlname": "u_a clk_out_b0",
+            "src": "bad_source_sync_internal.sv:9.18-9.28"
+          }
+        },
+        "u_a.clk_out_b0_w": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "hdlname": "u_a clk_out_b0_w",
+            "keep": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:28.21-28.33"
+          }
+        },
+        "u_a.clk_out_b1": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "u_a clk_out_b1",
+            "src": "bad_source_sync_internal.sv:10.18-10.28"
+          }
+        },
+        "u_a.clk_out_b1_w": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "u_a clk_out_b1_w",
+            "keep": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:28.35-28.47"
+          }
+        },
+        "u_a.d_in": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "hdlname": "u_a d_in",
+            "src": "bad_source_sync_internal.sv:12.18-12.22"
+          }
+        },
+        "u_a.q": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "u_a q",
+            "src": "bad_source_sync_internal.sv:15.11-15.12"
+          }
+        },
+        "u_a.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_a rst_n",
+            "src": "bad_source_sync_internal.sv:11.18-11.23"
+          }
+        },
+        "u_b0.b_q": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "hdlname": "u_b0 b_q",
+            "src": "bad_source_sync_internal.sv:40.18-40.21"
+          }
+        },
+        "u_b0.clk_in": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "hdlname": "u_b0 clk_in",
+            "src": "bad_source_sync_internal.sv:36.18-36.24"
+          }
+        },
+        "u_b0.clk_out": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "u_b0 clk_out",
+            "src": "bad_source_sync_internal.sv:37.18-37.25"
+          }
+        },
+        "u_b0.clk_out_w": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "u_b0 clk_out_w",
+            "keep": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:49.21-49.30"
+          }
+        },
+        "u_b0.d_in": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "u_b0 d_in",
+            "src": "bad_source_sync_internal.sv:39.18-39.22"
+          }
+        },
+        "u_b0.q": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "hdlname": "u_b0 q",
+            "src": "bad_source_sync_internal.sv:42.11-42.12"
+          }
+        },
+        "u_b0.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_b0 rst_n",
+            "src": "bad_source_sync_internal.sv:38.18-38.23"
+          }
+        },
+        "u_b1.b_q": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "u_b1 b_q",
+            "src": "bad_source_sync_internal.sv:40.18-40.21"
+          }
+        },
+        "u_b1.clk_in": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "u_b1 clk_in",
+            "src": "bad_source_sync_internal.sv:36.18-36.24"
+          }
+        },
+        "u_b1.clk_out": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "hdlname": "u_b1 clk_out",
+            "src": "bad_source_sync_internal.sv:37.18-37.25"
+          }
+        },
+        "u_b1.clk_out_w": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "hdlname": "u_b1 clk_out_w",
+            "keep": "00000000000000000000000000000001",
+            "src": "bad_source_sync_internal.sv:49.21-49.30"
+          }
+        },
+        "u_b1.d_in": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "u_b1 d_in",
+            "src": "bad_source_sync_internal.sv:39.18-39.22"
+          }
+        },
+        "u_b1.q": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "u_b1 q",
+            "src": "bad_source_sync_internal.sv:42.11-42.12"
+          }
+        },
+        "u_b1.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_b1 rst_n",
+            "src": "bad_source_sync_internal.sv:38.18-38.23"
+          }
+        },
+        "u_c0.c_q": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "hdlname": "u_c0 c_q",
+            "src": "bad_source_sync_internal.sv:58.18-58.21"
+          }
+        },
+        "u_c0.clk_in": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "u_c0 clk_in",
+            "src": "bad_source_sync_internal.sv:55.18-55.24"
+          }
+        },
+        "u_c0.d_in": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "hdlname": "u_c0 d_in",
+            "src": "bad_source_sync_internal.sv:57.18-57.22"
+          }
+        },
+        "u_c0.q": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "hdlname": "u_c0 q",
+            "src": "bad_source_sync_internal.sv:60.11-60.12"
+          }
+        },
+        "u_c0.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_c0 rst_n",
+            "src": "bad_source_sync_internal.sv:56.18-56.23"
+          }
+        },
+        "u_c1.c_q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "hdlname": "u_c1 c_q",
+            "src": "bad_source_sync_internal.sv:58.18-58.21"
+          }
+        },
+        "u_c1.clk_in": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "hdlname": "u_c1 clk_in",
+            "src": "bad_source_sync_internal.sv:55.18-55.24"
+          }
+        },
+        "u_c1.d_in": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "u_c1 d_in",
+            "src": "bad_source_sync_internal.sv:57.18-57.22"
+          }
+        },
+        "u_c1.q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "hdlname": "u_c1 q",
+            "src": "bad_source_sync_internal.sv:60.11-60.12"
+          }
+        },
+        "u_c1.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_c1 rst_n",
+            "src": "bad_source_sync_internal.sv:56.18-56.23"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_source_sync_internal/bad_source_sync_internal.sdc
+++ b/tests/fixtures/bad_source_sync_internal/bad_source_sync_internal.sdc
@@ -1,0 +1,25 @@
+create_clock -name ck_a -period 10.0 [get_ports ck_a]
+
+# Same internal-pin generated-clock declarations as the good fixture,
+# so each block's flops are labelled with its block-specific clock.
+create_generated_clock -name ck_b0 -source [get_ports ck_a] \
+    -master_clock ck_a [get_pins u_a/clk_out_b0]
+create_generated_clock -name ck_b1 -source [get_ports ck_a] \
+    -master_clock ck_a [get_pins u_a/clk_out_b1]
+create_generated_clock -name ck_c0 -source [get_pins u_a/clk_out_b0] \
+    -master_clock ck_b0 [get_pins u_b0/clk_out]
+create_generated_clock -name ck_c1 -source [get_pins u_a/clk_out_b1] \
+    -master_clock ck_b1 [get_pins u_b1/clk_out]
+
+# The methodology bug: integration SDC declares all five clocks
+# pairwise asynchronous, overriding the master chain. ``are_async``
+# honours this unresolved-name override, so each source-sync link
+# becomes a CDC-001 violation.
+set_clock_groups -asynchronous \
+    -group {ck_a} \
+    -group {ck_b0} \
+    -group {ck_b1} \
+    -group {ck_c0} \
+    -group {ck_c1}
+
+set_input_delay -clock ck_a 0.0 [get_ports d_in]

--- a/tests/fixtures/bad_source_sync_internal/bad_source_sync_internal.sv
+++ b/tests/fixtures/bad_source_sync_internal/bad_source_sync_internal.sv
@@ -1,0 +1,95 @@
+// Negative fixture: source-synchronous chain wired *internally*. The
+// system SDC declares each forwarded clock async to its master via
+// ``set_clock_groups -asynchronous``, overriding the create_generated_
+// clock master relationship. The analyzer must fire CDC-001 on each
+// of the four source-sync links (A→B0, A→B1, B0→C0, B1→C1).
+
+module block_a_bad (
+    input  logic clk_in,
+    output logic clk_out_b0,
+    output logic clk_out_b1,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic a_q
+);
+    logic q;
+    always_ff @(posedge clk_in or negedge rst_n) begin
+        if (!rst_n) q <= 1'b0;
+        else        q <= d_in;
+    end
+    assign a_q = q;
+
+    // Gate-level $_BUF_ primitive per fan-out: prevents the frontend
+    // from algebraically aliasing clk_out_b0/b1 back to clk_in (which
+    // would make every internal-pin SDC target hit the same bit, and
+    // ck_b0/b1 would be indistinguishable from ck_a after the trace).
+    // The CDC trace already treats $_BUF_ as transparent on the
+    // clock network.
+    (* keep *) wire clk_out_b0_w, clk_out_b1_w;
+    $_BUF_ u_buf_b0 (.A(clk_in), .Y(clk_out_b0_w));
+    $_BUF_ u_buf_b1 (.A(clk_in), .Y(clk_out_b1_w));
+    assign clk_out_b0 = clk_out_b0_w;
+    assign clk_out_b1 = clk_out_b1_w;
+endmodule
+
+module block_b_bad (
+    input  logic clk_in,
+    output logic clk_out,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic b_q
+);
+    logic q;
+    always_ff @(posedge clk_in or negedge rst_n) begin
+        if (!rst_n) q <= 1'b0;
+        else        q <= d_in;
+    end
+    assign b_q = q;
+
+    (* keep *) wire clk_out_w;
+    $_BUF_ u_buf (.A(clk_in), .Y(clk_out_w));
+    assign clk_out = clk_out_w;
+endmodule
+
+module block_c_bad (
+    input  logic clk_in,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic c_q
+);
+    logic q;
+    always_ff @(posedge clk_in or negedge rst_n) begin
+        if (!rst_n) q <= 1'b0;
+        else        q <= d_in;
+    end
+    assign c_q = q;
+endmodule
+
+module bad_source_sync_internal (
+    input  logic ck_a,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic q_out_c0,
+    output logic q_out_c1
+);
+
+    logic a_q, b0_q, b1_q, c0_q, c1_q;
+    // Internal forwarded clocks: A drives B0/B1, B0 drives C0, B1 drives C1.
+    (* keep *) wire ck_b0_int, ck_b1_int, ck_c0_int, ck_c1_int;
+
+    block_a_bad u_a  (.clk_in(ck_a),
+                      .clk_out_b0(ck_b0_int), .clk_out_b1(ck_b1_int),
+                      .rst_n(rst_n), .d_in(d_in), .a_q(a_q));
+    block_b_bad u_b0 (.clk_in(ck_b0_int), .clk_out(ck_c0_int),
+                      .rst_n(rst_n), .d_in(a_q),  .b_q(b0_q));
+    block_b_bad u_b1 (.clk_in(ck_b1_int), .clk_out(ck_c1_int),
+                      .rst_n(rst_n), .d_in(a_q),  .b_q(b1_q));
+    block_c_bad u_c0 (.clk_in(ck_c0_int),
+                      .rst_n(rst_n), .d_in(b0_q), .c_q(c0_q));
+    block_c_bad u_c1 (.clk_in(ck_c1_int),
+                      .rst_n(rst_n), .d_in(b1_q), .c_q(c1_q));
+
+    assign q_out_c0 = c0_q;
+    assign q_out_c1 = c1_q;
+
+endmodule

--- a/tests/fixtures/good_source_sync_internal/good_source_sync_internal.json
+++ b/tests/fixtures/good_source_sync_internal/good_source_sync_internal.json
@@ -1,0 +1,1007 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_source_sync_internal": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "good_source_sync_internal.sv:80.1-107.10"
+      },
+      "ports": {
+        "ck_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "d_in": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "q_out_c0": {
+          "direction": "output",
+          "bits": [ 5 ]
+        },
+        "q_out_c1": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$flatten\\u_a.$auto$proc_dff.cc:220:proc_dff$17": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 7 ]
+          }
+        },
+        "$flatten\\u_a.$logic_not$good_source_sync_internal.sv:29$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_source_sync_internal.sv:29.13-29.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$flatten\\u_a.$procdff$21": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:28.5-31.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 2 ],
+            "D": [ 4 ],
+            "Q": [ 9 ]
+          }
+        },
+        "$flatten\\u_b0.$auto$proc_dff.cc:220:proc_dff$12": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 10 ]
+          }
+        },
+        "$flatten\\u_b0.$logic_not$good_source_sync_internal.sv:56$4": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_source_sync_internal.sv:56.13-56.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 11 ]
+          }
+        },
+        "$flatten\\u_b0.$procdff$16": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:55.5-58.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 12 ],
+            "D": [ 9 ],
+            "Q": [ 13 ]
+          }
+        },
+        "$flatten\\u_b1.$auto$proc_dff.cc:220:proc_dff$12": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 14 ]
+          }
+        },
+        "$flatten\\u_b1.$logic_not$good_source_sync_internal.sv:56$4": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_source_sync_internal.sv:56.13-56.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 15 ]
+          }
+        },
+        "$flatten\\u_b1.$procdff$16": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:55.5-58.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 16 ],
+            "D": [ 9 ],
+            "Q": [ 17 ]
+          }
+        },
+        "$flatten\\u_c0.$auto$proc_dff.cc:220:proc_dff$7": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 18 ]
+          }
+        },
+        "$flatten\\u_c0.$logic_not$good_source_sync_internal.sv:74$6": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_source_sync_internal.sv:74.13-74.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 19 ]
+          }
+        },
+        "$flatten\\u_c0.$procdff$11": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:73.5-76.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 20 ],
+            "D": [ 13 ],
+            "Q": [ 5 ]
+          }
+        },
+        "$flatten\\u_c1.$auto$proc_dff.cc:220:proc_dff$7": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 21 ]
+          }
+        },
+        "$flatten\\u_c1.$logic_not$good_source_sync_internal.sv:74$6": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_source_sync_internal.sv:74.13-74.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "Y": [ 22 ]
+          }
+        },
+        "$flatten\\u_c1.$procdff$11": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:73.5-76.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 23 ],
+            "D": [ 17 ],
+            "Q": [ 6 ]
+          }
+        },
+        "u_a": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "good_source_sync_internal.sv:92.17-94.61",
+            "module": "block_a_int",
+            "module_src": "good_source_sync_internal.sv:19.1-45.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "u_a.u_buf_b0": {
+          "hide_name": 0,
+          "type": "\\$_BUF_",
+          "parameters": {
+          },
+          "attributes": {
+            "hdlname": "u_a u_buf_b0",
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:41.12-41.51"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "Y": [ 12 ]
+          }
+        },
+        "u_a.u_buf_b1": {
+          "hide_name": 0,
+          "type": "\\$_BUF_",
+          "parameters": {
+          },
+          "attributes": {
+            "hdlname": "u_a u_buf_b1",
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:42.12-42.51"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "Y": [ 16 ]
+          }
+        },
+        "u_b0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "good_source_sync_internal.sv:95.17-96.62",
+            "module": "block_b_int",
+            "module_src": "good_source_sync_internal.sv:47.1-64.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "u_b0.u_buf": {
+          "hide_name": 0,
+          "type": "\\$_BUF_",
+          "parameters": {
+          },
+          "attributes": {
+            "hdlname": "u_b0 u_buf",
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:62.12-62.45"
+          },
+          "connections": {
+            "A": [ 12 ],
+            "Y": [ 20 ]
+          }
+        },
+        "u_b1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "good_source_sync_internal.sv:97.17-98.62",
+            "module": "block_b_int",
+            "module_src": "good_source_sync_internal.sv:47.1-64.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "u_b1.u_buf": {
+          "hide_name": 0,
+          "type": "\\$_BUF_",
+          "parameters": {
+          },
+          "attributes": {
+            "hdlname": "u_b1 u_buf",
+            "module_not_derived": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:62.12-62.45"
+          },
+          "connections": {
+            "A": [ 16 ],
+            "Y": [ 23 ]
+          }
+        },
+        "u_c0": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "good_source_sync_internal.sv:99.17-100.62",
+            "module": "block_c_int",
+            "module_src": "good_source_sync_internal.sv:66.1-78.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        },
+        "u_c1": {
+          "hide_name": 0,
+          "type": "$scopeinfo",
+          "parameters": {
+            "TYPE": "module"
+          },
+          "attributes": {
+            "cell_module_not_derived": "00000000000000000000000000000001",
+            "cell_src": "good_source_sync_internal.sv:101.17-102.62",
+            "module": "block_c_int",
+            "module_src": "good_source_sync_internal.sv:66.1-78.10"
+          },
+          "port_directions": {
+          },
+          "connections": {
+          }
+        }
+      },
+      "netnames": {
+        "$flatten\\u_a.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:28.5-31.8"
+          }
+        },
+        "$flatten\\u_a.$auto$rtlil.cc:3255:Not$18": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_a.$auto$rtlil.cc:3259:ReduceOr$20": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_a.$logic_not$good_source_sync_internal.sv:29$2_Y": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:29.13-29.19"
+          }
+        },
+        "$flatten\\u_b0.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:55.5-58.8"
+          }
+        },
+        "$flatten\\u_b0.$auto$rtlil.cc:3255:Not$13": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_b0.$auto$rtlil.cc:3259:ReduceOr$15": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_b0.$logic_not$good_source_sync_internal.sv:56$4_Y": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:56.13-56.19"
+          }
+        },
+        "$flatten\\u_b1.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:55.5-58.8"
+          }
+        },
+        "$flatten\\u_b1.$auto$rtlil.cc:3255:Not$13": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_b1.$auto$rtlil.cc:3259:ReduceOr$15": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_b1.$logic_not$good_source_sync_internal.sv:56$4_Y": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:56.13-56.19"
+          }
+        },
+        "$flatten\\u_c0.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:73.5-76.8"
+          }
+        },
+        "$flatten\\u_c0.$auto$rtlil.cc:3255:Not$8": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_c0.$auto$rtlil.cc:3259:ReduceOr$10": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_c0.$logic_not$good_source_sync_internal.sv:74$6_Y": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:74.13-74.19"
+          }
+        },
+        "$flatten\\u_c1.$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:73.5-76.8"
+          }
+        },
+        "$flatten\\u_c1.$auto$rtlil.cc:3255:Not$8": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_c1.$auto$rtlil.cc:3259:ReduceOr$10": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$flatten\\u_c1.$logic_not$good_source_sync_internal.sv:74$6_Y": {
+          "hide_name": 1,
+          "bits": [ 22 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:74.13-74.19"
+          }
+        },
+        "a_q": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:88.11-88.14"
+          }
+        },
+        "b0_q": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:88.16-88.20"
+          }
+        },
+        "b1_q": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:88.22-88.26"
+          }
+        },
+        "c0_q": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:88.28-88.32"
+          }
+        },
+        "c1_q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:88.34-88.38"
+          }
+        },
+        "ck_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:81.18-81.22"
+          }
+        },
+        "ck_b0_int": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "keep": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:90.21-90.30"
+          }
+        },
+        "ck_b1_int": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "keep": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:90.32-90.41"
+          }
+        },
+        "ck_c0_int": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "keep": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:90.43-90.52"
+          }
+        },
+        "ck_c1_int": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "keep": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:90.54-90.63"
+          }
+        },
+        "d_in": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:83.18-83.22"
+          }
+        },
+        "q_out_c0": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:84.18-84.26"
+          }
+        },
+        "q_out_c1": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:85.18-85.26"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "good_source_sync_internal.sv:82.18-82.23"
+          }
+        },
+        "u_a.a_q": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "u_a a_q",
+            "src": "good_source_sync_internal.sv:25.18-25.21"
+          }
+        },
+        "u_a.clk_in": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "hdlname": "u_a clk_in",
+            "src": "good_source_sync_internal.sv:20.18-20.24"
+          }
+        },
+        "u_a.clk_out_b0": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "hdlname": "u_a clk_out_b0",
+            "src": "good_source_sync_internal.sv:21.18-21.28"
+          }
+        },
+        "u_a.clk_out_b0_w": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "hdlname": "u_a clk_out_b0_w",
+            "keep": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:40.21-40.33"
+          }
+        },
+        "u_a.clk_out_b1": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "u_a clk_out_b1",
+            "src": "good_source_sync_internal.sv:22.18-22.28"
+          }
+        },
+        "u_a.clk_out_b1_w": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "u_a clk_out_b1_w",
+            "keep": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:40.35-40.47"
+          }
+        },
+        "u_a.d_in": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "hdlname": "u_a d_in",
+            "src": "good_source_sync_internal.sv:24.18-24.22"
+          }
+        },
+        "u_a.q": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "u_a q",
+            "src": "good_source_sync_internal.sv:27.11-27.12"
+          }
+        },
+        "u_a.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_a rst_n",
+            "src": "good_source_sync_internal.sv:23.18-23.23"
+          }
+        },
+        "u_b0.b_q": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "hdlname": "u_b0 b_q",
+            "src": "good_source_sync_internal.sv:52.18-52.21"
+          }
+        },
+        "u_b0.clk_in": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "hdlname": "u_b0 clk_in",
+            "src": "good_source_sync_internal.sv:48.18-48.24"
+          }
+        },
+        "u_b0.clk_out": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "u_b0 clk_out",
+            "src": "good_source_sync_internal.sv:49.18-49.25"
+          }
+        },
+        "u_b0.clk_out_w": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "u_b0 clk_out_w",
+            "keep": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:61.21-61.30"
+          }
+        },
+        "u_b0.d_in": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "u_b0 d_in",
+            "src": "good_source_sync_internal.sv:51.18-51.22"
+          }
+        },
+        "u_b0.q": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "hdlname": "u_b0 q",
+            "src": "good_source_sync_internal.sv:54.11-54.12"
+          }
+        },
+        "u_b0.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_b0 rst_n",
+            "src": "good_source_sync_internal.sv:50.18-50.23"
+          }
+        },
+        "u_b1.b_q": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "u_b1 b_q",
+            "src": "good_source_sync_internal.sv:52.18-52.21"
+          }
+        },
+        "u_b1.clk_in": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "hdlname": "u_b1 clk_in",
+            "src": "good_source_sync_internal.sv:48.18-48.24"
+          }
+        },
+        "u_b1.clk_out": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "hdlname": "u_b1 clk_out",
+            "src": "good_source_sync_internal.sv:49.18-49.25"
+          }
+        },
+        "u_b1.clk_out_w": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "hdlname": "u_b1 clk_out_w",
+            "keep": "00000000000000000000000000000001",
+            "src": "good_source_sync_internal.sv:61.21-61.30"
+          }
+        },
+        "u_b1.d_in": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "hdlname": "u_b1 d_in",
+            "src": "good_source_sync_internal.sv:51.18-51.22"
+          }
+        },
+        "u_b1.q": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "u_b1 q",
+            "src": "good_source_sync_internal.sv:54.11-54.12"
+          }
+        },
+        "u_b1.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_b1 rst_n",
+            "src": "good_source_sync_internal.sv:50.18-50.23"
+          }
+        },
+        "u_c0.c_q": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "hdlname": "u_c0 c_q",
+            "src": "good_source_sync_internal.sv:70.18-70.21"
+          }
+        },
+        "u_c0.clk_in": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "hdlname": "u_c0 clk_in",
+            "src": "good_source_sync_internal.sv:67.18-67.24"
+          }
+        },
+        "u_c0.d_in": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "hdlname": "u_c0 d_in",
+            "src": "good_source_sync_internal.sv:69.18-69.22"
+          }
+        },
+        "u_c0.q": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "hdlname": "u_c0 q",
+            "src": "good_source_sync_internal.sv:72.11-72.12"
+          }
+        },
+        "u_c0.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_c0 rst_n",
+            "src": "good_source_sync_internal.sv:68.18-68.23"
+          }
+        },
+        "u_c1.c_q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "hdlname": "u_c1 c_q",
+            "src": "good_source_sync_internal.sv:70.18-70.21"
+          }
+        },
+        "u_c1.clk_in": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "hdlname": "u_c1 clk_in",
+            "src": "good_source_sync_internal.sv:67.18-67.24"
+          }
+        },
+        "u_c1.d_in": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "hdlname": "u_c1 d_in",
+            "src": "good_source_sync_internal.sv:69.18-69.22"
+          }
+        },
+        "u_c1.q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "hdlname": "u_c1 q",
+            "src": "good_source_sync_internal.sv:72.11-72.12"
+          }
+        },
+        "u_c1.rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "hdlname": "u_c1 rst_n",
+            "src": "good_source_sync_internal.sv:68.18-68.23"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_source_sync_internal/good_source_sync_internal.sdc
+++ b/tests/fixtures/good_source_sync_internal/good_source_sync_internal.sdc
@@ -1,0 +1,16 @@
+create_clock -name ck_a -period 10.0 [get_ports ck_a]
+
+# Forwarded clocks originating inside the design. Each is declared at
+# the internal pin where the new clock takes over and is rooted (via
+# -master_clock) at ck_a, so resolve() collapses every flop's domain
+# back to ck_a and ck_a↔ck_b0 (etc.) are synchronous.
+create_generated_clock -name ck_b0 -source [get_ports ck_a] \
+    -master_clock ck_a [get_pins u_a/clk_out_b0]
+create_generated_clock -name ck_b1 -source [get_ports ck_a] \
+    -master_clock ck_a [get_pins u_a/clk_out_b1]
+create_generated_clock -name ck_c0 -source [get_pins u_a/clk_out_b0] \
+    -master_clock ck_b0 [get_pins u_b0/clk_out]
+create_generated_clock -name ck_c1 -source [get_pins u_a/clk_out_b1] \
+    -master_clock ck_b1 [get_pins u_b1/clk_out]
+
+set_input_delay -clock ck_a 0.0 [get_ports d_in]

--- a/tests/fixtures/good_source_sync_internal/good_source_sync_internal.sv
+++ b/tests/fixtures/good_source_sync_internal/good_source_sync_internal.sv
@@ -1,0 +1,107 @@
+// Positive fixture: source-synchronous chain wired *internally*.
+//
+//     A ──► B0 ──► C0
+//      └──► B1 ──► C1
+//
+// Same topology as ``good_source_sync_chain`` but the forwarded clocks
+// are not exposed as top-level ports. The only top-level clock input
+// is ``ck_a``; A's clock-buffer outputs drive B0/B1's clock inputs
+// directly through internal wires, and B0/B1's outputs drive C0/C1.
+//
+// The CDC contract here is that the system SDC declares each forwarded
+// clock with ``create_generated_clock`` on the internal pin where it
+// originates (e.g. ``[get_pins u_a/clk_out_b0]`` declares ``ck_b0``).
+// The analyzer must stop tracing each flop's clock root at that pin
+// and adopt the generated clock's identity, so that ck_b0 resolves to
+// ck_a's master domain but is still distinct from ck_a as a clock
+// name. Zero async crossings, zero violations.
+
+module block_a_int (
+    input  logic clk_in,
+    output logic clk_out_b0,
+    output logic clk_out_b1,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic a_q
+);
+    logic q;
+    always_ff @(posedge clk_in or negedge rst_n) begin
+        if (!rst_n) q <= 1'b0;
+        else        q <= d_in;
+    end
+    assign a_q = q;
+
+    // Gate-level $_BUF_ primitive per fan-out: prevents the frontend
+    // from algebraically aliasing clk_out_b0/b1 back to clk_in (which
+    // would make every internal-pin SDC target hit the same bit, and
+    // ck_b0/b1 would be indistinguishable from ck_a after the trace).
+    // The CDC trace already treats $_BUF_ as transparent on the
+    // clock network.
+    (* keep *) wire clk_out_b0_w, clk_out_b1_w;
+    $_BUF_ u_buf_b0 (.A(clk_in), .Y(clk_out_b0_w));
+    $_BUF_ u_buf_b1 (.A(clk_in), .Y(clk_out_b1_w));
+    assign clk_out_b0 = clk_out_b0_w;
+    assign clk_out_b1 = clk_out_b1_w;
+endmodule
+
+module block_b_int (
+    input  logic clk_in,
+    output logic clk_out,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic b_q
+);
+    logic q;
+    always_ff @(posedge clk_in or negedge rst_n) begin
+        if (!rst_n) q <= 1'b0;
+        else        q <= d_in;
+    end
+    assign b_q = q;
+
+    (* keep *) wire clk_out_w;
+    $_BUF_ u_buf (.A(clk_in), .Y(clk_out_w));
+    assign clk_out = clk_out_w;
+endmodule
+
+module block_c_int (
+    input  logic clk_in,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic c_q
+);
+    logic q;
+    always_ff @(posedge clk_in or negedge rst_n) begin
+        if (!rst_n) q <= 1'b0;
+        else        q <= d_in;
+    end
+    assign c_q = q;
+endmodule
+
+module good_source_sync_internal (
+    input  logic ck_a,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic q_out_c0,
+    output logic q_out_c1
+);
+
+    logic a_q, b0_q, b1_q, c0_q, c1_q;
+    // Internal forwarded clocks: A drives B0/B1, B0 drives C0, B1 drives C1.
+    (* keep *) wire ck_b0_int, ck_b1_int, ck_c0_int, ck_c1_int;
+
+    block_a_int u_a  (.clk_in(ck_a),
+                      .clk_out_b0(ck_b0_int), .clk_out_b1(ck_b1_int),
+                      .rst_n(rst_n), .d_in(d_in), .a_q(a_q));
+    block_b_int u_b0 (.clk_in(ck_b0_int), .clk_out(ck_c0_int),
+                      .rst_n(rst_n), .d_in(a_q),  .b_q(b0_q));
+    block_b_int u_b1 (.clk_in(ck_b1_int), .clk_out(ck_c1_int),
+                      .rst_n(rst_n), .d_in(a_q),  .b_q(b1_q));
+    block_c_int u_c0 (.clk_in(ck_c0_int),
+                      .rst_n(rst_n), .d_in(b0_q), .c_q(c0_q));
+    block_c_int u_c1 (.clk_in(ck_c1_int),
+                      .rst_n(rst_n), .d_in(b1_q), .c_q(c1_q));
+
+    assign q_out_c0 = c0_q;
+    assign q_out_c1 = c1_q;
+
+endmodule

--- a/tests/test_bad_source_sync_internal.py
+++ b/tests/test_bad_source_sync_internal.py
@@ -1,0 +1,114 @@
+"""Negative-case fixture: source-synchronous chain wired *internally*.
+
+Same topology as ``bad_source_sync_chain``, but the forwarded clocks
+exist only as internal nets (not top-level ports). The system SDC
+declares each forwarded clock with ``create_generated_clock`` at the
+internal pin where it originates *and* lists all five clocks as
+pairwise asynchronous via ``set_clock_groups -asynchronous`` — the
+methodology bug we want to surface.
+
+The analyzer must:
+
+  - parse the pin-targeted ``create_generated_clock`` declarations
+    and stop ``trace_clock_root`` at each pin, giving every block a
+    distinct clock identity (ck_a, ck_b0, ck_b1, ck_c0, ck_c1);
+  - honour the unresolved-name async-groups override so each
+    source-sync link is reported as a CDC-001 violation.
+
+The paired ``good_source_sync_internal`` fixture uses the same RTL +
+the same ``create_generated_clock`` chain but *without* the
+``set_clock_groups -asynchronous`` line, and produces zero violations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_source_sync_internal"
+JSON = FIX_DIR / "bad_source_sync_internal.json"
+SDC = FIX_DIR / "bad_source_sync_internal.sdc"
+
+EXPECTED_LINKS = {
+    ("ck_a", "ck_b0"),
+    ("ck_a", "ck_b1"),
+    ("ck_b0", "ck_c0"),
+    ("ck_b1", "ck_c1"),
+}
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    async_crossings = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    return module, async_crossings, spec
+
+
+def test_internal_pin_generated_clocks_parsed(context) -> None:
+    """The SDC parser populates ``pin_clocks`` for each pin-targeted
+    ``create_generated_clock``."""
+    _module, _crossings, spec = context
+    assert spec.pin_clocks == {
+        "u_a/clk_out_b0": "ck_b0",
+        "u_a/clk_out_b1": "ck_b1",
+        "u_b0/clk_out": "ck_c0",
+        "u_b1/clk_out": "ck_c1",
+    }
+
+
+def test_four_async_crossings_one_per_source_sync_link(context) -> None:
+    _module, async_crossings, _spec = context
+    pairs = {(c.src_clock, c.dst_clock) for c in async_crossings}
+    assert pairs == EXPECTED_LINKS, (
+        f"expected one async crossing per source-sync link, got {sorted(pairs)}"
+    )
+
+
+def test_cdc_001_fires_on_every_link(context) -> None:
+    module, async_crossings, _spec = context
+    violations = run_all_rules(module, async_crossings)
+    cdc_001 = [v for v in violations if v.rule_id == "CDC-001"]
+    assert len(cdc_001) == 4, (
+        f"expected CDC-001 on each of the 4 source-sync links, "
+        f"got {[(v.rule_id, v.message) for v in violations]}"
+    )
+    assert all(v.severity == "error" for v in cdc_001)
+
+
+def test_good_sdc_resolves_all_clocks_to_ck_a() -> None:
+    """Sanity check: with the GOOD internal-pin SDC, every block clock
+    collapses to ck_a's master, so are_async returns False for every
+    cross-block pair. Pins the contract the good fixture relies on."""
+    good_sdc = (
+        Path(__file__).parent
+        / "fixtures"
+        / "good_source_sync_internal"
+        / "good_source_sync_internal.sdc"
+    )
+    spec = sdc_mod.parse_file(good_sdc)
+    clocks = ("ck_a", "ck_b0", "ck_b1", "ck_c0", "ck_c1")
+    for c in clocks:
+        assert spec.resolve(c) == "ck_a", f"{c} did not resolve to ck_a"
+    for a, b in EXPECTED_LINKS:
+        assert not spec.are_async(a, b), (
+            f"{a}/{b} flagged async under the good SDC — "
+            "create_generated_clock chain is broken"
+        )

--- a/tests/test_good_fixtures.py
+++ b/tests/test_good_fixtures.py
@@ -49,6 +49,13 @@ GOOD_FIXTURES = [
     # create_generated_clock so are_async() returns False and the
     # analyzer drops them all.
     ("good_source_sync_chain", 0),
+    # Same topology, but the forwarded clocks are wired internally
+    # rather than re-exposed as top-level ports. The good SDC declares
+    # each generated clock at the internal pin where it originates
+    # (``[get_pins u_a/clk_out_b0]`` etc.); trace_clock_root must stop
+    # at those pins to give each block a distinct clock name, then
+    # resolve() collapses them back to ck_a so no crossings remain.
+    ("good_source_sync_internal", 0),
 ]
 
 
@@ -62,7 +69,9 @@ def test_good_fixture_has_no_violations(name: str, expected_async: int) -> None:
 
     module = netlist.load(json_path)
     spec = sdc_mod.parse_file(sdc_path)
-    crossings = find_crossings(module, port_clock=spec.port_clock)
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
     async_crossings = []
     for c in crossings:
         a = spec.clock_for_port(c.src_clock) or c.src_clock

--- a/wiki/concepts/cdc-data-model.md
+++ b/wiki/concepts/cdc-data-model.md
@@ -61,8 +61,11 @@ class ClockSpec:
     exclusive_groups: list[list[set[str]]]         # -logically_exclusive / -physically_exclusive
     false_path_pairs: set[frozenset[str]]          # set_false_path -from -to clock pairs
     port_clock: dict[str, str]                     # port→clock mapping
+    pin_clocks: dict[str, str]                     # internal-pin → generated clock name
     partial_warnings: list[str]                    # parser diagnostics
 ```
+
+`pin_clocks` is populated when `create_generated_clock`'s target is `[get_pins <hier_pin>]` rather than a top-level port. The clock-trace pass keys on this map to stop walking at the pin where a forwarded clock originates, so each block in an internally-wired clock-forwarding chain gets a distinct clock identity that still resolves back to its master via `resolve()`. See [[clock-domain-tracing]] for the trace-side mechanics.
 
 `Clock` carries `master: str | None` and `is_generated: bool` for collapsing generated clocks to their root master.
 

--- a/wiki/concepts/clock-domain-tracing.md
+++ b/wiki/concepts/clock-domain-tracing.md
@@ -29,6 +29,16 @@ The walker recognizes four categories of clock-network cells:
 - **`max_depth` = 16** (default) — intentionally low; clock networks rarely exceed a handful of hops, and deep walks are more likely following data than clock
 - **`_bit_drivers`** is precomputed once and shared across all `trace_clock_root` calls
 
+## Internal-Pin Generated Clocks
+
+The walker also accepts an optional `bit_to_clock: dict[Bit, str]` short-circuit map, supplied by `assign_domains(module, pin_clocks=...)` and built from `ClockSpec.pin_clocks` via `_build_bit_to_clock`. When the walk lands on a bit that's in the map, it returns that clock name immediately instead of continuing back to a top-level port.
+
+This is what models SoC clock-forwarding chains where each block declares its forwarded clock with `create_generated_clock` at an internal pin (e.g. `[get_pins u_a/clk_out]`). Without this hop, every flop downstream of `u_a`'s clock buffer would collapse to whichever top input port feeds `u_a` — and the SDC's per-block clock declarations would be inert at integration scope.
+
+`_build_bit_to_clock` normalises the SDC pin convention (`u_a/clk_out`, `/`-separated) to Yosys' flattened netname convention (`u_a.clk_out`, `.`-separated) before looking up the netname's bits. If two generated clocks target the same net, first-writer-wins via `setdefault` — the SDC is internally inconsistent and we don't try to repair it.
+
+The returned clock name is a generated-clock identity (e.g. `ck_b0`), not a top-level port. Downstream consumers (`_filter_async`, `are_async`) handle this transparently because `ClockSpec.resolve()` already collapses generated clocks back to their root master.
+
 ## Role in CDC-008
 
 CDC-008 uses the same walker to compute the set of cells that drive a flop CLK (`_clock_network_cells()`). Cells flagged as clock-network are **exempt** from CDC-008 ("clock signal used as data") because legitimate ICGs, clock muxes, and dividers all read clocks as inputs.

--- a/wiki/concepts/sdc-parsing.md
+++ b/wiki/concepts/sdc-parsing.md
@@ -31,6 +31,8 @@ Plus: `#` comments, `\` line continuation, and permissive flag-skipping for unre
 ## Key Behaviors
 
 - **Generated clocks** fold back into their master via `ClockSpec.resolve` unless `set_clock_groups -asynchronous` explicitly overrides
+- **Internal-pin generated clocks** — when a `create_generated_clock` target is `[get_pins <hier_pin>]` rather than a top-level port, the pin path is stored in `ClockSpec.pin_clocks` and consumed by `trace_clock_root` to give each block in an internally-wired clock-forwarding chain a distinct clock identity. Pin paths use SDC convention (`u_a/clk_out`); the consumer normalises to Yosys' flattened netname (`u_a.clk_out`)
+- **`-source` parsing** is shlex-tolerant: the bracketed expression after `-source` is consumed forward to the next `-` flag, so `-source [get_ports ck_a]` (split by shlex into two tokens) doesn't leak `ck_a]` into the trailing target list
 - **`set_false_path`** between clocks is treated as a pairwise async hint
 - **Exclusive groups** (`-logically_exclusive`, `-physically_exclusive`) drop crossings as unreachable in `_filter_async` before any rule sees them
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -23,3 +23,10 @@
   - `concepts/cdc-testing-strategy.md`
 - All pages cross-referenced with [[wikilinks]] (minimum 2 outbound links each)
 - index.md populated with all 9 pages
+
+## [2026-05-11] update | Internal-pin `create_generated_clock` support
+- Issue: rtl-buddy/rtl-buddy-cdc#1
+- Updated `concepts/clock-domain-tracing.md` — new "Internal-Pin Generated Clocks" section covering `bit_to_clock`, `_build_bit_to_clock`, and the `/`→`.` netname normalisation
+- Updated `concepts/sdc-parsing.md` — `pin_clocks` behavior + shlex-tolerant `-source` parsing
+- Updated `concepts/cdc-data-model.md` — `ClockSpec.pin_clocks` field
+- Updated `raw/articles/rtl-buddy-cdc-architecture.md` — new §5.1, expanded §6.1, `ClockSpec` field list

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -195,8 +195,16 @@ class ClockSpec:
     exclusive_groups: list[list[set[str]]]         # -logically_exclusive / -physically_exclusive
     false_path_pairs: set[frozenset[str]]          # set_false_path -from -to clock pairs
     port_clock: dict[str, str]                     # set_input_delay / set_output_delay → port→clock
+    pin_clocks: dict[str, str]                     # internal-pin target → generated clock name
     partial_warnings: list[str]                    # diagnostics surfaced once at end-of-parse
 ```
+
+`pin_clocks` is populated when a `create_generated_clock` target is a
+`[get_pins <hier_pin>]` expression rather than a top-level port. It is
+consumed by `trace_clock_root` (§5) to stop the clock walk at the pin
+where a forwarded clock takes over, so each block in a source-sync
+chain wired through internal nets gets a distinct clock identity that
+still resolves back to its master via `resolve()`.
 
 `Clock` carries `master: str | None` and `is_generated: bool` so the
 analyzer can collapse generated clocks (dividers, PLL outputs) back
@@ -273,6 +281,41 @@ terminate cleanly. The depth budget is intentionally low — clock
 networks rarely exceed a handful of hops, and a deep walk is more
 likely to be following data than clock.
 
+### 5.1 Internal-pin generated clocks
+
+`trace_clock_root` accepts an optional `bit_to_clock` short-circuit
+map. When the walk lands on a bit in the map, it returns that clock
+name immediately instead of continuing back to a top-level port.
+
+The map is built by `_build_bit_to_clock(module, pin_clocks)` from
+`ClockSpec.pin_clocks` (§4.5): for each SDC pin path (e.g.
+`u_a/clk_out`), the helper normalises `/`→`.` to match Yosys'
+flattened netname convention, looks up the netname, and harvests
+every integer bit of that net. `assign_domains(module,
+pin_clocks=...)` and `find_crossings(module, ..., pin_clocks=...)`
+build and thread the map automatically when invoked from the CLI.
+
+This models SoC clock-forwarding chains where each block declares its
+forwarded clock with `create_generated_clock` at an internal pin.
+Without it, every flop downstream of the forwarding block's clock
+buffer would collapse to whichever top input port feeds the chain,
+making the per-block SDC declarations inert. The returned name is a
+generated-clock identity (`ck_b0`), not a port; downstream consumers
+handle this transparently because `resolve()` already collapses
+generated clocks to their root master, so async-pair checks behave
+identically whether the clock identity came from a port or a pin.
+
+A practical gotcha when building fixtures: Yosys' Verilog frontend
+algebraically aliases trivial assign chains (`assign x = y; assign z
+= ~~x;`), so a pin like `u_a/clk_out` declared on the output of a
+soft buffer can end up sharing a net bit with the upstream port — at
+which point the pin map collapses to a single bit and every flop in
+the design traces to whichever clock won the `setdefault` race.
+Forcing a real gate-level cell (`$_BUF_`, `$_NOT_` pair, or an
+attribute-kept primitive) on the forwarding path keeps each forwarded
+clock at a distinct bit identity. The `good_source_sync_internal`
+fixture uses `$_BUF_` primitives for this reason.
+
 This is also what CDC-008 uses to compute "the set of cells that
 drive a flop CLK": the structural detection of clock-network cells.
 Cells flagged by `_clock_network_cells()` are exempt from CDC-008
@@ -307,10 +350,21 @@ commands (so vendor-specific dialects don't choke).
 
 Generated clocks fold back into their master via `ClockSpec.resolve`
 unless an explicit `set_clock_groups -asynchronous` overrides the
-relationship. `set_false_path -from [get_clocks A] -to [get_clocks B]`
-is treated as a pairwise async hint (equivalent to async groups for
-that specific pair). Exclusive groups drop crossings as unreachable
-in `_filter_async` before any rule sees them.
+relationship. When a `create_generated_clock` target is a `[get_pins
+<hier_pin>]` expression rather than a top-level port, the pin path is
+recorded in `ClockSpec.pin_clocks` and consumed by the clock walker
+(§5.1) — that's the integration point for SoC clock-forwarding
+chains. `set_false_path -from [get_clocks A] -to [get_clocks B]` is
+treated as a pairwise async hint (equivalent to async groups for that
+specific pair). Exclusive groups drop crossings as unreachable in
+`_filter_async` before any rule sees them.
+
+The `-source` argument is consumed by scanning forward to the next
+`-` flag rather than skipping a fixed token count, because shlex
+splits `[get_ports ck_a]` into two tokens (`[get_ports` and `ck_a]`).
+A fixed skip would leak the trailing-`]` half into the target list
+and silently mis-attribute the generated clock to whichever name fell
+out of the bracket parsing.
 
 ### 6.2 What it deliberately ignores
 


### PR DESCRIPTION
Closes #1.

## Summary

Models SoC clock-forwarding chains where each block declares its forwarded clock with `create_generated_clock` at an internal pin (e.g. `[get_pins u_a/clk_out]`). `trace_clock_root` now stops at those pins and adopts the generated clock's identity, so each block in a source-sync chain gets a distinct clock that still resolves back to its root master via `ClockSpec.resolve()`. Without this, every flop downstream of the forwarding block's clock buffer collapsed to whichever top input port fed the chain — making per-block SDC declarations inert at integration scope.

## Changes

- **`sdc.py`** — `ClockSpec.pin_clocks` records `pin path → generated clock name` when `create_generated_clock`'s target is `[get_pins ...]`. Fixes a shlex-split bug in `-source` parsing that was previously masked by the target being discarded.
- **`domain.py`** — `trace_clock_root` takes a `bit_to_clock` short-circuit map; `_build_bit_to_clock` normalises SDC's `/` to Yosys' `.` netname convention. `assign_domains` and `find_crossings` accept `pin_clocks`.
- **`cli.py`** — threads `spec.pin_clocks` through.
- **Fixtures** — paired `good/bad_source_sync_internal` with realistic internal clock forwarding (only `ck_a` is a top input). RTL uses gate-level `$_BUF_` primitives so Yosys keeps each forwarded clock at a distinct bit identity rather than aliasing through `~~x` constant folding.
- **Wiki** — updated `concepts/{cdc-data-model,clock-domain-tracing,sdc-parsing}.md` and the raw architecture article (new §5.1, expanded §6.1, `ClockSpec` field list).

## Test plan

- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run pytest -q` — 91 passed (86 → 91, +5 tests)
- [x] Good fixture: 4 raw crossings, 0 async, 0 violations
- [x] Bad fixture: 4 async crossings, 4 CDC-001 errors (one per source-sync link)
- [x] Existing fixtures unchanged (no behavior regression on pin_clocks-less SDCs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)