### PR TITLE
docs: align README/AGENTS/wiki with current source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ schema or the CLI surface is a downstream-breaking change — see
 
 ## Read first
 
-- [`docs/architecture.md`](docs/architecture.md) — full reference for
+- [`wiki/raw/articles/rtl-buddy-cdc-architecture.md`](wiki/raw/articles/rtl-buddy-cdc-architecture.md) — full reference for
   the data model, pipeline, rule helpers, extension points. Read
   before changing anything in `domain.py`, `rules.py`, `sdc.py`, or
   the reporter contract.
@@ -112,7 +112,7 @@ both locally before pushing.
 3. Register: add `"CDC-NNN": check_cdc_NNN` to `RULES`. If the rule
    takes a configuration parameter, special-case it in `run_all`
    (CDC-002 / `required_depth` is the reference).
-4. Pick severity per [`docs/architecture.md`](docs/architecture.md)
+4. Pick severity per [`wiki/raw/articles/rtl-buddy-cdc-architecture.md`](wiki/raw/articles/rtl-buddy-cdc-architecture.md)
    §8.2: `error` for unambiguous bugs, `warning` for
    review-or-waive patterns.
 5. Add a paired fixture (see next section).
@@ -163,7 +163,7 @@ pairing is the regression net for false positives.
 The parser is intentionally `shlex`-based, **not** a Tcl
 interpreter. Don't pull in `tkinter.Tcl()` or a third-party Tcl host
 without first opening an issue — the design choice is documented in
-`docs/architecture.md` §6.
+`wiki/raw/articles/rtl-buddy-cdc-architecture.md` §6.
 
 When adding a new SDC command:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CDC bugs are notoriously hard to catch in simulation and devastating in silicon.
 
 ## Architecture
 
-For the full reference (data model, pipeline, rule helpers, extension points), see [`docs/architecture.md`](docs/architecture.md). The summary below is the elevator pitch.
+For the full reference (data model, pipeline, rule helpers, extension points), see [`wiki/raw/articles/rtl-buddy-cdc-architecture.md`](wiki/raw/articles/rtl-buddy-cdc-architecture.md). The summary below is the elevator pitch.
 
 `rtl-buddy-cdc` is a **pure analyzer**. It does not invoke Yosys itself in its primary mode — elaboration and netlist generation are the caller's responsibility. The standalone `lint` wrapper does shell out to yosys for convenience, but the core `analyze` entry point takes a pre-elaborated netlist as input.
 
@@ -105,7 +105,7 @@ The parser is a focused subset — STA-only commands (`set_max_delay`, `set_min_
 - `set_input_delay -clock <c> [get_ports <p>]` / `set_output_delay -clock <c> [get_ports <p>]` — assigns top-level data ports to a clock domain
 - Comments (`#`), backslash line continuation (`\`)
 
-When the parser sees a CDC-relevant command it can't fully understand (e.g. `set_false_path -through`, `[get_clocks -filter …]`), it accumulates a one-line warning and surfaces them all at the end of the run rather than spamming line-by-line. Truly unknown commands (`set_max_delay`, `set_load`, …) are silently dropped at INFO level.
+When the parser sees a CDC-relevant command it can't fully understand (e.g. `set_false_path -through`, `[get_clocks -filter …]`), it accumulates a one-line warning and surfaces them all at the end of the run rather than spamming line-by-line. Truly unknown commands (`set_max_delay`, `set_load`, …) are silently dropped at DEBUG level.
 
 If no SDC is supplied, the tool prints a structural summary and skips all rule checks.
 
@@ -227,6 +227,8 @@ tests/
   fixtures/
     bad_*/      # negative cases — each rule has at least one
     good_*/     # paired positive counterparts (textbook fixes)
+    {good,bad}_source_sync_chain/     # source-sync methodology (separate clk_in per block)
+    {good,bad}_source_sync_internal/  # source-sync with internal-pin create_generated_clock
     ip_cdc_handshake/    # canonical golden vendored from rtl-buddy-project-template
     clock_gating/        # ICG positive case
     marked_user_sync/    # (* cdc_sync *) attribute coverage

--- a/wiki/concepts/cdc-data-model.md
+++ b/wiki/concepts/cdc-data-model.md
@@ -35,7 +35,7 @@ A `Crossing` is the canonical unit of "one signal moves between two domains":
 ```python
 @dataclass(frozen=True)
 class Crossing:
-    src_clock: str               # top-level port name
+    src_clock: str               # top-level port name, or generated clock name when pin_clocks resolved it
     dst_flop: Flop
     dst_clock: str
     min_hops: int                # comb cells on shortest path

--- a/wiki/concepts/cdc-testing-strategy.md
+++ b/wiki/concepts/cdc-testing-strategy.md
@@ -38,7 +38,7 @@ yosys -p 'read_verilog -sv path/to/design.sv; \
 
 Where the analyzer is designed to be extended without architectural churn:
 
-- **New rules.** Add `check_<rule>` in `rules.py` + one line in `RULES`. Reuse helpers from §8.1
+- **New rules.** Add `check_<rule>` in `rules.py` + one line in `RULES`. Reuse helpers documented in [[cdc-rule-pack]]
 - **New SV attributes.** Define a frozenset + `user_<x>_flop_names(module)` helper; consult in relevant rules
 - **New SDC commands.** Add handler in `sdc.py`, extend `ClockSpec` if needed
 - **New output formats.** Add `render_<fmt>` in `reporter.py`, wire into `OutputFormat` and `cli._analyze_and_report`

--- a/wiki/concepts/clock-domain-tracing.md
+++ b/wiki/concepts/clock-domain-tracing.md
@@ -41,10 +41,10 @@ The returned clock name is a generated-clock identity (e.g. `ck_b0`), not a top-
 
 ## Role in CDC-008
 
-CDC-008 uses the same walker to compute the set of cells that drive a flop CLK (`_clock_network_cells()`). Cells flagged as clock-network are **exempt** from CDC-008 ("clock signal used as data") because legitimate ICGs, clock muxes, and dividers all read clocks as inputs.
+CDC-008 ("clock signal used as data") asks a related question — *which cells form the legitimate clock-distribution network?* — and answers it with its own helper, `rules._clock_network_cells`. That helper is a separate reverse-BFS from each flop's CLK pin (different drivers map shape, different visit shape) but conceptually mirrors `trace_clock_root`'s buffer/ICG/mux/divider categories. Cells flagged by it are **exempt** from CDC-008 because legitimate ICGs, clock muxes, and dividers all read clocks as inputs. If you change the clock-network cell taxonomy here, change it there too.
 
 ## Related Pages
 
 - [[cdc-data-model]] — `FlopDomain` dataclass produced by tracing
 - [[crossing-detection]] — BFS that consumes domain assignments
-- [[cdc-rule-pack]] — CDC-008's use of `_clock_network_cells()`
+- [[cdc-rule-pack]] — CDC-008's `_clock_network_cells()` (separate but parallel reverse-BFS)

--- a/wiki/concepts/sdc-parsing.md
+++ b/wiki/concepts/sdc-parsing.md
@@ -31,7 +31,7 @@ Plus: `#` comments, `\` line continuation, and permissive flag-skipping for unre
 ## Key Behaviors
 
 - **Generated clocks** fold back into their master via `ClockSpec.resolve` unless `set_clock_groups -asynchronous` explicitly overrides
-- **Internal-pin generated clocks** — when a `create_generated_clock` target is `[get_pins <hier_pin>]` rather than a top-level port, the pin path is stored in `ClockSpec.pin_clocks` and consumed by `trace_clock_root` to give each block in an internally-wired clock-forwarding chain a distinct clock identity. Pin paths use SDC convention (`u_a/clk_out`); the consumer normalises to Yosys' flattened netname (`u_a.clk_out`)
+- **Internal-pin generated clocks** — when a `create_generated_clock` target is `[get_pins <hier_pin>]` rather than a top-level port, the pin path is stored in `ClockSpec.pin_clocks` and consumed by `trace_clock_root` via the `_build_bit_to_clock` helper to give each block in an internally-wired clock-forwarding chain a distinct clock identity. Pin paths use SDC convention (`u_a/clk_out`); the consumer normalises to Yosys' flattened netname (`u_a.clk_out`)
 - **`-source` parsing** is shlex-tolerant: the bracketed expression after `-source` is consumed forward to the next `-` flag, so `-source [get_ports ck_a]` (split by shlex into two tokens) doesn't leak `ck_a]` into the trailing target list
 - **`set_false_path`** between clocks is treated as a pairwise async hint
 - **Exclusive groups** (`-logically_exclusive`, `-physically_exclusive`) drop crossings as unreachable in `_filter_async` before any rule sees them

--- a/wiki/entities/rtl-buddy-cdc.md
+++ b/wiki/entities/rtl-buddy-cdc.md
@@ -38,7 +38,7 @@ A Python-based CDC (clock-domain-crossing) linter that consumes a flattened Yosy
 | `reporter.py` | Format an `AnalysisResult` as text / JSON / SARIF | `AnalysisResult`, `render_text`, `render_json`, `render_sarif` |
 | `cli.py` | Typer entry points; orchestrates the pipeline | `analyze`, `lint`, `version` |
 
-`__init__.py` is intentionally empty. The package has no public API beyond these modules.
+`__init__.py` exposes a thin `main()` shim that delegates to `cli.app` (used by the console-script entry point). No other public API beyond these modules.
 
 ## Integration with rtl-buddy
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -30,3 +30,16 @@
 - Updated `concepts/sdc-parsing.md` — `pin_clocks` behavior + shlex-tolerant `-source` parsing
 - Updated `concepts/cdc-data-model.md` — `ClockSpec.pin_clocks` field
 - Updated `raw/articles/rtl-buddy-cdc-architecture.md` — new §5.1, expanded §6.1, `ClockSpec` field list
+
+## [2026-05-11] update | docs/source consistency audit
+- README.md / AGENTS.md — retarget `docs/architecture.md` link to `wiki/raw/articles/rtl-buddy-cdc-architecture.md` (the doc moved during the wiki ingest)
+- README.md — fix log-level claim: unknown SDC commands are dropped at DEBUG, not INFO (matches `sdc.py:221`)
+- `entities/rtl-buddy-cdc.md`, `raw/articles/rtl-buddy-cdc-architecture.md` — `__init__.py` is not empty; it exposes a `main()` shim to `cli.app`
+- `concepts/clock-domain-tracing.md`, `raw/articles/rtl-buddy-cdc-architecture.md` §5.1 — correct the claim that CDC-008 "uses the same walker"; `_clock_network_cells` is a separate reverse-BFS in `rules.py` that mirrors the same cell-type taxonomy but doesn't share code with `trace_clock_root`
+- `concepts/cdc-data-model.md` — annotate that `Crossing.src_clock` may be a generated clock name (not only a top-level port) since the pin_clocks work
+- `concepts/cdc-testing-strategy.md` — replace dangling `§8.1` ref with `[[cdc-rule-pack]]` wikilink
+
+## [2026-05-11] update | source-sync internal fixtures + trace signature
+- New paired fixtures in `tests/fixtures/{good,bad}_source_sync_internal/` exercise internal-pin `create_generated_clock` end-to-end; covered by `tests/test_bad_source_sync_internal.py` and a new entry in `test_good_fixtures.py`
+- `trace_clock_root` signature gained `bit_to_clock: dict[Bit, str] | None = None`; `assign_domains` and `find_crossings` gained `pin_clocks: dict[str, str] | None = None`
+- `sdc.py` `_handle_create_generated_clock` now consumes `-source [get_*]` by scanning forward to the next `-` flag (fixes shlex-split leak of `]`-suffixed name into the trailing target list)

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -103,8 +103,9 @@ without one the tool prints the structural summary and exits 0.
 | `reporter.py` | Format an `AnalysisResult` as text / JSON / SARIF | `AnalysisResult`, `render_text`, `render_json`, `render_sarif` |
 | `cli.py` | Typer entry points; orchestrates the pipeline | `analyze`, `lint`, `version` |
 
-`__init__.py` is intentionally empty. The package has no public API
-beyond these modules.
+`__init__.py` exposes a thin `main()` shim that calls `cli.app` (used
+by the console-script entry point). No other public API beyond these
+modules.
 
 ## 4. Data model
 
@@ -316,11 +317,18 @@ attribute-kept primitive) on the forwarding path keeps each forwarded
 clock at a distinct bit identity. The `good_source_sync_internal`
 fixture uses `$_BUF_` primitives for this reason.
 
-This is also what CDC-008 uses to compute "the set of cells that
-drive a flop CLK": the structural detection of clock-network cells.
-Cells flagged by `_clock_network_cells()` are exempt from CDC-008
-("clock signal used as data") because legitimate ICGs, clock muxes,
-and dividers all read clocks as inputs.
+CDC-008 ("clock signal used as data") asks a closely related
+question — *which cells form the legitimate clock-distribution
+network?* — and answers it with its own helper,
+`rules._clock_network_cells`. That helper is a separate reverse-BFS
+from each flop's CLK pin (different drivers-map shape, different
+visit shape) but conceptually mirrors the buffer/ICG/mux/divider
+categories above. Cells flagged by it are exempt from CDC-008
+because legitimate ICGs, clock muxes, and dividers all read clocks
+as inputs. The two walkers live in different modules deliberately —
+`domain.py` is responsible for clock identity, `rules.py` for the
+rule's own structural detection — and any change to the clock-cell
+taxonomy needs to land in both.
 
 ## 6. SDC parsing
 


### PR DESCRIPTION
Follow-up to #3. Cross-file consistency audit between the docs and current source. No behavioural change; pure docs / comments cleanup.

## Wrong (claims contradicted by source)

- `README.md` / `AGENTS.md` — retarget the `docs/architecture.md` link to `wiki/raw/articles/rtl-buddy-cdc-architecture.md` (the doc moved into the wiki during the wiki-skill ingest; 4 occurrences total).
- `README.md` — unknown SDC commands are dropped at **DEBUG**, not INFO (matches `sdc.py` `logger.debug(...)`).
- `wiki/entities/rtl-buddy-cdc.md`, architecture article §3 — `__init__.py` is not empty; it exposes a `main()` shim that calls `cli.app`.
- `wiki/concepts/clock-domain-tracing.md`, architecture article §5.1 — drop the claim that CDC-008 reuses `trace_clock_root`. `rules._clock_network_cells` is a separate reverse-BFS that mirrors the cell-type taxonomy but does not share code.

## Stale (correct when written, drifted since)

- `wiki/concepts/cdc-data-model.md` — annotate `Crossing.src_clock` as port name *or* generated-clock name (since the `pin_clocks` work in #3).
- `wiki/concepts/sdc-parsing.md` — name `_build_bit_to_clock` as the consumer-side helper for `pin_clocks`.
- `README.md` fixture inventory — add the four source-sync fixtures.
- `wiki/concepts/cdc-testing-strategy.md` — replace dangling `§8.1` ref with a `[[cdc-rule-pack]]` wikilink.

## Wiki log

`wiki/log.md` updated with this audit entry and a back-fill for the source-sync-internal fixture pair, `trace_clock_root`'s new `bit_to_clock` parameter, and the `-source` forward-scan parser fix — code changes that landed in #3 but were missing from the log.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest -q` — 91 passed
- [x] No source files changed; behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)