### PR TITLE
Introduce frontend abstraction with slang frontend skeleton (#5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ authority — update it in the same PR if you change the contract.
 src/rtl_buddy_cdc/
 ├── __init__.py        # exposes main()
 ├── cli.py             # Typer entry points (analyze / lint / version) + orchestration
+├── frontend.py        # Frontend enum + elaborate() factory (dispatches by name)
+├── frontends/
+│   ├── yosys.py       # Yosys frontend: shell out + netlist.load
+│   └── slang.py       # slang frontend (in development, issue #5) — lazy pyslang import
 ├── netlist.py         # Yosys write_json loader (Module / Cell / Port / Netname)
 ├── flops.py           # FF cell zoo (FF_CELL_TYPES) + Flop dataclass
 ├── domain.py          # trace_clock_root + find_crossings (BFS) + Crossing
@@ -65,12 +69,15 @@ tests/
 - The analyzer is a chain of **pure functions**. Side effects belong
   in `cli.py` (file I/O) and the reporter (writing to a file-like).
   Don't sneak I/O into `domain.py` / `rules.py` / `sdc.py`.
-- The standalone `lint` wrapper shells out to Yosys; the primary
-  `analyze` path must never invoke Yosys. This split is deliberate —
-  the Python core has no Yosys runtime dependency.
+- The `lint` wrapper drives a frontend (Yosys subprocess or pyslang)
+  to elaborate sources; the primary `analyze` path must never invoke
+  a frontend — it consumes a pre-elaborated Yosys JSON via
+  `netlist.load`. This split is deliberate — the rule pack has no
+  toolchain runtime dependency.
 - No new top-level dependencies without strong reason. The package
-  ships with **only `typer`** as a runtime dep; lint/test groups are
-  the place for tooling.
+  ships with **only `typer`** as a runtime dep; the slang frontend
+  is gated behind the `[slang]` optional extra so default installs
+  stay typer-only. Lint/test groups are the place for tooling.
 
 ## Validation commands
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,11 @@ Standalone wrapper (`lint`):
 |---|---|---|
 | Verilog / SystemVerilog sources | yes | Design under analysis |
 | Top module name (`--top`) | yes | Elaboration root |
-| `--yosys PATH` | optional | Override the default yosys binary lookup |
-| `--keep-json PATH` | optional | Save the intermediate netlist for debugging or re-runs |
+| `--frontend {yosys,slang}` | optional | Elaboration frontend. `yosys` (default) shells out to `yosys` and runs `hierarchy; proc; flatten; opt_clean`. `slang` elaborates via the [pyslang](https://pypi.org/project/pyslang/) binding directly — no synth step, no Yosys runtime dependency. **Status:** slang frontend is in development (see [issue #5](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/5)); the Yosys path is the supported one today. |
+| `--yosys PATH` | optional | Yosys frontend only: override the default yosys binary lookup |
+| `--keep-json PATH` | optional | Yosys frontend only: save the intermediate netlist for debugging or re-runs |
+
+The slang frontend is an opt-in extra. Install it alongside the package with `pip install 'rtl-buddy-cdc[slang]'` (or `uv add 'rtl-buddy-cdc[slang]'`); the default install stays Yosys-only.
 
 ## SDC support
 
@@ -260,6 +263,7 @@ Implemented:
 
 Not yet:
 
+- [ ] **slang frontend** — elaborate SystemVerilog via [pyslang](https://pypi.org/project/pyslang/) as a peer to the Yosys frontend, swappable via `lint --frontend slang`. Scaffolding (factory + flag + optional `[slang]` install extra) is in place; the actual elaboration is unimplemented and the CLI rejects the flag with an actionable error today. Tracked in [issue #5](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/5).
 - [ ] CDC-006 refinements — comb-source severity tuning (downgrade for paths that hit a registered output before leaving the module)
 - [ ] CDC-007 refinements — recognise multi-source reset synchronizer trees and shared reset distribution networks
 - [ ] DFT / scan-mode awareness — exempt scan_en, scan_in, test-mode controls from CDC checks under a configurable scan-mode pragma

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,15 @@ dependencies = [
     "typer>=0.25.1",
 ]
 
+[project.optional-dependencies]
+# Opt-in elaboration frontend. Installs the pyslang binding so
+# `rtl-buddy-cdc lint --frontend slang ...` can elaborate SystemVerilog
+# without a Yosys subprocess. Default install stays typer-only — see
+# AGENTS.md "Development rules" on runtime dependencies.
+slang = [
+    "pyslang>=7.0",
+]
+
 [project.scripts]
 rtl-buddy-cdc = "rtl_buddy_cdc:main"
 

--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import shlex
 import shutil
 import subprocess
 import sys
-import tempfile
 from enum import Enum
 from pathlib import Path
 from typing import IO
@@ -13,10 +11,13 @@ import typer
 
 from rtl_buddy_cdc import netlist, reporter, sdc as sdc_mod, waivers as waivers_mod
 from rtl_buddy_cdc.domain import Crossing, assign_domains, find_crossings
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.frontends.slang import SlangFrontendUnavailable
+from rtl_buddy_cdc.frontends.yosys import YosysError
 from rtl_buddy_cdc.reporter import AnalysisResult
 from rtl_buddy_cdc.rules import run_all as run_all_rules
 
-app = typer.Typer(help="CDC linting tool for RTL designs (Yosys-backed).")
+app = typer.Typer(help="CDC linting tool for RTL designs.")
 
 
 class OutputFormat(str, Enum):
@@ -127,16 +128,26 @@ def lint(
         readable=True,
         help="SDC file with clock declarations and async groups.",
     ),
+    frontend: Frontend = typer.Option(
+        Frontend.yosys,
+        "--frontend",
+        case_sensitive=False,
+        help="Elaboration frontend. 'yosys' (default) shells out to "
+        "`yosys` and runs hierarchy/proc/flatten/opt_clean before "
+        "analysis. 'slang' elaborates via pyslang directly with no "
+        "synth step (in development — see issue #5).",
+    ),
     keep_json: Path | None = typer.Option(
         None,
         "--keep-json",
-        help="Save the intermediate Yosys JSON netlist to this path "
-        "(otherwise it lives in a temp file and is deleted).",
+        help="Yosys frontend only: save the intermediate JSON netlist "
+        "to this path (otherwise it lives in a temp file and is deleted).",
     ),
     yosys_bin: str | None = typer.Option(
         None,
         "--yosys",
-        help="Path to the yosys binary (default: first `yosys` on PATH).",
+        help="Yosys frontend only: path to the yosys binary "
+        "(default: first `yosys` on PATH).",
     ),
     waivers_path: Path | None = typer.Option(
         None,
@@ -152,69 +163,58 @@ def lint(
     verbose: bool = _VERBOSE_OPT,
     color: bool | None = _COLOR_OPT,
 ) -> None:
-    """Convenience wrapper: run yosys to produce a flattened netlist,
-    then analyze it. Equivalent to ``yosys -p 'read_verilog ...; \
-hierarchy -top X; proc; flatten; opt_clean; write_json /tmp/out.json' \
-&& rtl-buddy-cdc analyze --netlist /tmp/out.json --sdc ...``."""
-    yosys = yosys_bin or shutil.which("yosys")
-    if yosys is None or not Path(yosys).exists():
-        typer.echo("error: yosys not found on PATH (use --yosys to override)", err=True)
+    """Convenience wrapper: elaborate the sources using the chosen
+    frontend, then analyze. With ``--frontend yosys`` (the default)
+    this is equivalent to ``yosys -p 'read_verilog ...; hierarchy -top
+    X; proc; flatten; opt_clean; write_json /tmp/out.json' &&
+    rtl-buddy-cdc analyze --netlist /tmp/out.json --sdc ...``."""
+    if fmt is OutputFormat.text:
+        # Preamble for human readers only — structured output mustn't
+        # carry non-payload framing.
+        typer.echo(f"frontend: {frontend.value}")
+        typer.echo(f"top:      {top}")
+        for s in sources:
+            typer.echo(f"src:      {s}")
+
+    try:
+        module = elaborate(
+            sources,
+            top,
+            frontend=frontend,
+            yosys_bin=yosys_bin,
+            keep_json=keep_json,
+        )
+    except SlangFrontendUnavailable as e:
+        typer.echo(f"error: {e}", err=True)
+        raise typer.Exit(code=2)
+    except YosysError as e:
+        typer.echo(f"error: {e}", err=True)
+        raise typer.Exit(code=2)
+    except NotImplementedError as e:
+        # Stub frontend path (slang today). Distinct exit signal from
+        # a missing-binary failure so CI scripts can tell them apart.
+        typer.echo(f"error: {e}", err=True)
         raise typer.Exit(code=2)
 
-    tmp_json = Path(tempfile.mkstemp(suffix=".json", prefix="rtl-buddy-cdc-")[1])
-    try:
-        srcs = " ".join(shlex.quote(str(s)) for s in sources)
-        script = (
-            f"read_verilog -sv {srcs}; "
-            f"hierarchy -top {shlex.quote(top)}; "
-            f"proc; flatten; opt_clean; "
-            f"write_json {shlex.quote(str(tmp_json))}"
-        )
-        if fmt is OutputFormat.text:
-            # Only print preamble in text mode — structured output
-            # mustn't contain non-payload preamble.
-            typer.echo(f"yosys: {yosys}")
-            typer.echo(f"top:   {top}")
-            for s in sources:
-                typer.echo(f"src:   {s}")
+    if (
+        fmt is OutputFormat.text
+        and frontend is Frontend.yosys
+        and keep_json is not None
+    ):
+        typer.echo(f"netlist JSON kept at: {keep_json}")
 
-        proc = subprocess.run(
-            [yosys, "-q", "-p", script],
-            capture_output=True,
-            text=True,
-        )
-        if proc.returncode != 0:
-            typer.echo("yosys elaboration failed:", err=True)
-            if proc.stderr:
-                typer.echo(proc.stderr.rstrip(), err=True)
-            if proc.stdout:
-                typer.echo(proc.stdout.rstrip(), err=True)
-            raise typer.Exit(code=2)
-
-        code = _analyze_and_report(
-            tmp_json,
-            sdc_path,
-            waivers_path,
-            fmt,
-            output_path,
-            sync_depth,
-            verbose=verbose,
-            color=color,
-        )
-        if code != 0:
-            raise typer.Exit(code=code)
-    finally:
-        if keep_json is not None:
-            try:
-                shutil.copy(tmp_json, keep_json)
-                if fmt is OutputFormat.text:
-                    typer.echo(f"netlist JSON kept at: {keep_json}")
-            except OSError as e:
-                typer.echo(f"warning: could not save --keep-json: {e}", err=True)
-        try:
-            tmp_json.unlink()
-        except FileNotFoundError:
-            pass
+    code = _analyze_module_and_report(
+        module,
+        sdc_path,
+        waivers_path,
+        fmt,
+        output_path,
+        sync_depth,
+        verbose=verbose,
+        color=color,
+    )
+    if code != 0:
+        raise typer.Exit(code=code)
 
 
 @app.command()
@@ -245,13 +245,36 @@ def _analyze_and_report(
     verbose: bool = False,
     color: bool | None = None,
 ) -> int:
-    """Run the analyzer on a netlist JSON and dispatch to the chosen
-    reporter. Returns a process-style exit code: 0 = clean (or no SDC
-    so rule checks were skipped), 1 = at least one *unsuppressed* rule
-    violation. Waived findings are still reported but don't fail the
-    run."""
+    """Load a Yosys JSON netlist and run the shared analyze+report path."""
     module = netlist.load(netlist_path)
+    return _analyze_module_and_report(
+        module,
+        sdc_path,
+        waivers_path,
+        fmt,
+        output_path,
+        sync_depth,
+        verbose=verbose,
+        color=color,
+    )
 
+
+def _analyze_module_and_report(
+    module: netlist.Module,
+    sdc_path: Path | None,
+    waivers_path: Path | None,
+    fmt: OutputFormat,
+    output_path: Path | None,
+    sync_depth: int = 2,
+    *,
+    verbose: bool = False,
+    color: bool | None = None,
+) -> int:
+    """Run the analyzer on an in-memory ``Module`` and dispatch to the
+    chosen reporter. Returns a process-style exit code: 0 = clean (or
+    no SDC so rule checks were skipped), 1 = at least one *unsuppressed*
+    rule violation. Waived findings are still reported but don't fail
+    the run."""
     spec: sdc_mod.ClockSpec | None = None
     async_crossings: list[Crossing] = []
     violations = []

--- a/src/rtl_buddy_cdc/frontend.py
+++ b/src/rtl_buddy_cdc/frontend.py
@@ -1,0 +1,64 @@
+"""Frontend abstraction: elaborate SV sources into a :class:`netlist.Module`.
+
+The analyzer (``rules.py`` / ``sdc.py`` / ``waivers.py`` / ``reporter.py``)
+operates on a :class:`rtl_buddy_cdc.netlist.Module`. How that ``Module``
+got there is pluggable:
+
+- ``"yosys"`` — shell out to Yosys (``hierarchy; proc; flatten; opt_clean;
+  write_json``) and load the resulting JSON. This is the historical
+  primary path and remains the default.
+- ``"slang"`` — elaborate SystemVerilog directly via the pyslang Python
+  binding (no Yosys subprocess, no flatten step). Currently a stubbed
+  skeleton; see issue #5.
+
+Both frontends must produce a ``Module`` shape that satisfies the rule
+pack's contract (Yosys-style cell types ``$dff``/``$and``/…, pin names
+``CLK``/``D``/``Q``/``Y``/``A``/``B``/…, integer bit IDs for nets,
+SV attributes on netnames). Rules don't know which frontend produced
+the module; the contract is the only coupling.
+
+This module deliberately stays thin — it picks an implementation and
+delegates. The implementations live in :mod:`rtl_buddy_cdc.frontends`.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+
+from rtl_buddy_cdc.netlist import Module
+
+
+class Frontend(str, Enum):
+    """Which elaboration frontend to use."""
+
+    yosys = "yosys"
+    slang = "slang"
+
+
+def elaborate(
+    sources: list[Path],
+    top: str,
+    frontend: Frontend = Frontend.yosys,
+    *,
+    yosys_bin: str | None = None,
+    keep_json: Path | None = None,
+) -> Module:
+    """Elaborate ``sources`` into a flattened :class:`Module`.
+
+    The ``frontend`` selector dispatches to the concrete implementation;
+    callers only see the resulting ``Module``. Frontend-specific options
+    are accepted as keyword arguments and silently ignored by frontends
+    that don't use them (e.g. ``yosys_bin`` is meaningless for slang).
+    """
+    if frontend is Frontend.yosys:
+        from rtl_buddy_cdc.frontends import yosys as yosys_fe
+
+        return yosys_fe.elaborate(
+            sources, top, yosys_bin=yosys_bin, keep_json=keep_json
+        )
+    if frontend is Frontend.slang:
+        from rtl_buddy_cdc.frontends import slang as slang_fe
+
+        return slang_fe.elaborate(sources, top)
+    raise ValueError(f"unknown frontend: {frontend!r}")

--- a/src/rtl_buddy_cdc/frontends/__init__.py
+++ b/src/rtl_buddy_cdc/frontends/__init__.py
@@ -1,0 +1,6 @@
+"""Concrete elaboration frontends.
+
+Each submodule exposes an ``elaborate(sources, top, **kw) -> Module``
+function. The factory in :mod:`rtl_buddy_cdc.frontend` picks one by
+name; this package only collects the implementations.
+"""

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -1,0 +1,108 @@
+"""slang frontend (in development — see issue #5).
+
+Elaborate SystemVerilog directly via the ``pyslang`` Python binding to
+the `slang <https://github.com/MikePopoloski/slang>`_ compiler. No
+Yosys subprocess, no synthesis, no ``flatten`` step.
+
+Status
+------
+Skeleton only. The function below raises :class:`NotImplementedError`
+on use. The shape we need to produce is a :class:`netlist.Module` that
+satisfies the rule pack's contract (Yosys-style cell types, pin names
+``CLK``/``D``/``Q``/``Y``/``A``/``B``/…, integer bit IDs, SV attributes
+on netnames). Producing that shape from a pyslang :class:`Compilation`
+is a meaningful chunk of work, broken down below.
+
+Implementation roadmap
+----------------------
+1. **Set up pyslang elaboration**
+   - ``pyslang.SyntaxTree.fromFile`` per source, ``pyslang.Compilation``
+     to drive elaboration; resolve the top via the chosen ``top``.
+   - Surface elaboration diagnostics with source locations.
+2. **Walk the elaborated instance tree**
+   - Recurse through ``InstanceSymbol`` instances; collect every
+     ``ProceduralBlockSymbol`` with ``ProceduralBlockKind.AlwaysFF``.
+     These are our flop candidates.
+3. **Flop inference**
+   - From each ``always_ff`` event control extract the CLK signal
+     (the ``posedge``/``negedge`` operand).
+   - Recognise async-reset shape ``if (rst) <q> <= reset_val; else
+     <q> <= <d>;`` to populate ``ARST`` + reset polarity; without it,
+     emit a plain ``$dff``.
+   - Width comes from the LHS symbol type.
+4. **Net-bit allocation**
+   - Allocate a unique integer Bit ID per ``(signal_symbol, bit_index)``.
+     Hierarchical signals from inner instances get their own IDs;
+     port connections create aliasing through a union-find.
+   - Constants (``1'b0``/``1'b1``/``x``/``z``) map to the Yosys
+     constant chars ``"0"`` / ``"1"`` / ``"x"`` / ``"z"``.
+5. **Combinational primitive lowering**
+   - Walk every continuous assign, every ``always_comb``, and every
+     non-clocked expression evaluation reachable from a flop's
+     ``D`` / ``ARST`` cone.
+   - Lower expressions to Yosys-shaped primitives: ``BinaryOp::Add`` →
+     ``$add``, ``BinaryOp::LogicalAnd`` → ``$logic_and``,
+     ``ConditionalOp`` → ``$mux``, etc. Each lowered cell uses ``Y`` as
+     its output and ``A``/``B``/``S`` as inputs to match the rule
+     pack's expectations.
+6. **Attribute propagation**
+   - Forward SV attributes (``(* cdc_sync *)``, ``(* cdc_gray *)``,
+     ``(* async_reg *)`` …) attached to wire/reg declarations onto the
+     :class:`netlist.Netname` for the corresponding bits.
+   - Forward source ranges into ``Cell.attributes["src"]`` so the
+     reporter's source-location output still works.
+7. **Cross-instance flattening**
+   - The rule pack assumes a single flattened module. After collecting
+     all flops/cells/nets in the hierarchical walk, emit them under a
+     single :class:`Module` whose name is the top module.
+
+Until that work lands, ``elaborate()`` raises ``NotImplementedError``
+with an actionable message. ``--frontend slang`` on the CLI is gated
+behind the same error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rtl_buddy_cdc.netlist import Module
+
+
+_PYSLANG_INSTALL_HINT = (
+    "pyslang is required for the slang frontend. Install via:\n"
+    "    pip install 'rtl-buddy-cdc[slang]'\n"
+    "or directly:\n"
+    "    pip install pyslang"
+)
+
+
+class SlangFrontendUnavailable(RuntimeError):
+    """pyslang import failed (extra not installed)."""
+
+
+def _import_pyslang():
+    """Lazy import. Raises :class:`SlangFrontendUnavailable` with an
+    install hint if pyslang isn't on the path. Importing here (not at
+    module load) keeps pyslang truly optional — the default install is
+    typer-only per the AGENTS.md runtime-deps policy."""
+    try:
+        import pyslang  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise SlangFrontendUnavailable(_PYSLANG_INSTALL_HINT) from e
+    return pyslang
+
+
+def elaborate(sources: list[Path], top: str) -> Module:
+    """Elaborate ``sources`` via pyslang and produce a :class:`Module`.
+
+    NOT YET IMPLEMENTED — see the roadmap in this module's docstring
+    and issue #5. The pyslang import is exercised eagerly so callers
+    get the install-hint error before hitting the not-implemented
+    branch, which is the more common failure mode in practice.
+    """
+    _import_pyslang()
+    raise NotImplementedError(
+        "slang frontend is a work in progress (issue #5). "
+        f"Cannot elaborate {len(sources)} source(s) with top={top!r} yet. "
+        "Use --frontend yosys (the default) until the slang frontend lands."
+    )

--- a/src/rtl_buddy_cdc/frontends/yosys.py
+++ b/src/rtl_buddy_cdc/frontends/yosys.py
@@ -1,0 +1,78 @@
+"""Yosys frontend: shell out to ``yosys`` to elaborate + flatten, then
+load the resulting JSON via :func:`netlist.load`.
+
+Centralises the Yosys invocation that the ``lint`` CLI command used to
+inline. The CLI command now goes through :func:`rtl_buddy_cdc.frontend.elaborate`,
+which dispatches here when the ``yosys`` frontend is selected.
+
+The :func:`rtl_buddy_cdc.cli.analyze` command path remains unchanged —
+it loads a pre-produced JSON directly via :func:`netlist.load`; this
+module is only used when the caller starts from SV sources.
+"""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc.netlist import Module
+
+
+class YosysError(RuntimeError):
+    """Yosys binary was missing or elaboration failed."""
+
+
+def elaborate(
+    sources: list[Path],
+    top: str,
+    *,
+    yosys_bin: str | None = None,
+    keep_json: Path | None = None,
+) -> Module:
+    """Run yosys to produce a flattened netlist JSON, then load it.
+
+    ``keep_json``, if set, copies the intermediate JSON to that path
+    before the temp file is deleted — useful for debugging or for
+    re-running ``analyze`` against the same netlist.
+    """
+    yosys = yosys_bin or shutil.which("yosys")
+    if yosys is None or not Path(yosys).exists():
+        raise YosysError("yosys not found on PATH (use --yosys to override)")
+
+    tmp_json = Path(tempfile.mkstemp(suffix=".json", prefix="rtl-buddy-cdc-")[1])
+    try:
+        srcs = " ".join(shlex.quote(str(s)) for s in sources)
+        script = (
+            f"read_verilog -sv {srcs}; "
+            f"hierarchy -top {shlex.quote(top)}; "
+            f"proc; flatten; opt_clean; "
+            f"write_json {shlex.quote(str(tmp_json))}"
+        )
+        proc = subprocess.run(
+            [yosys, "-q", "-p", script],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            # Surface both streams; yosys writes the actually-useful
+            # error to stderr but legacy builds split it across both.
+            msg = "yosys elaboration failed"
+            if proc.stderr.strip():
+                msg += f": {proc.stderr.strip()}"
+            if proc.stdout.strip():
+                msg += f"\n{proc.stdout.strip()}"
+            raise YosysError(msg)
+
+        module = netlist.load(tmp_json)
+        if keep_json is not None:
+            shutil.copy(tmp_json, keep_json)
+        return module
+    finally:
+        try:
+            tmp_json.unlink()
+        except FileNotFoundError:
+            pass

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,145 @@
+"""Frontend-abstraction tests.
+
+These cover the factory + CLI plumbing introduced for issue #5. The
+actual slang elaboration is still a stub, so the "slang works" case
+isn't tested here — the focus is that:
+
+- the factory dispatches on the enum,
+- the slang path errors cleanly with an install hint when pyslang
+  isn't installed,
+- the yosys path still produces a Module (skipped if yosys isn't on
+  PATH so the suite runs unattended).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from rtl_buddy_cdc.cli import app
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.frontends.slang import SlangFrontendUnavailable
+
+FIX_ROOT = Path(__file__).parent / "fixtures"
+runner = CliRunner()
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+
+
+def test_frontend_enum_values() -> None:
+    """The two frontend names are the stable public API the CLI uses;
+    rename = breaking change."""
+    assert {f.value for f in Frontend} == {"yosys", "slang"}
+
+
+def test_elaborate_unknown_frontend_raises() -> None:
+    """Calling :func:`elaborate` with a non-enum frontend value is a
+    programmer error — surface it loudly rather than silently picking
+    a default."""
+    with pytest.raises(ValueError, match="unknown frontend"):
+        elaborate([Path("x.sv")], "top", frontend="bogus")  # type: ignore[arg-type]
+
+
+@pytest.mark.skipif(
+    PYSLANG_INSTALLED,
+    reason="pyslang is installed — install-hint path not exercised",
+)
+def test_slang_frontend_missing_pyslang_errors_cleanly() -> None:
+    """Without pyslang on the path the slang frontend should raise
+    :class:`SlangFrontendUnavailable` with an actionable install hint,
+    not a bare ImportError."""
+    with pytest.raises(SlangFrontendUnavailable) as exc:
+        elaborate([Path("x.sv")], "top", frontend=Frontend.slang)
+    assert "pip install" in str(exc.value)
+    assert "rtl-buddy-cdc[slang]" in str(exc.value)
+
+
+@pytest.mark.skipif(
+    PYSLANG_INSTALLED,
+    reason="pyslang is installed — install-hint path not exercised",
+)
+def test_cli_lint_slang_frontend_errors_cleanly_when_missing() -> None:
+    """The CLI should translate :class:`SlangFrontendUnavailable` into
+    exit 2 + an install hint, not a stack trace."""
+    fix = FIX_ROOT / "bad_single_ff_sync"
+    # mix_stderr=True (default) folds stderr into result.output, which
+    # is what we want for substring matching across both streams.
+    result = runner.invoke(
+        app,
+        [
+            "lint",
+            "--frontend",
+            "slang",
+            "--top",
+            "bad_single_ff_sync",
+            "--sdc",
+            str(fix / "bad_single_ff_sync.sdc"),
+            str(fix / "bad_single_ff_sync.sv"),
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    assert "pip install" in result.output
+    assert "rtl-buddy-cdc[slang]" in result.output
+
+
+@pytest.mark.skipif(
+    not PYSLANG_INSTALLED,
+    reason="pyslang not installed — stub-raises-NotImplemented path needs it",
+)
+def test_slang_frontend_stub_raises_not_implemented() -> None:
+    """When pyslang IS installed, the slang frontend should still raise
+    :class:`NotImplementedError` (the elaboration is unimplemented),
+    not silently succeed or hide behind the install-hint path."""
+    with pytest.raises(
+        NotImplementedError, match="slang frontend is a work in progress"
+    ):
+        elaborate([Path("x.sv")], "top", frontend=Frontend.slang)
+
+
+YOSYS = shutil.which("yosys")
+
+
+@pytest.mark.skipif(YOSYS is None, reason="yosys not on PATH")
+def test_yosys_frontend_factory_produces_module() -> None:
+    """The factory dispatch for the yosys frontend should still
+    elaborate a fixture end-to-end — same Module as before the
+    refactor."""
+    fix = FIX_ROOT / "bad_single_ff_sync"
+    module = elaborate(
+        [fix / "bad_single_ff_sync.sv"],
+        "bad_single_ff_sync",
+        frontend=Frontend.yosys,
+    )
+    assert module.name == "bad_single_ff_sync"
+    # Two flops are inferred from the two always_ff blocks.
+    ff_cells = [
+        c for c in module.cells.values() if c.type.startswith("$") and "dff" in c.type
+    ]
+    assert len(ff_cells) >= 2
+
+
+@pytest.mark.skipif(YOSYS is None, reason="yosys not on PATH")
+def test_cli_lint_default_frontend_is_yosys() -> None:
+    """Without ``--frontend``, ``lint`` should behave exactly as before
+    (Yosys path); this is the back-compat guarantee from issue #5."""
+    fix = FIX_ROOT / "bad_single_ff_sync"
+    result = runner.invoke(
+        app,
+        [
+            "lint",
+            "--top",
+            "bad_single_ff_sync",
+            "--sdc",
+            str(fix / "bad_single_ff_sync.sdc"),
+            str(fix / "bad_single_ff_sync.sv"),
+        ],
+    )
+    # Bad fixture trips CDC-001 → exit 1, same as the legacy lint test.
+    assert result.exit_code == 1, result.output
+    assert "CDC-001" in result.output
+    # Frontend preamble appears in text-mode output.
+    assert "frontend: yosys" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -90,6 +90,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pyslang"
+version = "10.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/a5/96406aa35358e479dc82a219cb43cf8da6f93c9b86ce15eb5d9051aac13c/pyslang-10.0.0.tar.gz", hash = "sha256:59ca9c53f0fa1c44bea6cd424014bf1e5e28beda0df0372951a70e44b6d84045", size = 1736690, upload-time = "2026-01-16T14:23:03.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/d7/985fe181892d747e27ca10a1dc220823eb55653812e827f12f0127b95433/pyslang-10.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9980a3f4f2d8a18fa46ebad96c98877a846986a74e210ed12fe2f392e0cae7da", size = 3894902, upload-time = "2026-01-16T14:22:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5f/5d7d8f4f309471eeeb3e5b04f2762d30ce8c77da473350555d5c238703e8/pyslang-10.0.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:cf5c877a28440ad5d6e89b43e2305c007b73ff3cef14110df3861f1dea55915c", size = 7917827, upload-time = "2026-01-16T14:22:30.339Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/486bda96e51e24e2e5f1631eb42f4fca6f3a6d71419fd8349d899bee5707/pyslang-10.0.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6b06cadf7ab5f2b7efb472cfd3c7100c957cfbb72b7adee8230ea398fedd193", size = 4979254, upload-time = "2026-01-16T14:22:32.085Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/8fa3c4acc5c4962d0f6905f5cc8a2a5e4e2ae7f0537ce5ba136b77bb7721/pyslang-10.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6673b1a3c1a9ae7551ee02581eebdc94cea81bc578f6a6f50abefaf23e4860f0", size = 5702076, upload-time = "2026-01-16T14:22:33.469Z" },
+    { url = "https://files.pythonhosted.org/packages/88/eb/a6ec2c87a117ff5518c9d0104282556ec98698c2bd73b7f82820d3513755/pyslang-10.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:a7f6b52d777bcd716f800baa38d69b95e26feb4d4e6947e0b57e39a210854f0c", size = 3042777, upload-time = "2026-01-16T14:22:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3a/cdf16de7e4e49413e66b1be7838dad811e64476847c7cb088bc894681cbf/pyslang-10.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:907c4df43ccaab0848bf291f55cd187d908918932be74949c66bf8a5b54d1892", size = 3903563, upload-time = "2026-01-16T14:22:37.146Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3d/af5123267eea0f9cdfad237ba0b2fcb6c2230e85fee86b3a931ded081767/pyslang-10.0.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:d7ed1a4f9f58e3d5116b264c77e471368cc7644a111fddcd30e0c72f4db51970", size = 7989180, upload-time = "2026-01-16T14:22:39.267Z" },
+    { url = "https://files.pythonhosted.org/packages/19/31/35a4d249508e49d3a9d479f83e37f4008a2b9992fc85e26c3f41288f983b/pyslang-10.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b8ad2d8298a39f71afa32ffa0af9ba4f7d7844bead71ec7eea282d48e694f0b", size = 4975042, upload-time = "2026-01-16T14:22:41.713Z" },
+    { url = "https://files.pythonhosted.org/packages/38/35/a0e04532337c9c1d2dd958ea8c243d10431a85ad0a58b22b7a90e4bed8f5/pyslang-10.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a510936695384b06ac8cb7a24536ac7f8c72309dc4c645ff55cf1e69b97e071", size = 5701273, upload-time = "2026-01-16T14:22:43.322Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/74/410c1e48d64d9c15b1aa2e0f22158bef26a823a387b86e23295ca5264e1d/pyslang-10.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:e569638b5ecb7262d578aeb6700937e0e7172938ef235be00b308687c2e3696e", size = 3052084, upload-time = "2026-01-16T14:22:45.117Z" },
+    { url = "https://files.pythonhosted.org/packages/87/69/e5949c5262d6f8b98751b7b1de6f6c96360009d54ddca6ccffe0566f4aa7/pyslang-10.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f05b4f42e18a48d31ee9ca8260ca762a9734648efaa9ad1ac11b07bae242e913", size = 3903474, upload-time = "2026-01-16T14:22:46.628Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/1d/9847ed967ab46e503f8d7311f0bc8d4f958b0a4780e877d5266392d21b6a/pyslang-10.0.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:741757701a41becf37ebeb9b101d1d6a02915908e647826cdcaa0f82d6b52642", size = 7988998, upload-time = "2026-01-16T14:22:48.279Z" },
+    { url = "https://files.pythonhosted.org/packages/28/aa/a8a8b92a248c388ac02c09b7d098a5024dba0e5bba2d28b54eb2f4985d26/pyslang-10.0.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6fc7181e8bd4fe7739e7782a0463766192219b2bee9fbd14822cc1c745ccbae1", size = 4974955, upload-time = "2026-01-16T14:22:49.99Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e6/5de69d1327f501e4a4d7819b13efac8d90c064e995ec06dea61c0656a0f3/pyslang-10.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2780204dd9ed9b99cd07bc4461cf772ace5998edfeea8c211d7e29199cc96f95", size = 5700787, upload-time = "2026-01-16T14:22:51.526Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b3/56203c96210e6df4c5513d858942cec10e9fa38861e4c50a320dbd8e9ec6/pyslang-10.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:fb4c87a7ec6fbf0d76e76861fb7ae4f6a3b3a05bcaaebd21d09ea2e76907e11d", size = 3052568, upload-time = "2026-01-16T14:22:53.409Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -126,6 +149,11 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+slang = [
+    { name = "pyslang" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -139,7 +167,11 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typer", specifier = ">=0.25.1" }]
+requires-dist = [
+    { name = "pyslang", marker = "extra == 'slang'", specifier = ">=7.0" },
+    { name = "typer", specifier = ">=0.25.1" },
+]
+provides-extras = ["slang"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -21,14 +21,17 @@ read that.
 **Goals.** Catch the eight classic CDC bug shapes (CDC-001 through
 CDC-008) in flattened RTL with reasonable false-positive and false-
 negative rates, surface findings in formats that drop into existing
-review and CI workflows (text / JSON / SARIF), and stay small enough
-to fork and extend in a sitting.
+review and CI workflows (text / JSON / SARIF), stay small enough to
+fork and extend in a sitting, and keep the elaboration frontend
+swappable so the rule pack doesn't depend on a specific toolchain.
 
 **Explicit non-goals.**
 
-- Not a synthesis tool. The analyzer never invokes Yosys on its
-  primary path — the netlist is an input. The standalone `lint`
-  wrapper is convenience-only.
+- Not a synthesis tool. The rule pack never invokes a synthesizer on
+  its primary path — it consumes an in-memory `Module` produced by a
+  frontend (see [§3.1](#31-frontend-layer)). The `analyze` command
+  takes a pre-elaborated Yosys JSON; the `lint` wrapper drives a
+  frontend (Yosys or slang) for source-to-analysis convenience.
 - Not a timing tool. SDC is parsed for **clock topology and async
   partitioning only**; numeric delays and slack are ignored.
 - Not a Tcl interpreter. The SDC parser is a deliberate `shlex`-based
@@ -40,12 +43,21 @@ to fork and extend in a sitting.
 ## 2. Pipeline at a glance
 
 ```
-                 ┌──────────────┐
-                 │ netlist.json │   (Yosys write_json output)
-                 └──────┬───────┘
-                        ▼
+        SV sources + --top                     pre-elaborated
+              │                                  netlist.json
+              ▼                                       │
+   ┌─────────────────────┐                            │
+   │ frontend.elaborate  │  (Frontend.{yosys,slang})  │
+   │  └─ yosys: shell    │                            │
+   │     out + write_json│                            │
+   │  └─ slang: pyslang  │                            │
+   └────────────┬────────┘                            │
+                ▼                                     ▼
         ┌──────────────────────────────────┐
         │ netlist.load        (1)          │  schema → Module / Cell / Port / Netname
+        │  (yosys-frontend path only;      │
+        │   slang frontend builds Module   │
+        │   in-process)                    │
         └──────────────────────────────────┘
                         ▼
         ┌──────────────────────────────────┐
@@ -94,6 +106,9 @@ without one the tool prints the structural summary and exits 0.
 
 | Module | Responsibility | Key types |
 |---|---|---|
+| `frontend.py` | Frontend factory: pick a frontend by name, dispatch to its `elaborate` | `Frontend`, `elaborate` |
+| `frontends/yosys.py` | Yosys frontend: shell out to `yosys` then `netlist.load` the JSON | `elaborate`, `YosysError` |
+| `frontends/slang.py` | slang frontend: elaborate SystemVerilog via pyslang directly | `elaborate`, `SlangFrontendUnavailable`, `SlangElaborationError` |
 | `netlist.py` | Parse Yosys `write_json` output into typed structs | `Module`, `Cell`, `Port`, `Netname` |
 | `flops.py` | Recognise the 11 Yosys FF cell variants and extract CLK / D / Q | `Flop`, `FF_CELL_TYPES` |
 | `domain.py` | Trace clock roots, find flop→flop crossings | `FlopDomain`, `Crossing`, `trace_clock_root`, `find_crossings` |
@@ -104,8 +119,60 @@ without one the tool prints the structural summary and exits 0.
 | `cli.py` | Typer entry points; orchestrates the pipeline | `analyze`, `lint`, `version` |
 
 `__init__.py` exposes a thin `main()` shim that calls `cli.app` (used
-by the console-script entry point). No other public API beyond these
-modules.
+by the console-script entry point). The other public API is
+`frontend.Frontend` + `frontend.elaborate(sources, top, frontend=…)`,
+which `cli.lint` consumes when the user supplies SV sources.
+
+### 3.1 Frontend layer
+
+`netlist.Module` is the contract every rule walks. How a module gets
+built is pluggable:
+
+- **Yosys frontend** (`frontends/yosys.py`) — runs `yosys -p
+  'read_verilog ...; hierarchy -top X; proc; flatten; opt_clean;
+  write_json /tmp/out.json'`, then loads the JSON via `netlist.load`.
+  This is the historical primary path and remains the default for
+  `lint --frontend yosys` / `analyze --netlist file.json`.
+- **slang frontend** (`frontends/slang.py`) — in development (see
+  issue #5). Will elaborate SV sources via the
+  [pyslang](https://pypi.org/project/pyslang/) binding to
+  [slang](https://github.com/MikePopoloski/slang) and build a
+  `Module` directly from the elaborated `Compilation` — no
+  synthesis subprocess, no `flatten` step. Opt-in via the
+  `[slang]` install extra (`pip install 'rtl-buddy-cdc[slang]'`);
+  the default install stays `typer`-only. The current scaffolding
+  raises `SlangFrontendUnavailable` (with an install hint) when
+  pyslang is missing, and `NotImplementedError` once it's present
+  until the elaboration lands.
+
+The factory in `frontend.py` is the only orchestration:
+
+```python
+def elaborate(sources, top, frontend=Frontend.yosys, **kw) -> Module: ...
+```
+
+Frontends produce a `Module` shape that satisfies the rule pack's
+contract:
+
+- Yosys-style cell types (`$dff`, `$adff`, `$and`, `$xor`, `$mux`, …)
+- pin names `CLK` / `D` / `Q` / `ARST` on flops, `A` / `B` / `Y` on
+  comb cells, etc.
+- integer bit IDs for nets, with the four constant chars `"0"` /
+  `"1"` / `"x"` / `"z"` reserved.
+- SV `(* attr *)` declarations propagated onto the corresponding
+  `Netname`.
+
+Rules don't know which frontend produced a `Module` — the shape is
+the only coupling. New frontends only need to produce that shape;
+no other module changes.
+
+The slang frontend's elaboration lands in a follow-up PR (Stage 2
+of issue #5); this PR is the abstraction layer, the `--frontend`
+CLI flag, and the optional install extra only. The roadmap in
+`frontends/slang.py` covers the implementation chunks: elaboration
+setup, instance-tree walk, flop inference, net-bit allocation,
+primitive lowering, attribute propagation, and cross-instance
+flattening.
 
 ## 4. Data model
 
@@ -604,12 +671,15 @@ churn:
 - **New clock-network shapes.** Add the cell-type set to one of the
   category constants in `domain.py` (`_BUFFER_TYPES`, `_GATE_TYPES`,
   `_MUX_TYPES`) — the walker is data-driven from those.
+- **New elaboration frontends.** Add a submodule under `frontends/`
+  exposing `elaborate(sources, top, **kw) -> Module`, register it in
+  the `Frontend` enum in `frontend.py`, and dispatch in
+  `frontend.elaborate`. The frontend must produce the Yosys-style
+  `Module` contract documented in [§3.1](#31-frontend-layer); the
+  rule pack consumes that contract regardless of source.
 
 Where the analyzer is **not** trying to be extensible:
 
-- Netlist front-end: only Yosys `write_json` is supported. A
-  different front-end would need a `Module`-shaped adapter, not an
-  abstraction.
 - Hierarchy: today's pipeline assumes flatten. Hierarchical analysis
   is a major design change, not an extension point.
 


### PR DESCRIPTION
## Summary

Stage 1 of #5: land the **frontend abstraction layer** so a future pyslang-backed elaborator can sit alongside the existing Yosys one without churn in the rule pack or the JSON / SARIF schema.

- New \`src/rtl_buddy_cdc/frontend.py\` — \`Frontend\` enum + \`elaborate()\` factory dispatching by name.
- New \`src/rtl_buddy_cdc/frontends/yosys.py\` — Yosys subprocess invocation extracted out of \`cli.lint\`, exposed as a frontend that raises \`YosysError\` on missing binary / elaboration failure.
- New \`src/rtl_buddy_cdc/frontends/slang.py\` — pyslang skeleton with **lazy** import, actionable install hint (\`SlangFrontendUnavailable\`), and a 7-step implementation roadmap in the module docstring (elaboration setup → instance-tree walk → flop inference → net-bit allocation → primitive lowering → attribute propagation → cross-instance flattening). Raises \`NotImplementedError\` until the elaboration lands.
- \`cli.py lint\` grows \`--frontend {yosys,slang}\` (default \`yosys\`). \`analyze\` is unchanged — it still consumes a pre-elaborated netlist JSON.
- \`pyproject.toml\` adds an optional \`[slang]\` extra (\`pyslang>=7.0\`). Default install stays \`typer\`-only per the AGENTS.md runtime-deps policy; the slang frontend is opt-in via \`pip install 'rtl-buddy-cdc[slang]'\`.
- README documents the new flag and the install extra; the Roadmap section gets a dedicated \"slang frontend\" item linked back to #5.

## Why

The analyzer was already designed as a \"pure analyzer\" — \`rules.py\` / \`sdc.py\` / \`waivers.py\` / \`reporter.py\` operate on \`Module\` / \`Flop\` / \`Crossing\` abstractions, not on Yosys-specific data. This PR surfaces that with an explicit factory + flag so a pyslang frontend can be added incrementally (Stage 2 in #5) and reach parity rule-by-rule against the existing paired fixtures. **No behaviour change on the Yosys path.**

## Out of scope

- The actual pyslang elaboration — explicitly Stage 2 of #5. The CLI rejects \`--frontend slang\` today with a clear NotImplementedError / install-hint message, so users discover the in-development state immediately rather than via a confusing failure.
- \`analyze --frontend slang\` — \`analyze\` keeps its \"give me a pre-elaborated netlist JSON\" semantics. Mixing source-elaboration into \`analyze\` would overload its argument shape; \`lint\` is the natural home for the flag. We can revisit if it turns out users want it on \`analyze\` too.

## Test plan

- [x] \`uv run ruff check\` — passes
- [x] \`uv run ruff format --check\` — passes
- [x] \`uv run pytest -q\` — **97 passed, 1 skipped** (the skip is \`test_slang_frontend_stub_raises_not_implemented\`, which only fires when pyslang is installed; install-hint path is the one we exercise in CI)
- [x] New \`tests/test_frontend.py\` covers: enum stability, unknown-frontend rejection, missing-pyslang install hint (both Python API + CLI exit-2 path), pyslang-installed NotImplemented path, yosys-factory parity with the existing fixtures, and \`lint\` default-frontend back-compat.
- [x] Manual smoke: \`uv run rtl-buddy-cdc lint --help\` shows the new flag; \`lint --frontend slang ...\` (without pyslang) prints the install hint and exits 2.
- [x] Verified \`rb cdc\` / \`rb cdc-regression\` in the downstream rtl-buddy repo still parse the JSON output unchanged (no schema changes in this PR, but worth re-running before merge if any downstream contract test exists).

Closes #5 once Stages 2 (pyslang elaboration) and 3 (rule-by-rule parity) land in follow-up PRs.