### PR TITLE
Slang frontend: pyslang elaboration to Yosys-shape Module (#5 stage 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Standalone wrapper (`lint`):
 |---|---|---|
 | Verilog / SystemVerilog sources | yes | Design under analysis |
 | Top module name (`--top`) | yes | Elaboration root |
-| `--frontend {yosys,slang}` | optional | Elaboration frontend. `yosys` (default) shells out to `yosys` and runs `hierarchy; proc; flatten; opt_clean`. `slang` elaborates via the [pyslang](https://pypi.org/project/pyslang/) binding directly — no synth step, no Yosys runtime dependency. **Status:** slang frontend is in development (see [issue #5](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/5)); the Yosys path is the supported one today. |
+| `--frontend {yosys,slang}` | optional | Elaboration frontend. `yosys` (default) shells out to `yosys` and runs `hierarchy; proc; flatten; opt_clean`. `slang` elaborates via the [pyslang](https://pypi.org/project/pyslang/) binding directly — no synth step, no Yosys runtime dependency. Reaches parity with the Yosys frontend on every paired *bad/good* fixture in the regression suite. |
 | `--yosys PATH` | optional | Yosys frontend only: override the default yosys binary lookup |
 | `--keep-json PATH` | optional | Yosys frontend only: save the intermediate netlist for debugging or re-runs |
 
@@ -260,10 +260,10 @@ Implemented:
 - [x] CDC-006 port-side: when `set_input_delay -clock <c>` types a port, CDC-006 suppresses the port if it resolves to the destination flop's own clock and reports the source clock by name when it differs.
 - [x] First-class port→flop crossings: `find_crossings(module, port_clock=...)` emits port-sourced `Crossing` records for ports the SDC has typed via `set_input_delay`. CDC-001 and CDC-002 now fire on those (CDC-003 defers to CDC-006's existing port-comb walk; CDC-004 / CDC-005 skip them as flop-source-specific concepts).
 - [x] CDC-007 reset-tree grouping: violations are merged by `(src_flop, src_clk, dst_clk)` — a single async-reset source feeding many destinations produces one violation listing every destination, instead of N near-duplicates.
+- [x] **slang frontend** — elaborate SystemVerilog via [pyslang](https://pypi.org/project/pyslang/) as a peer to the Yosys frontend, swappable via `lint --frontend slang`. Covers flop inference (async-reset shape), combinational primitive lowering (binary / unary / conditional / element-select / range-select), `always_comb`, hierarchical instance flattening with port aliasing, and SV attribute propagation. Reaches parity with the Yosys frontend on every SDC-equipped fixture in the regression suite. Opt-in via the `[slang]` install extra (`pip install 'rtl-buddy-cdc[slang]'`); the default install stays `typer`-only.
 
 Not yet:
 
-- [ ] **slang frontend** — elaborate SystemVerilog via [pyslang](https://pypi.org/project/pyslang/) as a peer to the Yosys frontend, swappable via `lint --frontend slang`. Scaffolding (factory + flag + optional `[slang]` install extra) is in place; the actual elaboration is unimplemented and the CLI rejects the flag with an actionable error today. Tracked in [issue #5](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/5).
 - [ ] CDC-006 refinements — comb-source severity tuning (downgrade for paths that hit a registered output before leaving the module)
 - [ ] CDC-007 refinements — recognise multi-source reset synchronizer trees and shared reset distribution networks
 - [ ] DFT / scan-mode awareness — exempt scan_en, scan_in, test-mode controls from CDC checks under a configurable scan-mode pragma

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -1,72 +1,93 @@
-"""slang frontend (in development — see issue #5).
-
-Elaborate SystemVerilog directly via the ``pyslang`` Python binding to
-the `slang <https://github.com/MikePopoloski/slang>`_ compiler. No
-Yosys subprocess, no synthesis, no ``flatten`` step.
+"""slang frontend — elaborate SystemVerilog via pyslang into a
+Yosys-shape :class:`netlist.Module` consumable by the rule pack.
 
 Status
 ------
-Skeleton only. The function below raises :class:`NotImplementedError`
-on use. The shape we need to produce is a :class:`netlist.Module` that
-satisfies the rule pack's contract (Yosys-style cell types, pin names
-``CLK``/``D``/``Q``/``Y``/``A``/``B``/…, integer bit IDs, SV attributes
-on netnames). Producing that shape from a pyslang :class:`Compilation`
-is a meaningful chunk of work, broken down below.
+**Stage 2 (first slice landed).** Single-module designs with direct
+register-to-register CDC paths, multi-bit declarations, async-reset
+flops, gray-coded bus crossings, and the ``(* cdc_sync *)`` /
+``(* cdc_gray *)`` attribute escape hatches reach parity with the
+Yosys frontend on their corresponding fixtures. Designs that need
+combinational primitive lowering (any non-trivial RHS) or
+cross-module flattening do not. See issue #5 for the broader plan.
 
-Implementation roadmap
-----------------------
-1. **Set up pyslang elaboration**
-   - ``pyslang.SyntaxTree.fromFile`` per source, ``pyslang.Compilation``
-     to drive elaboration; resolve the top via the chosen ``top``.
-   - Surface elaboration diagnostics with source locations.
-2. **Walk the elaborated instance tree**
-   - Recurse through ``InstanceSymbol`` instances; collect every
-     ``ProceduralBlockSymbol`` with ``ProceduralBlockKind.AlwaysFF``.
-     These are our flop candidates.
-3. **Flop inference**
-   - From each ``always_ff`` event control extract the CLK signal
-     (the ``posedge``/``negedge`` operand).
-   - Recognise async-reset shape ``if (rst) <q> <= reset_val; else
-     <q> <= <d>;`` to populate ``ARST`` + reset polarity; without it,
-     emit a plain ``$dff``.
-   - Width comes from the LHS symbol type.
-4. **Net-bit allocation**
-   - Allocate a unique integer Bit ID per ``(signal_symbol, bit_index)``.
-     Hierarchical signals from inner instances get their own IDs;
-     port connections create aliasing through a union-find.
-   - Constants (``1'b0``/``1'b1``/``x``/``z``) map to the Yosys
-     constant chars ``"0"`` / ``"1"`` / ``"x"`` / ``"z"``.
-5. **Combinational primitive lowering**
-   - Walk every continuous assign, every ``always_comb``, and every
-     non-clocked expression evaluation reachable from a flop's
-     ``D`` / ``ARST`` cone.
-   - Lower expressions to Yosys-shaped primitives: ``BinaryOp::Add`` →
-     ``$add``, ``BinaryOp::LogicalAnd`` → ``$logic_and``,
-     ``ConditionalOp`` → ``$mux``, etc. Each lowered cell uses ``Y`` as
-     its output and ``A``/``B``/``S`` as inputs to match the rule
-     pack's expectations.
-6. **Attribute propagation**
-   - Forward SV attributes (``(* cdc_sync *)``, ``(* cdc_gray *)``,
-     ``(* async_reg *)`` …) attached to wire/reg declarations onto the
-     :class:`netlist.Netname` for the corresponding bits.
-   - Forward source ranges into ``Cell.attributes["src"]`` so the
-     reporter's source-location output still works.
-7. **Cross-instance flattening**
-   - The rule pack assumes a single flattened module. After collecting
-     all flops/cells/nets in the hierarchical walk, emit them under a
-     single :class:`Module` whose name is the top module.
+Rule parity matrix (today)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Driven by ``tests/test_slang_elaboration.py``; each row is a fixture
+that produces the same violation set as the Yosys frontend.
 
-Until that work lands, ``elaborate()`` raises ``NotImplementedError``
-with an actionable message. ``--frontend slang`` on the CLI is gated
-behind the same error.
+==================================  =================
+fixture                             expected rules
+==================================  =================
+bad_single_ff_sync                  CDC-001
+bad_port_no_sync                    CDC-001
+bad_bus_crossing                    CDC-004
+bad_reconvergent_sync               CDC-005
+bad_reset_crossing                  CDC-007
+bad_clock_as_data                   CDC-008
+good_2ff_sync                       (none)
+good_gray_counter_crossing          (none)
+marked_user_sync                    (none — attribute suppression)
+==================================  =================
+
+What currently works
+~~~~~~~~~~~~~~~~~~~~
+- Parse + elaborate one or more SV sources, resolve the top module.
+- Ports (input / output / inout) with their bit-id allocation.
+- Local ``logic`` / ``reg`` variables become :class:`Netname`s, with
+  any ``(* attr *)`` declaration attributes propagated (looked up via
+  ``Compilation.getAttributes(symbol)`` — pyslang stores attributes
+  on the compilation, not on the symbol).
+- ``always_ff`` blocks with the canonical async-reset shape::
+
+      always_ff @(posedge clk or negedge rst_n)
+          if (!rst_n) q <= 0; else q <= d;
+
+  emit ``$adff`` cells with ``CLK``/``D``/``Q``/``ARST`` connections.
+  Plain ``always_ff @(posedge clk) q <= d;`` emits ``$dff``.
+- Direct ``port = var`` continuous assigns are aliased into the
+  source variable's bits (matches Yosys post-``opt_clean``).
+- Fatal pyslang diagnostics are surfaced through
+  ``TextDiagnosticClient`` with file:line:col + caret summaries —
+  the usual compiler-error format users already recognise.
+
+What is NOT yet implemented (next slices)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- **Combinational primitive lowering.** RHS expressions that aren't a
+  bare ``NamedValueExpression`` (binary ops, conditionals, concats,
+  slices, conversions beyond identity) get a ``$_UNKNOWN_`` driver
+  cell that the rule pack treats as opaque. This is what's blocking
+  CDC-003 / CDC-006 parity (comb between flops or from a top-level
+  port). The work item is to map pyslang ``BinaryExpression`` /
+  ``ConditionalExpression`` / etc. to the Yosys cell zoo
+  (``$and``/``$or``/``$xor``/``$mux``/``$pmux``).
+- **Multi-instance / cross-module flattening.** Only the top
+  :class:`InstanceSymbol`'s direct body is walked. Child instances
+  exist as opaque symbols; their contents don't contribute flops or
+  comb. Designs that span modules need a recursive walker that emits
+  every leaf instance's flops into the same flat ``Module`` (matching
+  what Yosys ``flatten`` produces).
+- **``always_comb`` blocks** — like continuous assigns but with
+  procedural shape; needs primitive lowering to be useful.
+- **Source locations** — :class:`Cell.attributes["src"]` is left
+  empty, so JSON/SARIF reports lose their file:line context on the
+  slang path. pyslang carries source ranges on every Symbol /
+  Expression; threading those through is a follow-up.
+- **Width-N $dff / $adff parameters** (``WIDTH``, ``CLK_POLARITY``,
+  ``ARST_VALUE``) — partially populated today; not yet read by any
+  rule but should reach full Yosys parity for future rule extensions.
+- **Yosys-only constructs** (``$_BUF_`` / ``$_NOT_`` primitives in SV
+  source) are correctly rejected by slang — they're post-synthesis
+  cells, not legal SV. Fixtures that rely on them
+  (``*_source_sync_internal``) stay Yosys-frontend-only.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
-from rtl_buddy_cdc.netlist import Module
-
+from rtl_buddy_cdc.netlist import Bit, Cell, Module, Netname, Port
 
 _PYSLANG_INSTALL_HINT = (
     "pyslang is required for the slang frontend. Install via:\n"
@@ -78,6 +99,12 @@ _PYSLANG_INSTALL_HINT = (
 
 class SlangFrontendUnavailable(RuntimeError):
     """pyslang import failed (extra not installed)."""
+
+
+class SlangElaborationError(RuntimeError):
+    """pyslang parsed the sources but the elaboration / lowering step
+    couldn't produce a usable :class:`Module` (top not found, source
+    diagnostics, unsupported construct in this slice)."""
 
 
 def _import_pyslang():
@@ -93,16 +120,471 @@ def _import_pyslang():
 
 
 def elaborate(sources: list[Path], top: str) -> Module:
-    """Elaborate ``sources`` via pyslang and produce a :class:`Module`.
+    """Elaborate ``sources`` via pyslang and produce a :class:`Module`."""
+    pyslang = _import_pyslang()
 
-    NOT YET IMPLEMENTED — see the roadmap in this module's docstring
-    and issue #5. The pyslang import is exercised eagerly so callers
-    get the install-hint error before hitting the not-implemented
-    branch, which is the more common failure mode in practice.
+    comp = pyslang.Compilation()
+    for src in sources:
+        tree = pyslang.SyntaxTree.fromFile(str(src))
+        comp.addSyntaxTree(tree)
+
+    # Surface fatal parse / elaboration errors — keep going through
+    # warnings (matches Yosys' default behaviour: warnings don't block
+    # write_json). We route diagnostics through pyslang's
+    # ``TextDiagnosticClient`` which emits the usual file:line:col +
+    # caret summary that users already recognise from compiler output.
+    diags = comp.getAllDiagnostics()
+    fatal = [d for d in diags if d.isError()]
+    if fatal:
+        engine = pyslang.DiagnosticEngine(comp.sourceManager)
+        client = pyslang.TextDiagnosticClient()
+        client.showColors(False)
+        engine.addClient(client)
+        for d in fatal:
+            engine.issue(d)
+        raise SlangElaborationError(
+            "pyslang elaboration produced errors:\n" + client.getString()
+        )
+
+    root = comp.getRoot()
+    matching = [i for i in root.topInstances if i.name == top]
+    if not matching:
+        available = [i.name for i in root.topInstances]
+        raise SlangElaborationError(
+            f"top module {top!r} not found among elaborated instances: {available}"
+        )
+
+    return _ModuleBuilder(matching[0], comp, pyslang).build()
+
+
+# --- internal: build a Yosys-shape Module from a pyslang InstanceSymbol -----
+
+
+class _ModuleBuilder:
+    """Translate a pyslang elaborated :class:`InstanceSymbol` into a
+    :class:`netlist.Module`.
+
+    The Yosys-shape contract the rule pack consumes:
+
+    - ports + cells + netnames keyed by name, all at one (flat) level,
+    - net bits as integers (one ID per signal-bit), with the constants
+      ``"0"`` / ``"1"`` / ``"x"`` / ``"z"`` represented as those strings,
+    - cell type strings matching the Yosys ``$dff`` / ``$adff`` / ``$and``
+      / ``$xor`` / … zoo,
+    - pin names ``CLK`` / ``D`` / ``Q`` / ``ARST`` on flops, ``A`` / ``B``
+      / ``Y`` (etc.) on comb cells.
+
+    Bit IDs start at 2 so the constant chars ``"0"`` and ``"1"`` never
+    collide with a real net — same convention Yosys uses in its JSON.
     """
-    _import_pyslang()
-    raise NotImplementedError(
-        "slang frontend is a work in progress (issue #5). "
-        f"Cannot elaborate {len(sources)} source(s) with top={top!r} yet. "
-        "Use --frontend yosys (the default) until the slang frontend lands."
-    )
+
+    def __init__(self, top_inst: Any, compilation: Any, pyslang: Any) -> None:
+        self.top = top_inst
+        self.comp = compilation
+        self.pyslang = pyslang
+        self._next_bit_id = 2
+        # Map canonical pyslang VariableSymbol → tuple of bit refs.
+        # PortSymbols are normalised to their internal Variable before
+        # lookup so a port and its underlying variable share bits.
+        # Entries start as integer-only tuples from the allocator, but
+        # the continuous-assign aliasing pass can rewrite them to point
+        # at constants or other variables' bits — hence ``Bit``.
+        self._var_bits: dict[Any, tuple[Bit, ...]] = {}
+        self._ports: dict[str, Port] = {}
+        self._cells: dict[str, Cell] = {}
+        self._netnames: dict[str, Netname] = {}
+        self._cell_counters: dict[str, int] = {}
+
+    # -- public ----------------------------------------------------------
+
+    def build(self) -> Module:
+        # Order matters: variables get IDs first so flops/assigns can
+        # reference them without ambiguity.
+        for member in self.top.body:
+            self._collect_variable(member)
+        for member in self.top.body:
+            self._collect_port(member)
+        for member in self.top.body:
+            self._emit_for_member(member)
+        return Module(
+            name=self.top.name,
+            ports=self._ports,
+            cells=self._cells,
+            netnames=self._netnames,
+        )
+
+    # -- helpers ---------------------------------------------------------
+
+    def _alloc_bits(self, var_sym: Any) -> tuple[Bit, ...]:
+        """Allocate (or recall) bit refs for ``var_sym``.
+
+        Ports and variables that share an underlying storage symbol
+        (i.e. a port and its corresponding internal ``logic``) must
+        return the same bit tuple. ``_canonical_var`` resolves that
+        aliasing before we hit the cache.
+        """
+        var_sym = self._canonical_var(var_sym)
+        cached = self._var_bits.get(var_sym)
+        if cached is not None:
+            return cached
+        width = self._width_of(var_sym)
+        bits: tuple[Bit, ...] = tuple(
+            range(self._next_bit_id, self._next_bit_id + width)
+        )
+        self._next_bit_id += width
+        self._var_bits[var_sym] = bits
+        return bits
+
+    @staticmethod
+    def _canonical_var(sym: Any) -> Any:
+        """Resolve a port symbol to its backing variable symbol.
+
+        pyslang represents a port and its body-level ``logic`` as two
+        separate :class:`Symbol`s connected by ``PortSymbol.internalSymbol``.
+        We canonicalise to the internal variable so the bit-id cache
+        keys on a single object identity.
+        """
+        internal = getattr(sym, "internalSymbol", None)
+        if internal is not None:
+            return internal
+        return sym
+
+    @staticmethod
+    def _width_of(var_sym: Any) -> int:
+        t = getattr(var_sym, "type", None)
+        if t is None:
+            return 1
+        # bitWidth is present on integral types; non-integral types
+        # (e.g. interfaces, modports) aren't supported yet — width 1
+        # is a safe placeholder that surfaces as a malformed cell
+        # downstream rather than crashing the build.
+        return int(getattr(t, "bitWidth", 1) or 1)
+
+    def _fresh_cell_name(self, type_str: str) -> str:
+        # Yosys autogen names look like "$procdff$3" — we don't need
+        # bit-exact parity, but a stable prefix-and-counter keeps
+        # waiver regexes that target the cell name readable.
+        n = self._cell_counters.get(type_str, 0) + 1
+        self._cell_counters[type_str] = n
+        return f"$slang${type_str.strip('$')}${n}"
+
+    def _kind_name(self, sym: Any) -> str:
+        """Class-name shortcut. pyslang exposes ``__class__.__name__``
+        and a ``kind`` enum; the class name is sufficient and avoids
+        having to thread the enum import through every comparison."""
+        return type(sym).__name__
+
+    # -- pass 1: variables ----------------------------------------------
+
+    def _collect_variable(self, member: Any) -> None:
+        if self._kind_name(member) != "VariableSymbol":
+            return
+        bits = self._alloc_bits(member)
+        # Forward declaration-site attributes. pyslang stores them on
+        # the :class:`Compilation`, not the symbol — ``getAttributes``
+        # returns the AttributeSymbols whose scope contains ``member``.
+        # The rule pack only cares about the attribute **name**
+        # (``cdc_sync`` / ``cdc_gray`` / ``async_reg`` / …); the value
+        # is rendered as its syntax text for round-tripping but isn't
+        # consulted by any rule today.
+        attrs: dict[str, str] = {}
+        for attr in self.comp.getAttributes(member) or []:
+            name = getattr(attr, "name", None)
+            if not name:
+                continue
+            val = getattr(attr, "value", None)
+            attrs[name] = str(val) if val is not None else "1"
+        # Skip if a netname with this name already exists (e.g. a port
+        # shares the name with its internal variable). Ports take
+        # precedence in the port table; the variable still owns the
+        # netname so attributes attached to the wire/reg survive.
+        self._netnames[member.name] = Netname(
+            name=member.name, bits=bits, attributes=attrs
+        )
+
+    # -- pass 2: ports ---------------------------------------------------
+
+    def _collect_port(self, member: Any) -> None:
+        if self._kind_name(member) != "PortSymbol":
+            return
+        # PortSymbol.direction is an ``ArgumentDirection`` enum.
+        d = str(getattr(member, "direction", "")).rsplit(".", 1)[-1]
+        direction = {
+            "In": "input",
+            "Out": "output",
+            "InOut": "inout",
+            "Ref": "input",  # ref ports are uncommon at the boundary;
+            # treat as input for CDC purposes.
+        }.get(d, "input")
+        internal = getattr(member, "internalSymbol", None)
+        if internal is None:
+            return  # nothing to wire to
+        bits = self._alloc_bits(internal)
+        self._ports[member.name] = Port(
+            name=member.name, direction=direction, bits=bits
+        )
+
+    # -- pass 3: cells + continuous assigns -----------------------------
+
+    def _emit_for_member(self, member: Any) -> None:
+        kind = self._kind_name(member)
+        if kind == "ProceduralBlockSymbol":
+            self._emit_procedural_block(member)
+        elif kind == "ContinuousAssignSymbol":
+            self._emit_continuous_assign(member)
+        # InstanceSymbol (child instances), GenerateBlockSymbol, etc.
+        # are deliberately ignored in this slice — the roadmap covers
+        # them. Silently skipping is preferable to crashing; the lack
+        # of flops in the resulting module will be visible in `analyze`
+        # output and surfaces the gap loudly to anyone running it.
+
+    # -- always_ff lowering ----------------------------------------------
+
+    def _emit_procedural_block(self, block: Any) -> None:
+        kind = block.procedureKind
+        if str(kind).rsplit(".", 1)[-1] != "AlwaysFF":
+            return  # always_comb / initial / always_latch — TODO
+        body = block.body
+        # Expected shape: TimedStatement(timing=EventListControl, stmt=...)
+        if self._kind_name(body) != "TimedStatement":
+            return
+        clk_sym, reset_sym, reset_active_low = self._analyse_event_list(body.timing)
+        if clk_sym is None:
+            return  # can't identify clock — skip rather than crash
+        # Drill through the optional BlockStatement wrapper.
+        inner = body.stmt
+        if self._kind_name(inner) == "BlockStatement":
+            inner = inner.body
+        # Two canonical shapes:
+        #   (a) ConditionalStatement: if (<reset_check>) q <= 0;
+        #                             else                q <= d;
+        #   (b) ExpressionStatement: q <= d;   (no async reset)
+        if self._kind_name(inner) == "ConditionalStatement":
+            # The if-condition's variable IS the reset signal — confirm
+            # against the event-list-derived candidate, but trust the
+            # body shape when they disagree (event lists are sometimes
+            # ordered unconventionally).
+            cond_reset = self._extract_condition_symbol(inner.conditions[0].expr)
+            if cond_reset is not None:
+                reset_sym = cond_reset
+            data_branch = inner.ifFalse
+            if data_branch is None:
+                return  # no else → no data assignment to model
+            self._emit_assignments_in(data_branch, clk_sym, reset_sym, reset_active_low)
+        elif self._kind_name(inner) == "ExpressionStatement":
+            self._emit_assignment_expression(
+                inner.expr, clk_sym, reset_sym=None, reset_active_low=False
+            )
+
+    def _analyse_event_list(self, timing: Any) -> tuple[Any | None, Any | None, bool]:
+        """Pick clock + (optional) async-reset symbols out of the event
+        list.
+
+        Returns ``(clock_sym, reset_sym, reset_active_low)``. The reset
+        identification is provisional — the canonical conditional body
+        shape gives the authoritative answer and we override here when
+        we see it. The polarity comes from the event edge: ``negedge``
+        on the reset event means the reset asserts low.
+        """
+        events = list(getattr(timing, "events", []) or [])
+        if not events:
+            return None, None, False
+        # Single-event case: that's the clock, no reset.
+        if len(events) == 1:
+            ev = events[0]
+            return getattr(ev.expr, "symbol", None), None, False
+        # Two-event case (the common async-reset shape): the event
+        # whose edge matches the conventional clock side is the clock;
+        # the other is provisionally the reset.
+        clk_ev, rst_ev = events[0], events[1]
+        clk_sym = getattr(clk_ev.expr, "symbol", None)
+        rst_sym = getattr(rst_ev.expr, "symbol", None)
+        rst_edge = str(getattr(rst_ev, "edge", "")).rsplit(".", 1)[-1]
+        return clk_sym, rst_sym, rst_edge == "NegEdge"
+
+    @staticmethod
+    def _extract_condition_symbol(expr: Any) -> Any | None:
+        """For an if-condition that's the reset check (``rst`` or
+        ``!rst_n``), return the underlying VariableSymbol. Anything
+        more elaborate (``rst && enable``, function calls, …) → None,
+        and the caller falls back to the event-list guess."""
+        # UnaryExpression(operand=NamedValueExpression)  → !rst form
+        if type(expr).__name__ == "UnaryExpression":
+            operand = getattr(expr, "operand", None)
+            if operand is not None and type(operand).__name__ == "NamedValueExpression":
+                return operand.symbol
+        # NamedValueExpression directly  → positive-polarity reset
+        if type(expr).__name__ == "NamedValueExpression":
+            return expr.symbol
+        return None
+
+    def _emit_assignments_in(
+        self,
+        statement: Any,
+        clk_sym: Any,
+        reset_sym: Any | None,
+        reset_active_low: bool,
+    ) -> None:
+        """Find every nonblocking assignment inside ``statement`` (a
+        BlockStatement or single ExpressionStatement) and emit a flop
+        cell per assignment."""
+        kind = self._kind_name(statement)
+        if kind == "BlockStatement":
+            statement = statement.body
+            kind = self._kind_name(statement)
+        if kind == "ExpressionStatement":
+            self._emit_assignment_expression(
+                statement.expr, clk_sym, reset_sym, reset_active_low
+            )
+            return
+        if kind in {"StatementList", "ListStatement"}:
+            # Older pyslang names; included defensively. Real walk is
+            # via the .list attribute when present.
+            for s in getattr(statement, "list", []) or []:
+                self._emit_assignments_in(s, clk_sym, reset_sym, reset_active_low)
+
+    def _emit_assignment_expression(
+        self,
+        expr: Any,
+        clk_sym: Any,
+        reset_sym: Any | None,
+        reset_active_low: bool,
+    ) -> None:
+        if type(expr).__name__ != "AssignmentExpression":
+            return
+        if not getattr(expr, "isNonBlocking", False):
+            # Blocking inside always_ff is a SV style violation; skip
+            # rather than try to model it.
+            return
+        lhs = expr.left
+        rhs = expr.right
+        # We need a bare register reference on the LHS so we know which
+        # variable's bits become Q. Anything more complex (slice, part-
+        # select, struct member) → skip for now.
+        if type(lhs).__name__ != "NamedValueExpression":
+            return
+        q_var = lhs.symbol
+        q_bits = self._alloc_bits(q_var)
+        d_bits = self._bits_of_expression(rhs)
+        if d_bits is None:
+            # RHS isn't a bare named value yet — we'd need primitive
+            # lowering to model it. Emit a $_UNKNOWN_ driver so the
+            # netlist isn't corrupt; the rule pack will treat the D
+            # input as opaque (no upstream flops trace through it).
+            d_bits = self._unknown_driver(width=len(q_bits))
+
+        connections: dict[str, tuple[Bit, ...]] = {
+            "CLK": self._alloc_bits(clk_sym),
+            "D": d_bits,
+            "Q": q_bits,
+        }
+        cell_type = "$dff"
+        if reset_sym is not None:
+            connections["ARST"] = self._alloc_bits(reset_sym)
+            cell_type = "$adff"
+        # Polarity parameter mirrors Yosys' parameter encoding so any
+        # rule that later inspects polarity has it available; the rule
+        # pack doesn't read these today but the contract is cheap to
+        # preserve.
+        parameters: dict[str, str] = {
+            "CLK_POLARITY": "1",
+        }
+        if reset_sym is not None:
+            parameters["ARST_POLARITY"] = "0" if reset_active_low else "1"
+        name = self._fresh_cell_name(cell_type)
+        self._cells[name] = Cell(
+            name=name,
+            type=cell_type,
+            connections=connections,
+            parameters=parameters,
+            attributes={},
+        )
+
+    def _bits_of_expression(self, expr: Any) -> tuple[Bit, ...] | None:
+        """Return the bit tuple for an RHS expression, or ``None`` if
+        the shape isn't supported yet.
+
+        Today we only handle a bare :class:`NamedValueExpression` —
+        that's enough for the direct flop→flop wire in
+        ``bad_single_ff_sync``. Anything else (binary ops, conditional
+        expr, concat, part-select, conversions) lands in the
+        primitive-lowering work item; the caller substitutes an
+        unknown driver in the meantime.
+        """
+        kind = type(expr).__name__
+        if kind == "NamedValueExpression":
+            return self._alloc_bits(expr.symbol)
+        # ConversionExpression often wraps integer-width adjustment
+        # without affecting bit identity for width-1 signals — peek
+        # through it.
+        if kind == "ConversionExpression":
+            inner = getattr(expr, "operand", None)
+            if inner is not None:
+                return self._bits_of_expression(inner)
+        return None
+
+    def _unknown_driver(self, width: int) -> tuple[Bit, ...]:
+        """Allocate a fresh net driven by a stub ``$_UNKNOWN_`` cell.
+
+        Used for RHS shapes the elaborator doesn't model yet. The
+        driver cell exists so the rule pack's driver lookup still
+        finds *something* — but with type ``$_UNKNOWN_`` it isn't
+        recognised as a comb primitive or a flop, so traversal stops
+        there. That's the conservative behaviour: we miss real
+        crossings rather than emit phantom ones.
+        """
+        bits: tuple[Bit, ...] = tuple(
+            range(self._next_bit_id, self._next_bit_id + width)
+        )
+        self._next_bit_id += width
+        name = self._fresh_cell_name("$_UNKNOWN_")
+        self._cells[name] = Cell(
+            name=name,
+            type="$_UNKNOWN_",
+            connections={"Y": bits},
+            parameters={},
+            attributes={},
+        )
+        return bits
+
+    # -- continuous assigns ---------------------------------------------
+
+    def _emit_continuous_assign(self, member: Any) -> None:
+        a = getattr(member, "assignment", None)
+        if a is None or type(a).__name__ != "AssignmentExpression":
+            return
+        lhs, rhs = a.left, a.right
+        if type(lhs).__name__ != "NamedValueExpression":
+            return
+        rhs_bits = self._bits_of_expression(rhs)
+        if rhs_bits is None:
+            # Comb-driven port — primitive lowering will handle this.
+            return
+        # Aliasing trick: rewrite the LHS variable's bits to point at
+        # the RHS's bits so any reader of the LHS sees the RHS source
+        # directly. This matches Yosys' post-opt_clean output for
+        # ``assign out = sig`` and means we don't need a $buf cell.
+        canonical = self._canonical_var(lhs.symbol)
+        existing = self._var_bits.get(canonical)
+        self._var_bits[canonical] = rhs_bits
+        # Update any Port that already pointed at the old bits.
+        if existing is not None:
+            self._rewrite_bits_in_ports(existing, rhs_bits)
+            self._rewrite_bits_in_netname(canonical, rhs_bits)
+
+    def _rewrite_bits_in_ports(
+        self, old: tuple[Bit, ...], new: tuple[Bit, ...]
+    ) -> None:
+        for name, port in list(self._ports.items()):
+            if port.bits == old:
+                self._ports[name] = Port(
+                    name=port.name, direction=port.direction, bits=new
+                )
+
+    def _rewrite_bits_in_netname(self, var_sym: Any, new: tuple[Bit, ...]) -> None:
+        nn = self._netnames.get(var_sym.name)
+        if nn is None:
+            return
+        self._netnames[var_sym.name] = Netname(
+            name=nn.name, bits=new, attributes=nn.attributes
+        )

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -3,13 +3,14 @@ Yosys-shape :class:`netlist.Module` consumable by the rule pack.
 
 Status
 ------
-**Stage 2 (first slice landed).** Single-module designs with direct
-register-to-register CDC paths, multi-bit declarations, async-reset
-flops, gray-coded bus crossings, and the ``(* cdc_sync *)`` /
-``(* cdc_gray *)`` attribute escape hatches reach parity with the
-Yosys frontend on their corresponding fixtures. Designs that need
-combinational primitive lowering (any non-trivial RHS) or
-cross-module flattening do not. See issue #5 for the broader plan.
+**Stage 2 (second slice).** Single-module designs reach parity with
+the Yosys frontend on 23 of 25 SDC-equipped fixtures, including the
+combinational shapes (CDC-003 / CDC-006) that the first slice could
+not detect. Remaining gaps are multi-bit LHS bit-selects
+(``q[0] <= ...``) and cross-module flattening; the two
+fixtures that exercise pre-synthesis Yosys primitives
+(``$_BUF_`` / ``$_NOT_``) are correctly rejected by slang as not
+being legal SV. See issue #5 for the broader plan.
 
 Rule parity matrix (today)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -21,12 +22,21 @@ fixture                             expected rules
 ==================================  =================
 bad_single_ff_sync                  CDC-001
 bad_port_no_sync                    CDC-001
+bad_comb_before_sync                CDC-003
 bad_bus_crossing                    CDC-004
 bad_reconvergent_sync               CDC-005
+bad_comb_source                     CDC-006
+bad_input_delay_cross_domain        CDC-006
 bad_reset_crossing                  CDC-007
 bad_clock_as_data                   CDC-008
 good_2ff_sync                       (none)
 good_gray_counter_crossing          (none)
+good_registered_before_sync         (none)
+good_registered_source              (none)
+good_exclusive_clock_mux            (none)
+good_false_path_pair                (none)
+good_generated_clock_div2           (none)
+good_port_typed_sync                (none)
 marked_user_sync                    (none — attribute suppression)
 ==================================  =================
 
@@ -53,29 +63,38 @@ What currently works
 
 What is NOT yet implemented (next slices)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- **Combinational primitive lowering.** RHS expressions that aren't a
-  bare ``NamedValueExpression`` (binary ops, conditionals, concats,
-  slices, conversions beyond identity) get a ``$_UNKNOWN_`` driver
-  cell that the rule pack treats as opaque. This is what's blocking
-  CDC-003 / CDC-006 parity (comb between flops or from a top-level
-  port). The work item is to map pyslang ``BinaryExpression`` /
-  ``ConditionalExpression`` / etc. to the Yosys cell zoo
-  (``$and``/``$or``/``$xor``/``$mux``/``$pmux``).
+- **Multi-bit LHS bit-selects.** ``q[0] <= ...`` and friends fall
+  out of the ``NamedValueExpression``-LHS check in
+  :meth:`_emit_assignment_expression` and are silently skipped. The
+  fix is to recognise :class:`ElementSelectExpression` /
+  :class:`RangeSelectExpression` on the LHS and emit a flop whose
+  ``Q`` connects to the matching subset of bits. Blocks
+  ``bad_reset_tree`` (4-bit reg with per-bit ``always_ff``).
 - **Multi-instance / cross-module flattening.** Only the top
   :class:`InstanceSymbol`'s direct body is walked. Child instances
   exist as opaque symbols; their contents don't contribute flops or
   comb. Designs that span modules need a recursive walker that emits
-  every leaf instance's flops into the same flat ``Module`` (matching
-  what Yosys ``flatten`` produces).
-- **``always_comb`` blocks** — like continuous assigns but with
-  procedural shape; needs primitive lowering to be useful.
+  every leaf instance's flops into the same flat ``Module`` (matches
+  what Yosys ``flatten`` produces). Blocks ``bad_source_sync_chain``
+  / ``good_source_sync_chain`` (4-module designs).
+- **Concat / part-select / replication on the RHS.** Today these
+  fall through :meth:`_bits_of_expression` and the caller emits a
+  ``$_UNKNOWN_`` placeholder driver. Real lowering needs
+  :class:`ConcatenationExpression` → bit-tuple concat,
+  :class:`RangeSelectExpression` → bit-tuple slice, and
+  :class:`ReplicationExpression` → repeated bits.
+- **``always_comb`` with ``if`` / ``case``.** Body walks descend into
+  both branches and may produce inconsistent aliasing when each
+  branch writes the same variable. The full lowering builds a
+  ``$mux`` per LHS that appears in both branches; today we
+  conservatively pass through whichever branch wrote last.
 - **Source locations** — :class:`Cell.attributes["src"]` is left
   empty, so JSON/SARIF reports lose their file:line context on the
   slang path. pyslang carries source ranges on every Symbol /
   Expression; threading those through is a follow-up.
-- **Width-N $dff / $adff parameters** (``WIDTH``, ``CLK_POLARITY``,
-  ``ARST_VALUE``) — partially populated today; not yet read by any
-  rule but should reach full Yosys parity for future rule extensions.
+- **Width-N $dff / $adff parameters** (``WIDTH``, ``ARST_VALUE``)
+  — partially populated today; not yet read by any rule but should
+  reach full Yosys parity for future rule extensions.
 - **Yosys-only constructs** (``$_BUF_`` / ``$_NOT_`` primitives in SV
   source) are correctly rejected by slang — they're post-synthesis
   cells, not legal SV. Fixtures that rely on them
@@ -341,9 +360,12 @@ class _ModuleBuilder:
     # -- always_ff lowering ----------------------------------------------
 
     def _emit_procedural_block(self, block: Any) -> None:
-        kind = block.procedureKind
-        if str(kind).rsplit(".", 1)[-1] != "AlwaysFF":
-            return  # always_comb / initial / always_latch — TODO
+        kind_name = str(block.procedureKind).rsplit(".", 1)[-1]
+        if kind_name == "AlwaysComb":
+            self._emit_always_comb(block)
+            return
+        if kind_name != "AlwaysFF":
+            return  # initial / always_latch / final — not modelled
         body = block.body
         # Expected shape: TimedStatement(timing=EventListControl, stmt=...)
         if self._kind_name(body) != "TimedStatement":
@@ -504,24 +526,200 @@ class _ModuleBuilder:
         """Return the bit tuple for an RHS expression, or ``None`` if
         the shape isn't supported yet.
 
-        Today we only handle a bare :class:`NamedValueExpression` —
-        that's enough for the direct flop→flop wire in
-        ``bad_single_ff_sync``. Anything else (binary ops, conditional
-        expr, concat, part-select, conversions) lands in the
-        primitive-lowering work item; the caller substitutes an
-        unknown driver in the meantime.
+        Handles the common cases:
+        - :class:`NamedValueExpression` — direct variable read.
+        - :class:`ConversionExpression` — pass through (pyslang inserts
+          these for implicit width / type unification; the underlying
+          bit identity is what we want).
+        - :class:`IntegerLiteral` — single-bit constants ``1'b0`` /
+          ``1'b1`` (the only widths we use in fixtures today).
+        - :class:`BinaryExpression` — lowered to a Yosys-shape comb
+          cell (``$and``/``$or``/``$xor``/…) via :meth:`_lower_binary`.
+        - :class:`UnaryExpression` — lowered to ``$not``/``$logic_not``/
+          ``$neg``/``$reduce_*`` via :meth:`_lower_unary`.
+        - :class:`ConditionalExpression` — lowered to a ``$mux`` cell.
+
+        Anything else (concat, part-select, function call, …) returns
+        ``None``; the caller substitutes an ``$_UNKNOWN_`` driver so
+        the rule pack treats the upstream as opaque rather than
+        crashing.
         """
         kind = type(expr).__name__
         if kind == "NamedValueExpression":
             return self._alloc_bits(expr.symbol)
-        # ConversionExpression often wraps integer-width adjustment
-        # without affecting bit identity for width-1 signals — peek
-        # through it.
         if kind == "ConversionExpression":
             inner = getattr(expr, "operand", None)
             if inner is not None:
                 return self._bits_of_expression(inner)
+        if kind == "IntegerLiteral":
+            return self._bits_of_integer_literal(expr)
+        if kind == "BinaryExpression":
+            return self._lower_binary(expr)
+        if kind == "UnaryExpression":
+            return self._lower_unary(expr)
+        if kind == "ConditionalExpression":
+            return self._lower_conditional(expr)
         return None
+
+    # --- expression lowering --------------------------------------------
+
+    # pyslang BinaryOperator → Yosys cell type. Where Yosys distinguishes
+    # bitwise (``$and``) from reduction-style logical (``$logic_and``),
+    # we follow the same split. Comparisons and arithmetic round-trip to
+    # the same Yosys op names the post-``proc`` netlist would carry.
+    _BINOP_CELL: dict[str, str] = {
+        "BinaryAnd": "$and",
+        "BinaryOr": "$or",
+        "BinaryXor": "$xor",
+        "BinaryXnor": "$xnor",
+        "LogicalAnd": "$logic_and",
+        "LogicalOr": "$logic_or",
+        "Equality": "$eq",
+        "Inequality": "$ne",
+        "CaseEquality": "$eqx",
+        "CaseInequality": "$nex",
+        "LessThan": "$lt",
+        "LessThanEqual": "$le",
+        "GreaterThan": "$gt",
+        "GreaterThanEqual": "$ge",
+        "Add": "$add",
+        "Subtract": "$sub",
+        "Multiply": "$mul",
+        "Divide": "$div",
+        "Mod": "$mod",
+        "LogicalShiftLeft": "$shl",
+        "LogicalShiftRight": "$shr",
+        "ArithmeticShiftLeft": "$sshl",
+        "ArithmeticShiftRight": "$sshr",
+    }
+
+    _UNOP_CELL: dict[str, str] = {
+        "BitwiseNot": "$not",
+        "LogicalNot": "$logic_not",
+        "Minus": "$neg",
+        # Reduction operators — these collapse a multi-bit operand to a
+        # single bit. ``Plus`` is identity and skipped at the call site.
+        "BitwiseAnd": "$reduce_and",
+        "BitwiseOr": "$reduce_or",
+        "BitwiseXor": "$reduce_xor",
+        "BitwiseNand": "$reduce_and",  # then invert; we don't model the
+        # inversion explicitly — the rule
+        # pack doesn't read the cell name
+        # beyond category membership.
+        "BitwiseNor": "$reduce_or",
+        "BitwiseXnor": "$reduce_xor",
+    }
+
+    def _lower_binary(self, expr: Any) -> tuple[Bit, ...] | None:
+        op_name = str(expr.op).rsplit(".", 1)[-1]
+        cell_type = self._BINOP_CELL.get(op_name)
+        if cell_type is None:
+            return None  # unmodelled op → unknown driver
+        a_bits = self._bits_of_expression(expr.left)
+        b_bits = self._bits_of_expression(expr.right)
+        if a_bits is None or b_bits is None:
+            return None
+        width = self._expr_width(expr)
+        return self._emit_comb_cell(
+            cell_type, {"A": a_bits, "B": b_bits}, output_width=width
+        )
+
+    def _lower_unary(self, expr: Any) -> tuple[Bit, ...] | None:
+        op_name = str(expr.op).rsplit(".", 1)[-1]
+        if op_name == "Plus":
+            # Unary plus is identity in SV — peek through.
+            return self._bits_of_expression(expr.operand)
+        cell_type = self._UNOP_CELL.get(op_name)
+        if cell_type is None:
+            return None
+        a_bits = self._bits_of_expression(expr.operand)
+        if a_bits is None:
+            return None
+        # Reduction operators produce a single bit regardless of input
+        # width; everything else preserves the operand width.
+        if cell_type.startswith("$reduce_") or cell_type == "$logic_not":
+            output_width = 1
+        else:
+            output_width = self._expr_width(expr) or len(a_bits)
+        return self._emit_comb_cell(cell_type, {"A": a_bits}, output_width=output_width)
+
+    def _lower_conditional(self, expr: Any) -> tuple[Bit, ...] | None:
+        # pyslang ConditionalExpression has ``conditions`` (a list) and
+        # ``left``/``right`` — the conditional-pattern grammar is more
+        # general than ``cond ? a : b``, but for our purposes we only
+        # need the single-condition shape.
+        conds = getattr(expr, "conditions", None)
+        if not conds:
+            return None
+        sel_bits = self._bits_of_expression(conds[0].expr)
+        a_bits = self._bits_of_expression(expr.left)
+        b_bits = self._bits_of_expression(expr.right)
+        if sel_bits is None or a_bits is None or b_bits is None:
+            return None
+        width = self._expr_width(expr) or max(len(a_bits), len(b_bits))
+        # Yosys ``$mux`` selects between A (sel=0) and B (sel=1); same
+        # convention we use here. The S pin takes the (single-bit)
+        # selector.
+        return self._emit_comb_cell(
+            cell_type="$mux",
+            inputs={"A": a_bits, "B": b_bits, "S": sel_bits[:1]},
+            output_width=width,
+        )
+
+    def _bits_of_integer_literal(self, expr: Any) -> tuple[Bit, ...] | None:
+        """Map an :class:`IntegerLiteral` to Yosys constant bits.
+
+        Yosys represents constant bits as the strings ``"0"``, ``"1"``,
+        ``"x"``, ``"z"``. The bit tuple is LSB-first to match Yosys
+        write_json ordering.
+        """
+        # pyslang exposes the value via ``expr.value`` as an SVInt.
+        # SVInt has a ``__int__`` for small concrete values; bigger
+        # ones we'd need to walk per-bit. For our fixtures the literals
+        # are 1-bit (``1'b0`` / ``1'b1``).
+        val = getattr(expr, "value", None)
+        if val is None:
+            return None
+        try:
+            as_int = int(val)
+        except (TypeError, ValueError):
+            return None
+        width = self._expr_width(expr) or 1
+        # LSB-first per Yosys convention.
+        return tuple("1" if (as_int >> i) & 1 else "0" for i in range(width))
+
+    def _expr_width(self, expr: Any) -> int:
+        t = getattr(expr, "type", None)
+        if t is None:
+            return 0
+        return int(getattr(t, "bitWidth", 0) or 0)
+
+    def _emit_comb_cell(
+        self,
+        cell_type: str,
+        inputs: dict[str, tuple[Bit, ...]],
+        output_width: int,
+    ) -> tuple[Bit, ...]:
+        """Allocate a fresh Y net and emit a ``cell_type`` cell with the
+        given inputs. Returns the Y bits so callers can wire them up.
+
+        Width defensively clamped to at least 1 so we never emit a
+        zero-width cell (which would confuse the rule pack's bit walks).
+        """
+        width = max(int(output_width or 1), 1)
+        y_bits: tuple[Bit, ...] = tuple(
+            range(self._next_bit_id, self._next_bit_id + width)
+        )
+        self._next_bit_id += width
+        name = self._fresh_cell_name(cell_type)
+        self._cells[name] = Cell(
+            name=name,
+            type=cell_type,
+            connections={**inputs, "Y": y_bits},
+            parameters={},
+            attributes={},
+        )
+        return y_bits
 
     def _unknown_driver(self, width: int) -> tuple[Bit, ...]:
         """Allocate a fresh net driven by a stub ``$_UNKNOWN_`` cell.
@@ -546,6 +744,66 @@ class _ModuleBuilder:
             attributes={},
         )
         return bits
+
+    # -- always_comb ----------------------------------------------------
+
+    def _emit_always_comb(self, block: Any) -> None:
+        """Treat each blocking assignment in an ``always_comb`` block as
+        a continuous assign of its RHS to its LHS.
+
+        SV semantics already require an ``always_comb`` to be
+        combinational, so the rewrite is semantically faithful (no
+        priority encoding or latching to model). We descend through
+        the typical ``BlockStatement(body=ExpressionStatement(...))``
+        wrapper plus optional ``ListStatement`` for multi-assign
+        bodies.
+        """
+        self._walk_comb_statement(block.body)
+
+    def _walk_comb_statement(self, stmt: Any) -> None:
+        kind = self._kind_name(stmt)
+        if kind == "BlockStatement":
+            self._walk_comb_statement(stmt.body)
+            return
+        if kind in {"StatementList", "ListStatement"}:
+            for s in getattr(stmt, "list", []) or []:
+                self._walk_comb_statement(s)
+            return
+        if kind == "ExpressionStatement":
+            self._alias_assign(stmt.expr)
+            return
+        if kind == "ConditionalStatement":
+            # if/else in an always_comb is a selection between two
+            # assignments. The full lowering would build a $mux per LHS
+            # variable that appears in both branches; that's a follow-up
+            # — for now we descend into both branches so any unconditional
+            # writes get aliased and any conditional-only writes are
+            # missed (conservative).
+            self._walk_comb_statement(stmt.ifTrue)
+            if stmt.ifFalse is not None:
+                self._walk_comb_statement(stmt.ifFalse)
+            return
+        # case statements, for/while loops, etc. → ignore for now.
+
+    def _alias_assign(self, expr: Any) -> None:
+        """For a blocking assignment ``lhs = rhs``, rewrite ``lhs``'s
+        bits to point at ``rhs``'s lowered bits — same aliasing trick
+        the continuous-assign path uses."""
+        if type(expr).__name__ != "AssignmentExpression":
+            return
+        if getattr(expr, "isNonBlocking", False):
+            return  # nonblocking in always_comb is a SV style violation
+        if type(expr.left).__name__ != "NamedValueExpression":
+            return
+        rhs_bits = self._bits_of_expression(expr.right)
+        if rhs_bits is None:
+            return
+        canonical = self._canonical_var(expr.left.symbol)
+        existing = self._var_bits.get(canonical)
+        self._var_bits[canonical] = rhs_bits
+        if existing is not None:
+            self._rewrite_bits_in_ports(existing, rhs_bits)
+            self._rewrite_bits_in_netname(canonical, rhs_bits)
 
     # -- continuous assigns ---------------------------------------------
 

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -3,14 +3,14 @@ Yosys-shape :class:`netlist.Module` consumable by the rule pack.
 
 Status
 ------
-**Stage 2 (third slice).** Single-module designs reach parity with
-the Yosys frontend on 24 of 25 SDC-equipped fixtures, including the
-combinational shapes (CDC-003 / CDC-006) and multi-bit LHS
-bit-selects (``q[0] <= ...``). The only remaining gap is cross-
-module flattening (``bad_source_sync_chain`` is a 4-module design);
-the two fixtures that exercise pre-synthesis Yosys primitives
-(``$_BUF_`` / ``$_NOT_``) are correctly rejected by slang as not
-being legal SV. See issue #5 for the broader plan.
+**Stage 2 (fourth slice — full fixture parity).** All 25
+SDC-equipped fixtures reach parity with the Yosys frontend,
+covering register-to-register CDC, combinational shapes,
+multi-bit LHS bit-selects, and now multi-module hierarchies.
+The two ``*_source_sync_internal`` fixtures that embed Yosys-
+internal ``$_BUF_`` primitives in SV source are correctly
+rejected by slang as not being legal SystemVerilog and stay
+Yosys-frontend-only by design.
 
 Rule parity matrix (today)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -30,6 +30,7 @@ bad_input_delay_cross_domain        CDC-006
 bad_reset_crossing                  CDC-007
 bad_reset_tree                      CDC-007 (grouped)
 bad_clock_as_data                   CDC-008
+bad_source_sync_chain               CDC-001 × 4 (4-module hierarchy)
 good_2ff_sync                       (none)
 good_gray_counter_crossing          (none)
 good_registered_before_sync         (none)
@@ -57,20 +58,32 @@ What currently works
   emit ``$adff`` cells with ``CLK``/``D``/``Q``/``ARST`` connections.
   Plain ``always_ff @(posedge clk) q <= d;`` emits ``$dff``.
 - Direct ``port = var`` continuous assigns are aliased into the
-  source variable's bits (matches Yosys post-``opt_clean``).
+  source variable's bits (matches Yosys post-``opt_clean``). The
+  aliasing is propagated globally: every entry in the bit-id maps
+  that holds the old tuple is rewritten, so chains across the
+  hierarchy boundary (parent ``a_q`` ← child ``q``) collapse to a
+  single net rather than leaving stale aliases.
+- Multi-module hierarchies — child :class:`InstanceSymbol`s are
+  walked recursively; their flops, comb cells, and netnames land
+  in the same flat ``Module`` with dotted prefixes (``u_b0.q``,
+  ``u_b0.$slang$adff$3``) matching Yosys-flatten output. Port
+  connections are the wiring step: each child internal variable
+  backing a port is aliased to the parent's connection expression
+  bits, so flop A's Q in one instance and flop B's D in the next
+  resolve to the same net.
+- Combinational primitive lowering: see :meth:`_lower_binary`
+  / :meth:`_lower_unary` / :meth:`_lower_conditional`. Pyslang
+  expression operators round-trip to the Yosys cell zoo
+  (``$and``/``$or``/``$xor``/``$mux``/…), so the rule pack walks
+  the comb cone correctly.
+- LHS bit-selects (``q[0] <= ...``) and contiguous ranges
+  (``bus[3:0] <= ...``) — see :meth:`_lvalue_bits`.
 - Fatal pyslang diagnostics are surfaced through
   ``TextDiagnosticClient`` with file:line:col + caret summaries —
   the usual compiler-error format users already recognise.
 
 What is NOT yet implemented (next slices)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- **Multi-instance / cross-module flattening.** Only the top
-  :class:`InstanceSymbol`'s direct body is walked. Child instances
-  exist as opaque symbols; their contents don't contribute flops or
-  comb. Designs that span modules need a recursive walker that emits
-  every leaf instance's flops into the same flat ``Module`` (matches
-  what Yosys ``flatten`` produces). Blocks ``bad_source_sync_chain``
-  / ``good_source_sync_chain`` (4-module designs).
 - **Concat / part-select / replication on the RHS.** Today these
   fall through :meth:`_bits_of_expression` and the caller emits a
   ``$_UNKNOWN_`` placeholder driver. Real lowering needs
@@ -207,24 +220,60 @@ class _ModuleBuilder:
         self._cells: dict[str, Cell] = {}
         self._netnames: dict[str, Netname] = {}
         self._cell_counters: dict[str, int] = {}
+        # Stack of dotted hierarchy prefixes used by ``_fresh_cell_name``
+        # so cells emitted while walking a child instance carry the
+        # ``u_child.`` prefix matching Yosys-flatten output. ``""`` at
+        # the top level. Push/pop bracket each ``_walk_instance`` call.
+        self._hier_stack: list[str] = [""]
 
     # -- public ----------------------------------------------------------
 
     def build(self) -> Module:
-        # Order matters: variables get IDs first so flops/assigns can
-        # reference them without ambiguity.
-        for member in self.top.body:
-            self._collect_variable(member)
-        for member in self.top.body:
-            self._collect_port(member)
-        for member in self.top.body:
-            self._emit_for_member(member)
+        # The top instance's ports become the flat ``Module``'s ports;
+        # child instances contribute flops / comb / netnames into the
+        # same flat namespace, hierarchically prefixed (``u_b0.q``).
+        self._walk_instance(self.top, hier_prefix="", bound_internals=frozenset())
         return Module(
             name=self.top.name,
             ports=self._ports,
             cells=self._cells,
             netnames=self._netnames,
         )
+
+    def _walk_instance(
+        self,
+        inst: Any,
+        hier_prefix: str,
+        bound_internals: frozenset[Any],
+    ) -> None:
+        """Walk an :class:`InstanceSymbol`'s body in three passes —
+        variables, ports (top only), then cells / continuous assigns /
+        child instances.
+
+        ``hier_prefix`` is the dotted instance path (``""`` at the top,
+        ``"u_a."`` one level in, ``"u_top.u_a."`` two levels) used to
+        namespace netname keys and emitted cell names. ``bound_internals``
+        is the set of port-internal variables this instance has already
+        had its bits aliased to a parent expression — they get skipped
+        in pass 1 so we don't allocate fresh bits for them.
+        """
+        self._hier_stack.append(hier_prefix)
+        try:
+            for member in inst.body:
+                if (
+                    self._kind_name(member) == "VariableSymbol"
+                    and member not in bound_internals
+                ):
+                    self._collect_variable(member, hier_prefix)
+            # Only the top module exposes ports in the flat ``Module``;
+            # child ports get folded into their parents' connections.
+            if hier_prefix == "":
+                for member in inst.body:
+                    self._collect_port(member)
+            for member in inst.body:
+                self._emit_for_member(member, hier_prefix)
+        finally:
+            self._hier_stack.pop()
 
     # -- helpers ---------------------------------------------------------
 
@@ -276,10 +325,14 @@ class _ModuleBuilder:
     def _fresh_cell_name(self, type_str: str) -> str:
         # Yosys autogen names look like "$procdff$3" — we don't need
         # bit-exact parity, but a stable prefix-and-counter keeps
-        # waiver regexes that target the cell name readable.
+        # waiver regexes that target the cell name readable. The
+        # current hierarchy prefix (e.g. ``u_b0.``) matches what
+        # Yosys ``flatten`` would produce for cells inside a child
+        # instance.
         n = self._cell_counters.get(type_str, 0) + 1
         self._cell_counters[type_str] = n
-        return f"$slang${type_str.strip('$')}${n}"
+        prefix = self._hier_stack[-1] if self._hier_stack else ""
+        return f"{prefix}$slang${type_str.strip('$')}${n}"
 
     def _kind_name(self, sym: Any) -> str:
         """Class-name shortcut. pyslang exposes ``__class__.__name__``
@@ -289,7 +342,7 @@ class _ModuleBuilder:
 
     # -- pass 1: variables ----------------------------------------------
 
-    def _collect_variable(self, member: Any) -> None:
+    def _collect_variable(self, member: Any, hier_prefix: str = "") -> None:
         if self._kind_name(member) != "VariableSymbol":
             return
         bits = self._alloc_bits(member)
@@ -307,13 +360,13 @@ class _ModuleBuilder:
                 continue
             val = getattr(attr, "value", None)
             attrs[name] = str(val) if val is not None else "1"
-        # Skip if a netname with this name already exists (e.g. a port
-        # shares the name with its internal variable). Ports take
-        # precedence in the port table; the variable still owns the
-        # netname so attributes attached to the wire/reg survive.
-        self._netnames[member.name] = Netname(
-            name=member.name, bits=bits, attributes=attrs
-        )
+        # Hierarchical name matches Yosys-flatten output: ``u_b0.q``,
+        # ``u_top.u_b0.q``, etc. At the top level ``hier_prefix`` is
+        # empty so the bare name is used. The rule pack consults
+        # netname attributes via the bits→netname reverse-lookup, so
+        # the name is only consulted for debug / source-location use.
+        full_name = f"{hier_prefix}{member.name}"
+        self._netnames[full_name] = Netname(name=full_name, bits=bits, attributes=attrs)
 
     # -- pass 2: ports ---------------------------------------------------
 
@@ -339,21 +392,82 @@ class _ModuleBuilder:
 
     # -- pass 3: cells + continuous assigns -----------------------------
 
-    def _emit_for_member(self, member: Any) -> None:
+    def _emit_for_member(self, member: Any, hier_prefix: str = "") -> None:
         kind = self._kind_name(member)
         if kind == "ProceduralBlockSymbol":
-            self._emit_procedural_block(member)
+            self._emit_procedural_block(member, hier_prefix)
         elif kind == "ContinuousAssignSymbol":
             self._emit_continuous_assign(member)
-        # InstanceSymbol (child instances), GenerateBlockSymbol, etc.
-        # are deliberately ignored in this slice — the roadmap covers
-        # them. Silently skipping is preferable to crashing; the lack
-        # of flops in the resulting module will be visible in `analyze`
-        # output and surfaces the gap loudly to anyone running it.
+        elif kind == "InstanceSymbol":
+            self._emit_child_instance(member, hier_prefix)
+        # GenerateBlockSymbol and other unmodelled kinds fall through
+        # silently — the lack of expected flops will be visible in
+        # `analyze` output, which is a better failure mode than
+        # crashing on an unrecognised member kind.
+
+    def _emit_child_instance(self, child: Any, parent_prefix: str) -> None:
+        """Inline a child instance's body into the flat ``Module``.
+
+        Port connections are the load-bearing wiring step: the child's
+        internal variables backing each port get their bits aliased to
+        the parent's connection expression so net identity is preserved
+        across the hierarchy boundary. After that, the child body is
+        walked exactly like the top.
+        """
+        bound: set[Any] = set()
+        for pc in getattr(child, "portConnections", []) or []:
+            port = pc.port
+            internal = getattr(port, "internalSymbol", None)
+            if internal is None:
+                continue
+            parent_bits = self._port_connection_bits(pc)
+            if parent_bits is None:
+                continue
+            # Alias the child's internal-variable bits to the parent's
+            # wire. ``_alloc_bits`` keys on the internal Symbol identity
+            # which is unique per elaborated instance, so two
+            # instantiations of the same module don't share bits.
+            self._var_bits[self._canonical_var(internal)] = parent_bits
+            bound.add(internal)
+
+        child_prefix = f"{parent_prefix}{child.name}."
+        self._walk_instance(
+            child, hier_prefix=child_prefix, bound_internals=frozenset(bound)
+        )
+
+    def _port_connection_bits(self, pc: Any) -> tuple[Bit, ...] | None:
+        """Resolve a :class:`PortConnection` to the parent-side bits.
+
+        Three shapes appear in practice:
+        - **Input port**: ``pc.expression`` is the parent-side driver
+          expression (typically a :class:`NamedValueExpression`).
+          Just lower it.
+        - **Output port**: ``pc.expression`` is an
+          :class:`AssignmentExpression` whose ``.left`` is the
+          parent's capturing variable. ``.right`` is an
+          :class:`EmptyArgumentExpression` placeholder. Use the LHS.
+        - **Unconnected port**: ``pc.expression`` is None — nothing
+          to alias to. Return None so the child's internal allocates
+          its own fresh bits.
+        """
+        ex = pc.expression
+        if ex is None:
+            return None
+        kind = type(ex).__name__
+        if kind == "AssignmentExpression":
+            return self._lvalue_bits(ex.left)
+        if kind == "EmptyArgumentExpression":
+            return None
+        return self._bits_of_expression(ex)
 
     # -- always_ff lowering ----------------------------------------------
 
-    def _emit_procedural_block(self, block: Any) -> None:
+    def _emit_procedural_block(self, block: Any, hier_prefix: str = "") -> None:
+        # hier_prefix is read indirectly through ``_hier_stack`` which
+        # the walker keeps in sync via the ``_walk_instance`` push/pop;
+        # accept it on the signature for symmetry with the other
+        # ``_emit_*`` callbacks.
+        del hier_prefix
         kind_name = str(block.procedureKind).rsplit(".", 1)[-1]
         if kind_name == "AlwaysComb":
             self._emit_always_comb(block)
@@ -870,12 +984,7 @@ class _ModuleBuilder:
         rhs_bits = self._bits_of_expression(expr.right)
         if rhs_bits is None:
             return
-        canonical = self._canonical_var(expr.left.symbol)
-        existing = self._var_bits.get(canonical)
-        self._var_bits[canonical] = rhs_bits
-        if existing is not None:
-            self._rewrite_bits_in_ports(existing, rhs_bits)
-            self._rewrite_bits_in_netname(canonical, rhs_bits)
+        self._rewrite_aliased(expr.left, rhs_bits)
 
     # -- continuous assigns ---------------------------------------------
 
@@ -894,27 +1003,40 @@ class _ModuleBuilder:
         # the RHS's bits so any reader of the LHS sees the RHS source
         # directly. This matches Yosys' post-opt_clean output for
         # ``assign out = sig`` and means we don't need a $buf cell.
+        self._rewrite_aliased(lhs, rhs_bits)
+
+    def _rewrite_aliased(self, lhs: Any, rhs_bits: tuple[Bit, ...]) -> None:
+        """Make every alias that currently holds ``lhs``'s bits point at
+        ``rhs_bits`` instead.
+
+        Crossing the hierarchy boundary, a single net (the parent's
+        ``a_q`` wire, say) is represented by several aliased entries:
+        the parent's :class:`VariableSymbol`, the child instance's
+        :class:`PortSymbol`-internal variable, and any local wires
+        that capture it. When ``assign a_q = q`` runs inside the child,
+        every one of those aliases needs to follow — not just the
+        child's own a_q entry — or the parent's reader sees stale bits.
+
+        We do the cheap thing: scan ``_var_bits`` / ``_ports`` /
+        ``_netnames`` for entries whose bits equal the old tuple and
+        rewrite them. O(n) per assign, fine for the design sizes the
+        analyzer targets.
+        """
         canonical = self._canonical_var(lhs.symbol)
-        existing = self._var_bits.get(canonical)
+        old_bits = self._var_bits.get(canonical)
         self._var_bits[canonical] = rhs_bits
-        # Update any Port that already pointed at the old bits.
-        if existing is not None:
-            self._rewrite_bits_in_ports(existing, rhs_bits)
-            self._rewrite_bits_in_netname(canonical, rhs_bits)
-
-    def _rewrite_bits_in_ports(
-        self, old: tuple[Bit, ...], new: tuple[Bit, ...]
-    ) -> None:
-        for name, port in list(self._ports.items()):
-            if port.bits == old:
-                self._ports[name] = Port(
-                    name=port.name, direction=port.direction, bits=new
-                )
-
-    def _rewrite_bits_in_netname(self, var_sym: Any, new: tuple[Bit, ...]) -> None:
-        nn = self._netnames.get(var_sym.name)
-        if nn is None:
+        if old_bits is None or old_bits == rhs_bits:
             return
-        self._netnames[var_sym.name] = Netname(
-            name=nn.name, bits=new, attributes=nn.attributes
-        )
+        for sym, bits in list(self._var_bits.items()):
+            if bits == old_bits:
+                self._var_bits[sym] = rhs_bits
+        for name, port in list(self._ports.items()):
+            if port.bits == old_bits:
+                self._ports[name] = Port(
+                    name=port.name, direction=port.direction, bits=rhs_bits
+                )
+        for name, nn in list(self._netnames.items()):
+            if nn.bits == old_bits:
+                self._netnames[name] = Netname(
+                    name=nn.name, bits=rhs_bits, attributes=nn.attributes
+                )

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -3,12 +3,12 @@ Yosys-shape :class:`netlist.Module` consumable by the rule pack.
 
 Status
 ------
-**Stage 2 (second slice).** Single-module designs reach parity with
-the Yosys frontend on 23 of 25 SDC-equipped fixtures, including the
-combinational shapes (CDC-003 / CDC-006) that the first slice could
-not detect. Remaining gaps are multi-bit LHS bit-selects
-(``q[0] <= ...``) and cross-module flattening; the two
-fixtures that exercise pre-synthesis Yosys primitives
+**Stage 2 (third slice).** Single-module designs reach parity with
+the Yosys frontend on 24 of 25 SDC-equipped fixtures, including the
+combinational shapes (CDC-003 / CDC-006) and multi-bit LHS
+bit-selects (``q[0] <= ...``). The only remaining gap is cross-
+module flattening (``bad_source_sync_chain`` is a 4-module design);
+the two fixtures that exercise pre-synthesis Yosys primitives
 (``$_BUF_`` / ``$_NOT_``) are correctly rejected by slang as not
 being legal SV. See issue #5 for the broader plan.
 
@@ -28,6 +28,7 @@ bad_reconvergent_sync               CDC-005
 bad_comb_source                     CDC-006
 bad_input_delay_cross_domain        CDC-006
 bad_reset_crossing                  CDC-007
+bad_reset_tree                      CDC-007 (grouped)
 bad_clock_as_data                   CDC-008
 good_2ff_sync                       (none)
 good_gray_counter_crossing          (none)
@@ -63,13 +64,6 @@ What currently works
 
 What is NOT yet implemented (next slices)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- **Multi-bit LHS bit-selects.** ``q[0] <= ...`` and friends fall
-  out of the ``NamedValueExpression``-LHS check in
-  :meth:`_emit_assignment_expression` and are silently skipped. The
-  fix is to recognise :class:`ElementSelectExpression` /
-  :class:`RangeSelectExpression` on the LHS and emit a flop whose
-  ``Q`` connects to the matching subset of bits. Blocks
-  ``bad_reset_tree`` (4-bit reg with per-bit ``always_ff``).
 - **Multi-instance / cross-module flattening.** Only the top
   :class:`InstanceSymbol`'s direct body is walked. Child instances
   exist as opaque symbols; their contents don't contribute flops or
@@ -480,13 +474,14 @@ class _ModuleBuilder:
             return
         lhs = expr.left
         rhs = expr.right
-        # We need a bare register reference on the LHS so we know which
-        # variable's bits become Q. Anything more complex (slice, part-
-        # select, struct member) → skip for now.
-        if type(lhs).__name__ != "NamedValueExpression":
+        # Resolve the LHS to the subset of a variable's bits that the
+        # flop's Q should drive. Supports bare ``NamedValueExpression``
+        # (full width), ``ElementSelectExpression`` (single bit), and
+        # ``RangeSelectExpression`` (a contiguous range). Other LHS
+        # shapes (struct member, hierarchical reference, …) are skipped.
+        q_bits = self._lvalue_bits(lhs)
+        if q_bits is None:
             return
-        q_var = lhs.symbol
-        q_bits = self._alloc_bits(q_var)
         d_bits = self._bits_of_expression(rhs)
         if d_bits is None:
             # RHS isn't a bare named value yet — we'd need primitive
@@ -521,6 +516,79 @@ class _ModuleBuilder:
             parameters=parameters,
             attributes={},
         )
+
+    def _lvalue_bits(self, expr: Any) -> tuple[Bit, ...] | None:
+        """Resolve an LHS expression to the variable-bit subset it
+        writes."""
+        kind = type(expr).__name__
+        if kind == "NamedValueExpression":
+            return self._alloc_bits(expr.symbol)
+        if kind == "ElementSelectExpression":
+            return self._element_select_bits(expr)
+        if kind == "RangeSelectExpression":
+            return self._range_select_bits(expr)
+        return None
+
+    def _element_select_bits(self, expr: Any) -> tuple[Bit, ...] | None:
+        """``var[i]`` — return the single-bit subset of ``var``'s bits.
+
+        Falls back to ``None`` when the underlying value isn't a bare
+        named variable (e.g. nested selects, slices of expressions),
+        and when the selector isn't a constant integer — dynamic
+        indexing would require muxing across all possible bits, which
+        no rule today is worth.
+        """
+        inner = expr.value
+        if type(inner).__name__ != "NamedValueExpression":
+            return None
+        idx = self._const_int(getattr(expr, "selector", None))
+        if idx is None:
+            return None
+        var_bits = self._alloc_bits(inner.symbol)
+        if not (0 <= idx < len(var_bits)):
+            return None
+        return (var_bits[idx],)
+
+    def _range_select_bits(self, expr: Any) -> tuple[Bit, ...] | None:
+        """``var[hi:lo]`` — return the contiguous bit subset.
+
+        Yosys stores bits LSB-first, so ``var[3:0]`` returns
+        ``var_bits[0:4]``. Non-constant ranges and indexed parts
+        (``var[i+:N]``) return ``None``.
+        """
+        inner = expr.value
+        if type(inner).__name__ != "NamedValueExpression":
+            return None
+        left = self._const_int(getattr(expr, "left", None))
+        right = self._const_int(getattr(expr, "right", None))
+        if left is None or right is None:
+            return None
+        lo, hi = min(left, right), max(left, right)
+        var_bits = self._alloc_bits(inner.symbol)
+        if lo < 0 or hi >= len(var_bits):
+            return None
+        return tuple(var_bits[lo : hi + 1])
+
+    @staticmethod
+    def _const_int(expr: Any) -> int | None:
+        """Best-effort: extract an ``int`` from a constant pyslang
+        expression. Returns ``None`` if the expression isn't a
+        compile-time constant — selectors on the LHS need to be
+        static for the flop-shape model to work."""
+        if expr is None:
+            return None
+        # pyslang exposes ``.constant`` (an SVInt) on most expressions
+        # once compilation has folded the operand; an IntegerLiteral
+        # additionally has ``.value``.
+        for attr in ("constant", "value"):
+            v = getattr(expr, attr, None)
+            if v is None:
+                continue
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                continue
+        return None
 
     def _bits_of_expression(self, expr: Any) -> tuple[Bit, ...] | None:
         """Return the bit tuple for an RHS expression, or ``None`` if
@@ -559,6 +627,10 @@ class _ModuleBuilder:
             return self._lower_unary(expr)
         if kind == "ConditionalExpression":
             return self._lower_conditional(expr)
+        if kind == "ElementSelectExpression":
+            return self._element_select_bits(expr)
+        if kind == "RangeSelectExpression":
+            return self._range_select_bits(expr)
         return None
 
     # --- expression lowering --------------------------------------------

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -86,20 +86,6 @@ def test_cli_lint_slang_frontend_errors_cleanly_when_missing() -> None:
     assert "rtl-buddy-cdc[slang]" in result.output
 
 
-@pytest.mark.skipif(
-    not PYSLANG_INSTALLED,
-    reason="pyslang not installed — stub-raises-NotImplemented path needs it",
-)
-def test_slang_frontend_stub_raises_not_implemented() -> None:
-    """When pyslang IS installed, the slang frontend should still raise
-    :class:`NotImplementedError` (the elaboration is unimplemented),
-    not silently succeed or hide behind the install-hint path."""
-    with pytest.raises(
-        NotImplementedError, match="slang frontend is a work in progress"
-    ):
-        elaborate([Path("x.sv")], "top", frontend=Frontend.slang)
-
-
 YOSYS = shutil.which("yosys")
 
 

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -102,6 +102,42 @@ def test_cdc_004_silent_on_good_gray_counter_crossing() -> None:
     assert _run("good_gray_counter_crossing") == []
 
 
+# --- Combinational lowering parity (Stage 2.2) -----------------------------
+
+
+def test_cdc_003_fires_on_bad_comb_before_sync() -> None:
+    """Comb logic (`src_q1 & src_q2`) feeding the synchronizer's first
+    stage. Exercises the BinaryExpression → ``$and`` lowering; without
+    it the comb output is opaque and CDC-003 cannot see the source
+    flops."""
+    assert _run("bad_comb_before_sync") == ["CDC-003"]
+
+
+def test_cdc_006_fires_on_bad_comb_source() -> None:
+    """Synchronizer fed directly by comb of top-level inputs
+    (``a & b``) with no registering flop. Confirms the lowering also
+    works inside an ``always_ff`` body's D-side expression."""
+    assert _run("bad_comb_source") == ["CDC-006"]
+
+
+def test_cdc_006_fires_on_bad_input_delay_cross_domain() -> None:
+    """Input delay typed to a different clock domain than the flop's
+    own — port-sourced CDC-006 path through the comb cone."""
+    assert _run("bad_input_delay_cross_domain") == ["CDC-006"]
+
+
+def test_paired_positives_stay_silent() -> None:
+    """The good_* counterparts to the bad_* cases above. Together with
+    the bad_* tests these confirm the comb lowering doesn't introduce
+    false positives — the rule pack only fires where it should."""
+    assert _run("good_registered_before_sync") == []
+    assert _run("good_registered_source") == []
+    assert _run("good_exclusive_clock_mux") == []
+    assert _run("good_false_path_pair") == []
+    assert _run("good_generated_clock_div2") == []
+    assert _run("good_port_typed_sync") == []
+
+
 # --- SV-attribute pass-through ---------------------------------------------
 
 

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -126,6 +126,35 @@ def test_cdc_006_fires_on_bad_input_delay_cross_domain() -> None:
     assert _run("bad_input_delay_cross_domain") == ["CDC-006"]
 
 
+def test_cdc_001_fires_on_4_module_hierarchy() -> None:
+    """bad_source_sync_chain — 4-module design with a source-sync
+    topology (A → B0/B1 → C0/C1) and a deliberately-broken SDC that
+    groups every clock asynchronous. The recursive instance walker
+    must flatten 5 child instances into one ``Module`` and preserve
+    net identity across each port boundary (so flop A's Q is also
+    flop B0's D); otherwise CDC-001 doesn't see the crossings."""
+    rules = _run("bad_source_sync_chain")
+    assert rules == ["CDC-001"]
+
+
+def test_hierarchical_module_cell_names_use_dotted_prefix() -> None:
+    """Cells emitted from a child instance should carry the dotted
+    instance path so they're distinguishable in waiver regexes and
+    diagnostic output (matches Yosys-flatten convention)."""
+    fix = FIX / "bad_source_sync_chain"
+    module = elaborate(
+        sorted(fix.glob("*.sv")),
+        "bad_source_sync_chain",
+        frontend=Frontend.slang,
+    )
+    flop_names = sorted(
+        c.name for c in module.cells.values() if c.type in {"$dff", "$adff"}
+    )
+    assert any(n.startswith("u_a.") for n in flop_names)
+    assert any(n.startswith("u_b0.") for n in flop_names)
+    assert any(n.startswith("u_c1.") for n in flop_names)
+
+
 def test_cdc_007_groups_reset_tree_violations() -> None:
     """4-bit register written per-bit by 4 ``always_ff`` blocks, all
     using a foreign-domain flop as ``ARST``. Exercises the

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -126,6 +126,33 @@ def test_cdc_006_fires_on_bad_input_delay_cross_domain() -> None:
     assert _run("bad_input_delay_cross_domain") == ["CDC-006"]
 
 
+def test_cdc_007_groups_reset_tree_violations() -> None:
+    """4-bit register written per-bit by 4 ``always_ff`` blocks, all
+    using a foreign-domain flop as ``ARST``. Exercises the
+    ElementSelect-LHS path (``dst_q[0] <= ...``) — each block emits
+    a separate ``$adff`` whose ``Q`` ties to one bit of the shared
+    register. CDC-007's reset-tree grouping collapses the four
+    crossings to a single violation."""
+    fixture = "bad_reset_tree"
+    assert _run(fixture) == ["CDC-007"]
+    # Sanity-check the module shape — five flops total (one source,
+    # four destinations) and the four destinations share the same
+    # ARST bit.
+    d = FIX / fixture
+    module = elaborate(
+        sorted(d.glob("*.sv")),
+        fixture,
+        frontend=Frontend.slang,
+    )
+    ffs = [c for c in module.cells.values() if c.type in {"$dff", "$adff"}]
+    assert len(ffs) == 5
+    arst_bits = [c.connections["ARST"] for c in ffs if "ARST" in c.connections]
+    # Source flop has its own ARST (a port); the four destinations
+    # share a common ARST bit from the source flop's Q.
+    dst_arsts = [a for a in arst_bits if len({a}) == 1]
+    assert len(set(dst_arsts)) >= 1
+
+
 def test_paired_positives_stay_silent() -> None:
     """The good_* counterparts to the bad_* cases above. Together with
     the bad_* tests these confirm the comb lowering doesn't introduce

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -1,0 +1,168 @@
+"""Slang-frontend elaboration tests (Stage 2 of issue #5).
+
+These exercise the pyslang-backed :func:`elaborate` against real
+fixtures and confirm that the rule pack — unchanged — produces the
+expected violation set when fed slang-elaborated modules. The tests
+mirror the small subset of fixtures the slang frontend reaches parity
+on today; broader coverage waits on the comb-primitive-lowering and
+hierarchy-flattening work items.
+
+Tests skip when pyslang isn't installed; the install-hint path is
+already covered in :mod:`test_frontend`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.cli import _filter_async
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.rules import run_all
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang elaboration tests are gated on it",
+        allow_module_level=True,
+    )
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+def _run(fixture: str, sv_files: list[str] | None = None) -> list[str]:
+    """Elaborate one fixture via slang, run the rule pack against it,
+    and return the sorted list of rule IDs that fired. Helper keeps
+    each test a one-liner."""
+    d = FIX / fixture
+    svs = [d / s for s in sv_files] if sv_files else sorted(d.glob("*.sv"))
+    sdcs = sorted(d.glob("*.sdc"))
+    module = elaborate(svs, fixture, frontend=Frontend.slang)
+    if not sdcs:
+        return []
+    spec = sdc_mod.parse_file(sdcs[0])
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    async_c = _filter_async(crossings, spec)
+    violations = run_all(module, async_c, spec)
+    return sorted({v.rule_id for v in violations})
+
+
+# --- Parity confirmations (positive: rule fires correctly) -----------------
+
+
+def test_cdc_001_fires_on_bad_single_ff_sync() -> None:
+    """The simplest CDC-001 shape — direct flop→flop wire across
+    domains. Stage 2's headline target."""
+    assert _run("bad_single_ff_sync") == ["CDC-001"]
+
+
+def test_cdc_001_silent_on_good_2ff_sync() -> None:
+    """Paired positive case — the 2FF synchronizer is correct, no
+    rule should fire."""
+    assert _run("good_2ff_sync") == []
+
+
+def test_cdc_001_fires_on_bad_port_no_sync() -> None:
+    """Port-sourced CDC-001 (typed via ``set_input_delay`` in the
+    SDC). Confirms the port-side crossing path lights up too, not
+    just flop-to-flop."""
+    assert _run("bad_port_no_sync") == ["CDC-001"]
+
+
+def test_cdc_004_fires_on_bad_bus_crossing() -> None:
+    """Multi-bit bus crossing without gating or gray-coding."""
+    assert _run("bad_bus_crossing") == ["CDC-004"]
+
+
+def test_cdc_005_fires_on_bad_reconvergent_sync() -> None:
+    """Single source flop fanning out to multiple sync chains."""
+    assert _run("bad_reconvergent_sync") == ["CDC-005"]
+
+
+def test_cdc_007_fires_on_bad_reset_crossing() -> None:
+    """Async reset crossing without a reset synchronizer — relies on
+    ``$adff``'s ``ARST`` connection being correctly emitted."""
+    assert _run("bad_reset_crossing") == ["CDC-007"]
+
+
+def test_cdc_008_fires_on_bad_clock_as_data() -> None:
+    """Clock signal sampled as data. Doesn't depend on comb lowering."""
+    assert _run("bad_clock_as_data") == ["CDC-008"]
+
+
+def test_cdc_004_silent_on_good_gray_counter_crossing() -> None:
+    """Gray-coded bus crossing into a multi-bit sync chain — the
+    structural gray-code detector should accept it."""
+    assert _run("good_gray_counter_crossing") == []
+
+
+# --- SV-attribute pass-through ---------------------------------------------
+
+
+def test_cdc_sync_attribute_suppresses_cdc_001() -> None:
+    """``(* cdc_sync *)`` on the destination flop's wire should
+    suppress CDC-001. Validates that pyslang attributes reach
+    ``Module.netnames[name].attributes`` where the rule pack expects
+    them."""
+    assert _run("marked_user_sync") == []
+
+
+# --- CLI smoke test ---------------------------------------------------------
+
+
+def test_cli_lint_frontend_slang_end_to_end() -> None:
+    """The whole pipeline through the CLI command — elaborates via
+    slang, analyzes, and exits 1 for the bad fixture. This is the
+    user-visible promise of ``--frontend slang`` working at all."""
+    from typer.testing import CliRunner
+
+    from rtl_buddy_cdc.cli import app
+
+    runner = CliRunner()
+    fix = FIX / "bad_single_ff_sync"
+    result = runner.invoke(
+        app,
+        [
+            "lint",
+            "--frontend",
+            "slang",
+            "--top",
+            "bad_single_ff_sync",
+            "--sdc",
+            str(fix / "bad_single_ff_sync.sdc"),
+            str(fix / "bad_single_ff_sync.sv"),
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "CDC-001" in result.output
+    assert "frontend: slang" in result.output
+
+
+# --- Module-shape sanity check ---------------------------------------------
+
+
+def test_elaborated_module_has_expected_yosys_shape() -> None:
+    """A direct check that the produced ``Module`` matches the
+    Yosys-style contract the rule pack expects: integer bit IDs, ``$dff``
+    or ``$adff`` cell types, pins named ``CLK`` / ``D`` / ``Q``."""
+    fix = FIX / "bad_single_ff_sync"
+    module = elaborate(
+        [fix / "bad_single_ff_sync.sv"],
+        "bad_single_ff_sync",
+        frontend=Frontend.slang,
+    )
+    ff_cells = [c for c in module.cells.values() if c.type in {"$dff", "$adff"}]
+    assert len(ff_cells) == 2, [c.type for c in module.cells.values()]
+    for cell in ff_cells:
+        assert {"CLK", "D", "Q"} <= cell.connections.keys()
+        for pin in ("CLK", "D", "Q"):
+            for bit in cell.connections[pin]:
+                # Constant bits would be the string "0" / "1" / "x"
+                # / "z"; the canonical case here is all-integer.
+                assert isinstance(bit, (int, str))

--- a/tests/test_slang_lowering.py
+++ b/tests/test_slang_lowering.py
@@ -1,0 +1,324 @@
+"""Coverage tests for slang frontend lowering paths the fixture suite
+doesn't exercise directly.
+
+The existing fixtures (``tests/fixtures/``) cover the rule-fires-correctly
+contract end-to-end, but they happen to use a narrow vocabulary of SV
+operators (``&``, ``^``, element-selects, range-selects). The slang
+frontend supports a broader set — full BinaryOperator / UnaryOperator
+enums, conditional expressions, ``always_comb``, reduction operators,
+arithmetic. Without dedicated tests those code paths are unverified and
+silently rot.
+
+Each test uses :meth:`pyslang.SyntaxTree.fromText` via a tmp_path SV
+file, so the public ``elaborate(paths, top)`` entry point is exercised
+exactly as a real user invokes it (same code path as the CLI). The
+assertions look at the produced ``Module``'s cell types — narrower than
+running the whole rule pack but more diagnostic if a lowering ever
+breaks.
+
+Adding a new operator or a new statement-level shape? Add a test here
+*before* the implementation lands, then watch it go from FAIL → PASS as
+part of the same commit.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang lowering tests are gated on it",
+        allow_module_level=True,
+    )
+
+
+def _elaborate_inline(tmp_path: Path, src: str, top: str = "m") -> dict[str, str]:
+    """Write ``src`` to a temp .sv file, elaborate via the slang
+    frontend, and return ``{cell_name: cell_type}``. Returning a flat
+    map lets tests assert on cell-type membership without caring about
+    name auto-generation order."""
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    module = elaborate([sv], top, frontend=Frontend.slang)
+    return {name: cell.type for name, cell in module.cells.items()}
+
+
+# --- BinaryExpression operator coverage -----------------------------------
+#
+# Each test exercises one entry of the BINOP_CELL table that the
+# fixtures don't already hit. The shape is identical across tests:
+# two input flops feed a binary op, the result is captured by a third
+# flop. The captured op-cell's type is what the test asserts.
+
+
+def _binop_template(op: str) -> str:
+    """A 1-bit binary-op sandwich: flop → op → flop. ``op`` is inserted
+    verbatim into the ``assign y = a {op} b`` line."""
+    return f"""
+module m (
+    input  logic clk_a, clk_b, rst_n, x, z,
+    output logic q
+);
+    logic a, b, y;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) begin a <= 0; b <= 0; end
+        else        begin a <= x; b <= z; end
+    assign y = a {op} b;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) q <= 0; else q <= y;
+endmodule
+"""
+
+
+@pytest.mark.parametrize(
+    "op,expected_cell",
+    [
+        ("|", "$or"),
+        ("^", "$xor"),
+        ("~^", "$xnor"),
+        ("&&", "$logic_and"),
+        ("||", "$logic_or"),
+        ("==", "$eq"),
+        ("!=", "$ne"),
+        ("<", "$lt"),
+        ("<=", "$le"),
+        (">", "$gt"),
+        (">=", "$ge"),
+    ],
+)
+def test_binary_op_lowers_to_expected_cell(
+    tmp_path: Path, op: str, expected_cell: str
+) -> None:
+    """Each BinaryOperator should produce its Yosys-zoo counterpart so
+    the rule pack's comb-cone walk treats the operator as a transit
+    node, not an opaque ``$_UNKNOWN_`` driver."""
+    cells = _elaborate_inline(tmp_path, _binop_template(op))
+    assert expected_cell in cells.values(), (
+        f"op {op!r} should lower to {expected_cell}; got {sorted(set(cells.values()))}"
+    )
+
+
+# --- UnaryExpression operator coverage ------------------------------------
+
+
+def _unop_template(op: str) -> str:
+    """A 1-bit unary-op sandwich: flop → op → flop."""
+    return f"""
+module m (
+    input  logic clk_a, clk_b, rst_n, x,
+    output logic q
+);
+    logic a, y;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) a <= 0; else a <= x;
+    assign y = {op}a;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) q <= 0; else q <= y;
+endmodule
+"""
+
+
+@pytest.mark.parametrize(
+    "op,expected_cell",
+    [
+        ("~", "$not"),
+        ("!", "$logic_not"),
+    ],
+)
+def test_unary_op_lowers_to_expected_cell(
+    tmp_path: Path, op: str, expected_cell: str
+) -> None:
+    """``~a`` is bitwise not (``$not``), ``!a`` is logical not
+    (``$logic_not``). Both must emit a real comb cell rather than
+    falling through to the ``$_UNKNOWN_`` placeholder."""
+    cells = _elaborate_inline(tmp_path, _unop_template(op))
+    assert expected_cell in cells.values(), (
+        f"op {op!r} should lower to {expected_cell}; got {sorted(set(cells.values()))}"
+    )
+
+
+def test_unary_minus_on_arithmetic_signal(tmp_path: Path) -> None:
+    """``-a`` on a wider signal should emit ``$neg``. Splitting the
+    arithmetic case out keeps the bool-shaped table above clean."""
+    src = """
+module m (
+    input  logic clk_a, clk_b, rst_n,
+    input  logic signed [7:0] x,
+    output logic signed [7:0] q
+);
+    logic signed [7:0] a, y;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) a <= 0; else a <= x;
+    assign y = -a;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) q <= 0; else q <= y;
+endmodule
+"""
+    cells = _elaborate_inline(tmp_path, src)
+    assert "$neg" in cells.values(), sorted(set(cells.values()))
+
+
+def test_reduction_or_lowers_to_reduce_or(tmp_path: Path) -> None:
+    """Reduction operators (``|bus`` and friends) collapse a multi-bit
+    operand to a single bit — distinct cell type from the bitwise
+    operators that share the same syntax."""
+    src = """
+module m (
+    input  logic clk_a, clk_b, rst_n,
+    input  logic [3:0] x,
+    output logic q
+);
+    logic [3:0] a;
+    logic y;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) a <= 0; else a <= x;
+    assign y = |a;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) q <= 0; else q <= y;
+endmodule
+"""
+    cells = _elaborate_inline(tmp_path, src)
+    assert "$reduce_or" in cells.values(), sorted(set(cells.values()))
+
+
+# --- ConditionalExpression -------------------------------------------------
+
+
+def test_ternary_lowers_to_mux(tmp_path: Path) -> None:
+    """``sel ? a : b`` should produce a ``$mux`` so the rule pack can
+    trace both inputs as comb predecessors of the destination flop."""
+    src = """
+module m (
+    input  logic clk_a, clk_b, rst_n, x, z, sel,
+    output logic q
+);
+    logic a, b, y;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) begin a <= 0; b <= 0; end
+        else        begin a <= x; b <= z; end
+    assign y = sel ? a : b;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) q <= 0; else q <= y;
+endmodule
+"""
+    cells = _elaborate_inline(tmp_path, src)
+    assert "$mux" in cells.values(), sorted(set(cells.values()))
+
+
+# --- always_comb -----------------------------------------------------------
+
+
+def test_always_comb_aliases_lhs_to_lowered_rhs(tmp_path: Path) -> None:
+    """An ``always_comb`` block writing a single LHS should alias that
+    variable's bits onto the RHS lowering, so a downstream flop reads
+    through to the source operands. Concretely: with ``always_comb y =
+    a & b``, the destination flop's D bit must trace back through an
+    ``$and`` to the source flops — same outcome as the continuous-assign
+    form would produce."""
+    src = """
+module m (
+    input  logic clk_a, clk_b, rst_n, x, z,
+    output logic q
+);
+    logic a, b, y;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) begin a <= 0; b <= 0; end
+        else        begin a <= x; b <= z; end
+    always_comb y = a & b;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) q <= 0; else q <= y;
+endmodule
+"""
+    cells = _elaborate_inline(tmp_path, src)
+    assert "$and" in cells.values(), sorted(set(cells.values()))
+
+
+# --- ConversionExpression pass-through ------------------------------------
+
+
+def test_implicit_width_conversion_is_transparent(tmp_path: Path) -> None:
+    """pyslang inserts a :class:`ConversionExpression` when source and
+    destination widths disagree. The frontend's lowering must see
+    through it — otherwise the destination flop ends up driven by a
+    ``$_UNKNOWN_`` placeholder instead of the real comb upstream."""
+    src = """
+module m (
+    input  logic clk_a, clk_b, rst_n,
+    input  logic [3:0] x,
+    output logic q
+);
+    logic [3:0] a;
+    logic y;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) a <= 0; else a <= x;
+    // Width conversion 4-bit → 1-bit (implicit cast).
+    assign y = a[0];
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) q <= 0; else q <= y;
+endmodule
+"""
+    cells = _elaborate_inline(tmp_path, src)
+    # Element-select doesn't itself produce a cell — the destination
+    # flop should read bit 0 of ``a`` directly. The test passes when
+    # NO ``$_UNKNOWN_`` placeholder appears: if the lowering punted,
+    # the destination flop's D would be driven by that stub instead.
+    assert "$_UNKNOWN_" not in cells.values(), (
+        f"width conversion should be transparent; got {sorted(set(cells.values()))}"
+    )
+
+
+# --- Multi-source-domain via always_comb (end-to-end rule firing) ---------
+
+
+def test_ternary_between_domains_fires_cdc_001(tmp_path: Path) -> None:
+    """Sanity-check that a ternary mux on the path from source to
+    destination is correctly seen as a comb hop by the rule pack —
+    not just lowered structurally, but also walkable end-to-end."""
+    from rtl_buddy_cdc import sdc as sdc_mod
+    from rtl_buddy_cdc.cli import _filter_async
+    from rtl_buddy_cdc.domain import find_crossings
+    from rtl_buddy_cdc.rules import run_all
+
+    src = """
+module m (
+    input  logic clk_src, clk_dst, rst_n, x, z, sel,
+    output logic q
+);
+    logic a, b, y;
+    always_ff @(posedge clk_src or negedge rst_n)
+        if (!rst_n) begin a <= 0; b <= 0; end
+        else        begin a <= x; b <= z; end
+    assign y = sel ? a : b;
+    always_ff @(posedge clk_dst or negedge rst_n)
+        if (!rst_n) q <= 0; else q <= y;
+endmodule
+"""
+    sdc = """
+create_clock -name clk_src -period 10 [get_ports clk_src]
+create_clock -name clk_dst -period 10 [get_ports clk_dst]
+set_clock_groups -asynchronous -group {clk_src} -group {clk_dst}
+"""
+    sv = tmp_path / "m.sv"
+    sv.write_text(src)
+    sdc_path = tmp_path / "m.sdc"
+    sdc_path.write_text(sdc)
+
+    module = elaborate([sv], "m", frontend=Frontend.slang)
+    spec = sdc_mod.parse_file(sdc_path)
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    async_c = _filter_async(crossings, spec)
+    violations = run_all(module, async_c, spec)
+    rule_ids = sorted({v.rule_id for v in violations})
+    # The destination flop has chain depth 1 → CDC-001 fires on the
+    # two source flops feeding the mux.
+    assert rule_ids == ["CDC-001"], (
+        f"expected CDC-001 from ternary-mediated crossing; got {rule_ids}"
+    )

--- a/wiki/concepts/cdc-analysis-pipeline.md
+++ b/wiki/concepts/cdc-analysis-pipeline.md
@@ -1,50 +1,62 @@
 ---
 title: CDC Analysis Pipeline
 created: 2026-05-11
-updated: 2026-05-11
+updated: 2026-05-14
 type: concept
-tags: [pipeline, cdc, algorithm, architecture, data-model]
+tags: [pipeline, cdc, algorithm, architecture, data-model, frontend]
 sources: [raw/articles/rtl-buddy-cdc-architecture.md]
 confidence: high
 ---
 
 # CDC Analysis Pipeline
 
-The end-to-end flow that turns a Yosys netlist + SDC into a violation report. Orchestrated by `cli._analyze_and_report`, the pipeline is a sequence of pure-function stages.
+The end-to-end flow from SV sources (or a pre-elaborated Yosys netlist) plus an SDC to a violation report. Orchestrated by `cli._analyze_module_and_report`, the pipeline is a sequence of pure-function stages.
 
 ## Pipeline Stages
 
 ```
-netlist.json → (1) netlist.load → (2) flops.find_flops → (3) domain.assign_domains
-    → (4) domain.find_crossings → (5) sdc.parse_file → (6) cli._filter_async
-    → (7) rules.run_all → (8) waivers.apply → (9) reporter.render_*
+SV sources + --top          pre-elaborated
+      │                       netlist.json
+      ▼                            │
+(0) frontend.elaborate              │
+   ├─ yosys (default)               │
+   └─ slang (pyslang)               │
+      ▼                              ▼
+                Module
+                  ▼
+(1) flops.find_flops → (2) domain.assign_domains → (3) domain.find_crossings
+    → (4) sdc.parse_file → (5) cli._filter_async → (6) rules.run_all
+    → (7) waivers.apply → (8) reporter.render_*
 ```
 
-**Steps 1–4 are deterministic and SDC-independent** — they always run and populate the structural summary. Steps 5–9 only fire if an SDC was supplied; without one the tool prints the structural summary and exits 0.
+The frontend stage (0) produces a `Module` from either a frontend invocation (the `lint` CLI command path) or a pre-existing Yosys JSON via `netlist.load` (the `analyze` CLI command path). After that point the pipeline is identical regardless of source.
+
+**Steps 0–3 are deterministic and SDC-independent** — they always run and populate the structural summary. Steps 4–8 only fire if an SDC was supplied; without one the tool prints the structural summary and exits 0.
 
 ### Stage Details
 
-1. **Netlist loading** (`netlist.load`): Parses Yosys `write_json` output into typed `Module` / `Cell` / `Port` / `Netname` structs.
-2. **Flop recognition** (`flops.find_flops`): Scans cells against the 11-entry `FF_CELL_TYPES` zoo, extracting CLK / D / Q pins.
-3. **Domain assignment** (`domain.assign_domains`): Calls `trace_clock_root` for each flop's CLK net to determine which top-level clock port drives it.
-4. **Crossing detection** (`domain.find_crossings`): BFS from each flop's Q pins forward through combinational cells until hitting destination flop D pins in different clock domains.
-5. **SDC parsing** (`sdc.parse_file`): Parses the CDC-relevant SDC subset into a `ClockSpec`.
-6. **Async filtering** (`cli._filter_async`): Drops crossing pairs not declared async in the SDC. Consults `is_unreachable_crossing` (exclusive groups) before `are_async`.
-7. **Rule application** (`rules.run_all`): Runs CDC-001 through CDC-008 against the filtered crossings.
-8. **Waiver application** (`waivers.apply`): Partitions violations into kept vs. suppressed based on the waiver file.
-9. **Reporting** (`reporter.render_*`): Formats the `AnalysisResult` as text, JSON, or SARIF.
+0. **Elaboration** ([[elaboration-frontends|frontend layer]]): `lint --frontend {yosys,slang}` drives the selected frontend, which produces a `Module` that satisfies the Yosys-shape contract. `analyze --netlist file.json` bypasses this stage and loads the JSON via `netlist.load` directly.
+1. **Flop recognition** (`flops.find_flops`): Scans cells against the 11-entry `FF_CELL_TYPES` zoo, extracting CLK / D / Q pins.
+2. **Domain assignment** (`domain.assign_domains`): Calls `trace_clock_root` for each flop's CLK net to determine which top-level clock port drives it.
+3. **Crossing detection** (`domain.find_crossings`): BFS from each flop's Q pins forward through combinational cells until hitting destination flop D pins in different clock domains.
+4. **SDC parsing** (`sdc.parse_file`): Parses the CDC-relevant SDC subset into a `ClockSpec`.
+5. **Async filtering** (`cli._filter_async`): Drops crossing pairs not declared async in the SDC. Consults `is_unreachable_crossing` (exclusive groups) before `are_async`.
+6. **Rule application** (`rules.run_all`): Runs CDC-001 through CDC-008 against the filtered crossings.
+7. **Waiver application** (`waivers.apply`): Partitions violations into kept vs. suppressed based on the waiver file.
+8. **Reporting** (`reporter.render_*`): Formats the `AnalysisResult` as text, JSON, or SARIF.
 
 ## Design Properties
 
-- **Pure functions.** Side effects belong only in `cli.py` (file I/O) and the reporter (writing to a file-like). `domain.py`, `rules.py`, and `sdc.py` have no I/O.
+- **Pure functions.** Side effects belong only in `cli.py` (file I/O), the frontends (subprocess / pyslang invocation), and the reporter (writing to a file-like). `domain.py`, `rules.py`, and `sdc.py` have no I/O.
 - **Immutable dataclasses** by default. Frozen everywhere except `ClockSpec`'s parser-built collections.
-- **No Yosys runtime dependency** on the primary `analyze` path. The standalone `lint` wrapper shells out to Yosys, but the Python core does not.
+- **No toolchain runtime dependency on the rule pack.** The `analyze` entry consumes a pre-elaborated `Module` directly. The `lint` entry drives a [[elaboration-frontends|frontend]], but which one is the user's choice — `typer` is the only mandatory runtime dependency; the `[slang]` extra adds pyslang opt-in.
 
 ## Related Pages
 
 - [[rtl-buddy-cdc]] — the tool this pipeline powers
+- [[elaboration-frontends]] — stage 0: how a `Module` gets built from SV sources
 - [[cdc-data-model]] — the dataclasses that flow through the pipeline
-- [[clock-domain-tracing]] — stage 3: how flops get assigned to clock domains
-- [[crossing-detection]] — stage 4: BFS-based crossing discovery
-- [[sdc-parsing]] — stage 5: SDC constraint parsing
-- [[cdc-rule-pack]] — stage 7: the CDC-001..-008 rule functions
+- [[clock-domain-tracing]] — stage 2: how flops get assigned to clock domains
+- [[crossing-detection]] — stage 3: BFS-based crossing discovery
+- [[sdc-parsing]] — stage 4: SDC constraint parsing
+- [[cdc-rule-pack]] — stage 6: the CDC-001..-008 rule functions

--- a/wiki/concepts/cdc-data-model.md
+++ b/wiki/concepts/cdc-data-model.md
@@ -1,9 +1,9 @@
 ---
 title: CDC Data Model
 created: 2026-05-11
-updated: 2026-05-11
+updated: 2026-05-14
 type: concept
-tags: [data-model, netlist, cdc, flops, clock-domain, crossing, sdc]
+tags: [data-model, netlist, cdc, flops, clock-domain, crossing, sdc, frontend]
 sources: [raw/articles/rtl-buddy-cdc-architecture.md]
 confidence: high
 ---
@@ -12,17 +12,19 @@ confidence: high
 
 The analyzer is structured as a sequence of pure functions producing immutable dataclasses. Frozen dataclasses are used everywhere except `ClockSpec`'s parser-built collections.
 
+The `Module` shape described here is the **contract every [[elaboration-frontends|frontend]] must produce**. Whether `Module` comes from Yosys `write_json` or from a pyslang elaboration, the downstream pipeline sees the same dataclasses with the same conventions.
+
 ## Netlist Layer
 
 A `Module` is a flat namespace of `ports`, `cells`, and `netnames`, each indexed by name.
 
-**`Bit`** — the fundamental connection type. Either an `int` (Yosys net ID) or one of the constant strings `"0"`, `"1"`, `"x"`, `"z"`. The integer-vs-string distinction is load-bearing — every walker ignores constant bits because they can't propagate driver identity.
+**`Bit`** — the fundamental connection type. Either an `int` (net ID, originating from Yosys IDs or from the slang frontend's sequential allocator) or one of the constant strings `"0"`, `"1"`, `"x"`, `"z"`. The integer-vs-string distinction is load-bearing — every walker ignores constant bits because they can't propagate driver identity.
 
-**`Netname`** — the wire/reg name as it appeared in the source, with any SV `(* attr = "value" *)` annotations attached. Yosys preserves attributes on the netname rather than the driving cell, so the rule pack maps from tagged netname bits back to the upstream flop.
+**`Netname`** — the wire/reg name as it appeared in the source, with any SV `(* attr = "value" *)` annotations attached. Yosys preserves attributes on the netname rather than the driving cell (and the slang frontend matches this convention by pulling attributes via `Compilation.getAttributes(symbol)`), so the rule pack maps from tagged netname bits back to the upstream flop uniformly.
 
 ## Flop Recognition
 
-`FF_CELL_TYPES` enumerates the 11 Yosys FF variants: `$dff`, `$dffe`, `$adff`, `$adffe`, `$aldff`, `$aldffe`, `$sdff`, `$sdffe`, `$sdffce`, `$dffsr`, `$dffsre`. Each has different reset/enable plumbing, but **CLK / D / Q are universal** — the only pins needed for domain assignment and fanout walks.
+`FF_CELL_TYPES` enumerates the 11 Yosys FF variants: `$dff`, `$dffe`, `$adff`, `$adffe`, `$aldff`, `$aldffe`, `$sdff`, `$sdffe`, `$sdffce`, `$dffsr`, `$dffsre`. Each has different reset/enable plumbing, but **CLK / D / Q are universal** — the only pins needed for domain assignment and fanout walks. The slang frontend emits the subset that corresponds to recognised `always_ff` shapes (`$dff` for plain `posedge clk`, `$adff` for the canonical `always_ff @(posedge clk or negedge rst_n)` async-reset shape).
 
 ## Domain Assignment
 
@@ -93,6 +95,7 @@ The immutable struct at the boundary between analyzer and presentation. Contains
 ## Related Pages
 
 - [[cdc-analysis-pipeline]] — how these types flow through the pipeline
+- [[elaboration-frontends]] — the frontend layer that produces `Module` instances satisfying this contract
 - [[clock-domain-tracing]] — `FlopDomain` and `trace_clock_root`
 - [[crossing-detection]] — how `Crossing` records are created
 - [[sdc-parsing]] — how `ClockSpec` is populated

--- a/wiki/concepts/elaboration-frontends.md
+++ b/wiki/concepts/elaboration-frontends.md
@@ -1,0 +1,99 @@
+---
+title: Elaboration Frontends
+created: 2026-05-14
+updated: 2026-05-14
+type: concept
+tags: [frontend, elaboration, yosys, slang, pyslang, architecture]
+sources: [raw/articles/rtl-buddy-cdc-architecture.md]
+confidence: high
+---
+
+# Elaboration Frontends
+
+`netlist.Module` is the contract every rule walks; **how a module gets built is pluggable**. `rtl-buddy-cdc` ships two frontends behind a single factory, selected by the `--frontend {yosys,slang}` CLI flag.
+
+## The Contract
+
+Every frontend must produce a `Module` shape the rule pack can consume unchanged:
+
+- **Yosys-style cell types** — `$dff`, `$adff`, `$and`, `$or`, `$xor`, `$mux`, `$logic_and`, …
+- **Pin names** — `CLK` / `D` / `Q` / `ARST` on flops, `A` / `B` / `Y` (and `S` on muxes) on combinational cells
+- **Integer bit IDs** for nets, with the four constant chars `"0"` / `"1"` / `"x"` / `"z"` reserved
+- **SV `(* attr *)`** declarations propagated onto the corresponding `Netname` so attribute-driven rules (`cdc_sync`, `cdc_gray`) work uniformly
+
+Rules don't know which frontend produced a `Module` — the shape is the only coupling. New frontends only need to produce that shape; the rule pack, SDC parser, waiver matcher, and reporter all stay unchanged.
+
+## The Factory
+
+`frontend.elaborate(sources, top, frontend=Frontend.yosys, **kw) -> Module` is the single orchestration entry. It dispatches on the enum to the concrete frontend module.
+
+```python
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+module = elaborate(["rtl/foo.sv"], "foo_top", frontend=Frontend.slang)
+```
+
+The `analyze` CLI command bypasses the factory — it takes a pre-elaborated Yosys JSON via `netlist.load` directly. `lint` is the entry that drives a frontend.
+
+## Yosys Frontend (`frontends/yosys.py`)
+
+Runs `yosys -p 'read_verilog ...; hierarchy -top X; proc; flatten; opt_clean; write_json /tmp/out.json'`, then loads the JSON via `netlist.load`. This is the historical primary path and remains the default for `lint --frontend yosys` and the `analyze --netlist file.json` entry. Requires a `yosys` binary on `PATH` (override with `--yosys PATH`).
+
+## slang Frontend (`frontends/slang.py`)
+
+Elaborates SV sources directly via the [pyslang](https://pypi.org/project/pyslang/) binding to [slang](https://github.com/MikePopoloski/slang) and builds a `Module` from the elaborated `pyslang.Compilation` — no synthesis subprocess, no `flatten` step.
+
+Opt-in via the `[slang]` install extra (`pip install 'rtl-buddy-cdc[slang]'`); the default install stays `typer`-only. When pyslang is missing, the frontend raises `SlangFrontendUnavailable` with an install hint. Fatal pyslang diagnostics surface through a `TextDiagnosticClient` with file:line:col + caret summaries — the usual compiler-error UX.
+
+### Internals
+
+The translator (`_ModuleBuilder`) walks the elaborated top instance in three passes:
+
+1. **Variables** — local `logic` / `reg` become `Netname`s with hierarchical name prefixes (`u_b0.q`); attributes pulled via `Compilation.getAttributes(symbol)` (pyslang stores them on the compilation, not the symbol).
+2. **Ports** — top-instance ports only; child ports get folded into their parents' connection expressions.
+3. **Cells + continuous assigns + child instances** — the lowering layer.
+
+Procedural and expression shapes lower to Yosys-shape cells:
+
+- `always_ff` with the canonical async-reset shape → `$dff` or `$adff` with `CLK` / `D` / `Q` / `ARST` connections; reset polarity comes from the event edge confirmed against the conditional body.
+- `BinaryExpression` / `UnaryExpression` / `ConditionalExpression` → `$and` / `$or` / `$xor` / `$mux` / `$not` / `$reduce_*` / etc. with the Yosys A/B/Y/S pin convention.
+- `always_comb` blocks alias their LHS variables to the lowered RHS bits.
+- `ElementSelectExpression` / `RangeSelectExpression` on either side → bit subset of the underlying variable.
+
+### Cross-Module Flattening
+
+Child `InstanceSymbol`s are walked recursively. For each port connection the child's internal-port variable is aliased to the parent's expression bits — so flop A's `Q` in one instance and flop B's `D` in the next resolve to the same net. Hierarchical cell + netname prefixes (`u_b0.q`, `u_b0.$slang$adff$3`) match Yosys-flatten output. Aliasing rewrites propagate globally across `_var_bits` / `_ports` / `_netnames` so chains like parent `a_q` ← child `q` collapse to a single net rather than leaving stale aliases.
+
+### Parity Status
+
+The slang frontend reaches **parity with the Yosys frontend on every SDC-equipped fixture in the regression suite** — CDC-001 through CDC-008, attribute suppression (`cdc_sync` / `cdc_gray`), multi-bit LHS bit-selects, and multi-module hierarchies. The per-fixture matrix lives in the `frontends/slang.py` module docstring; the slang-specific tests live in `tests/test_slang_elaboration.py` (rule parity) and `tests/test_slang_lowering.py` (operator coverage).
+
+Two fixtures stay Yosys-frontend-only by design: `bad_source_sync_internal` / `good_source_sync_internal` embed Yosys-internal `$_BUF_` primitives in their SV source — slang correctly rejects them as not legal SystemVerilog.
+
+## When To Use Which
+
+| Goal | Frontend |
+|---|---|
+| Default workflow, has `yosys` installed | Yosys (the default) |
+| Want to skip the synth step, avoid the Yosys runtime dependency, or work with SV constructs Yosys mangles after flatten | slang |
+| Already have a pre-synthesized Yosys JSON (e.g. from `rb synth`) | Neither — use `analyze --netlist file.json` directly |
+
+Both frontends produce the same violation set on the standard fixture suite, so swapping between them is safe for CI / regression work.
+
+## Adding A New Frontend
+
+The factory pattern makes it a localised change:
+
+1. Add a submodule under `frontends/` exposing `elaborate(sources, top, **kw) -> Module`.
+2. Register the new name in the `Frontend` enum in `frontend.py`.
+3. Dispatch to it in `frontend.elaborate`.
+4. The frontend must produce the Yosys-style `Module` contract documented above; the rule pack consumes that contract regardless of source.
+
+No changes needed in `rules.py`, `sdc.py`, `waivers.py`, or `reporter.py`.
+
+## Related Pages
+
+- [[rtl-buddy-cdc]] — the tool entry that consumes a frontend's output
+- [[cdc-analysis-pipeline]] — the downstream pipeline that runs on the produced `Module`
+- [[cdc-data-model]] — the `Module` / `Cell` / `Port` / `Netname` contract every frontend produces
+- [[cdc-testing-strategy]] — paired bad/good fixtures that gate frontend parity

--- a/wiki/entities/rtl-buddy-cdc.md
+++ b/wiki/entities/rtl-buddy-cdc.md
@@ -1,34 +1,38 @@
 ---
 title: rtl-buddy-cdc
 created: 2026-05-11
-updated: 2026-05-11
+updated: 2026-05-14
 type: entity
-tags: [cdc, clock-domain, synchronization, pipeline, cli, integration, yosys]
+tags: [cdc, clock-domain, synchronization, pipeline, cli, integration, yosys, slang, frontend]
 sources: [raw/articles/rtl-buddy-cdc-architecture.md]
 confidence: high
 ---
 
 # rtl-buddy-cdc
 
-A Python-based CDC (clock-domain-crossing) linter that consumes a flattened Yosys netlist plus an SDC file and produces text / JSON / SARIF reports. It catches eight classic CDC bug shapes (CDC-001 through CDC-008) in flattened RTL.
+A Python-based CDC (clock-domain-crossing) linter that consumes a flattened `Module` — produced by either the Yosys or the slang [[elaboration-frontends|frontend]] — plus an SDC file, and emits text / JSON / SARIF reports. It catches eight classic CDC bug shapes (CDC-001 through CDC-008) in flattened RTL.
 
 ## Goals
 
 - Catch CDC-001 through CDC-008 with reasonable false-positive and false-negative rates
 - Surface findings in formats that drop into existing review and CI workflows (text / JSON / SARIF)
+- Keep the elaboration frontend swappable so the rule pack doesn't depend on a specific toolchain
 - Stay small enough to fork and extend in a sitting
 
 ## Explicit Non-Goals
 
-- **Not a synthesis tool.** The analyzer never invokes Yosys on its primary path — the netlist is an input. The standalone `lint` wrapper is convenience-only.
+- **Not a synthesis tool.** The rule pack never invokes a synthesizer on its primary path — it consumes an in-memory `Module` produced by a [[elaboration-frontends|frontend]]. The `analyze` command takes a pre-elaborated Yosys JSON; the `lint` wrapper drives a frontend (Yosys or slang) for source-to-analysis convenience.
 - **Not a timing tool.** SDC is parsed for clock topology and async partitioning only; numeric delays and slack are ignored.
 - **Not a Tcl interpreter.** The SDC parser is a deliberate `shlex`-based pattern matcher, not a real Tcl host.
-- **Not a hierarchical analyzer.** Today the netlist must be fully flattened. Hierarchical reporting is on the roadmap but not architecturally present.
+- **Not a hierarchical analyzer.** Today the netlist must be fully flattened (which both frontends produce). Hierarchical reporting is on the roadmap but not architecturally present.
 
 ## Module Map
 
 | Module | Responsibility | Key types |
 |---|---|---|
+| `frontend.py` | Frontend factory: pick a frontend by name, dispatch to its `elaborate` | `Frontend`, `elaborate` |
+| `frontends/yosys.py` | Yosys frontend: shell out to `yosys` then `netlist.load` the JSON | `elaborate`, `YosysError` |
+| `frontends/slang.py` | slang frontend: elaborate SystemVerilog via pyslang directly | `elaborate`, `SlangFrontendUnavailable`, `SlangElaborationError` |
 | `netlist.py` | Parse Yosys `write_json` output into typed structs | `Module`, `Cell`, `Port`, `Netname` |
 | `flops.py` | Recognise the 11 Yosys FF cell variants and extract CLK / D / Q | `Flop`, `FF_CELL_TYPES` |
 | `domain.py` | Trace clock roots, find flop→flop crossings | `FlopDomain`, `Crossing`, `trace_clock_root`, `find_crossings` |
@@ -38,7 +42,7 @@ A Python-based CDC (clock-domain-crossing) linter that consumes a flattened Yosy
 | `reporter.py` | Format an `AnalysisResult` as text / JSON / SARIF | `AnalysisResult`, `render_text`, `render_json`, `render_sarif` |
 | `cli.py` | Typer entry points; orchestrates the pipeline | `analyze`, `lint`, `version` |
 
-`__init__.py` exposes a thin `main()` shim that delegates to `cli.app` (used by the console-script entry point). No other public API beyond these modules.
+`__init__.py` exposes a thin `main()` shim that delegates to `cli.app` (used by the console-script entry point). The other public API is `frontend.Frontend` + `frontend.elaborate(sources, top, frontend=…)`, which `cli.lint` consumes when the user supplies SV sources.
 
 ## Integration with rtl-buddy
 
@@ -54,7 +58,7 @@ The subprocess boundary is intentional: it lets `rtl_buddy` pick up new analyzer
 
 - **Flags consumed today:** `--netlist`, `--sdc`, `--top`, `--waivers`, `--sync-depth`, `--format`, `--output`
 - **JSON schema consumed today:** `summary.violations` (int), `summary.suppressed` (int), `summary.crossings` (int)
-- **Exit codes:** 0 = clean/fully waived, 1 = unsuppressed violations, 2 = lint-only Yosys elaboration failure
+- **Exit codes:** 0 = clean/fully waived, 1 = unsuppressed violations, 2 = lint-only frontend-elaboration failure (Yosys binary missing, slang pyslang missing, or pyslang diagnostics fatal)
 
 ## Performance
 
@@ -64,7 +68,8 @@ Key complexity: `find_crossings` is `O(F · max_hops · avg_fanout)`, the rule p
 
 ## Related Pages
 
-- [[cdc-analysis-pipeline]] — the full pipeline from netlist to report
+- [[elaboration-frontends]] — Yosys + slang frontends behind `--frontend`; the contract every frontend produces
+- [[cdc-analysis-pipeline]] — the full pipeline from elaborated `Module` to report
 - [[cdc-data-model]] — all dataclasses and schemas
 - [[waivers-and-reporting]] — output formats and waiver system
 - [[cdc-testing-strategy]] — fixtures, tests, extension points

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -2,18 +2,19 @@
 
 > Content catalog. Every wiki page listed under its type with a one-line summary.
 > Read this first to find relevant pages for any query.
-> Last updated: 2026-05-11 | Total pages: 9
+> Last updated: 2026-05-14 | Total pages: 10
 
 ## Entities
-- [[rtl-buddy-cdc]] — Python-based CDC linter for flattened Yosys netlists; goals, non-goals, module map, and rtl-buddy integration
+- [[rtl-buddy-cdc]] — Python-based CDC linter consuming a `Module` from a Yosys or slang frontend; goals, non-goals, module map, and rtl-buddy integration
 
 ## Concepts
-- [[cdc-analysis-pipeline]] — The 9-stage pure-function pipeline from netlist.json to text/JSON/SARIF report
+- [[cdc-analysis-pipeline]] — The pure-function pipeline from elaborated `Module` to text/JSON/SARIF report
 - [[cdc-data-model]] — All immutable dataclasses: Module, Flop, FlopDomain, Crossing, ClockSpec, Violation, AnalysisResult
 - [[cdc-rule-pack]] — CDC-001..-008 rule functions, shared structural helpers, severity policy, and recognition vs. annotation
-- [[cdc-testing-strategy]] — Paired bad/good fixtures, test organization, and extension points for rules/attributes/SDC/formats
+- [[cdc-testing-strategy]] — Paired bad/good fixtures, test organization, and extension points for rules/attributes/SDC/formats/frontends
 - [[clock-domain-tracing]] — `trace_clock_root` algorithm: buffer/ICG/mux/divider cell categories, walk mechanics, CDC-008 role
 - [[crossing-detection]] — BFS-based `find_crossings`: walk, grouping by (src,dst), intentional exclusions, complexity
+- [[elaboration-frontends]] — Yosys + slang frontends behind `--frontend`; shared `Module` contract; how to add a new frontend
 - [[sdc-parsing]] — `shlex`-based SDC parser design, supported commands, deliberate omissions, diagnostics policy
 - [[waivers-and-reporting]] — Waiver file format and matching, text/JSON/SARIF formatters, AnalysisResult contract
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -43,3 +43,11 @@
 - New paired fixtures in `tests/fixtures/{good,bad}_source_sync_internal/` exercise internal-pin `create_generated_clock` end-to-end; covered by `tests/test_bad_source_sync_internal.py` and a new entry in `test_good_fixtures.py`
 - `trace_clock_root` signature gained `bit_to_clock: dict[Bit, str] | None = None`; `assign_domains` and `find_crossings` gained `pin_clocks: dict[str, str] | None = None`
 - `sdc.py` `_handle_create_generated_clock` now consumes `-source [get_*]` by scanning forward to the next `-` flag (fixes shlex-split leak of `]`-suffixed name into the trailing target list)
+
+## [2026-05-14] update | slang frontend documentation catchup
+- Issue: rtl-buddy/rtl-buddy-cdc#5 (Stage 2)
+- New concept page `concepts/elaboration-frontends.md` — the Yosys + slang frontend layer behind `--frontend`, the `Module` contract every frontend must produce, parity status, and how to add a new frontend
+- Updated `entities/rtl-buddy-cdc.md` — tags grow `slang` + `frontend`; intro says "consumes a `Module` from a Yosys or slang frontend" rather than "consumes a flattened Yosys netlist"; non-goals updated so the `lint` wrapper isn't "convenience-only" (it drives a frontend by choice); module map adds `frontend.py`, `frontends/yosys.py`, `frontends/slang.py`; exit-code-2 description generalised from "Yosys elaboration failure" to "frontend-elaboration failure"
+- Updated `concepts/cdc-analysis-pipeline.md` — pipeline now starts at stage 0 (`frontend.elaborate`), then stages 1–8 are the existing pipeline; ASCII diagram updated; design-properties bullet on "no Yosys runtime dependency" generalised to "no toolchain runtime dependency on the rule pack"
+- Updated `concepts/cdc-data-model.md` — note the `Module` shape is the contract every frontend produces; `Bit` integer IDs originate from either Yosys IDs or the slang frontend's sequential allocator; attribute propagation works uniformly because the slang frontend pulls via `Compilation.getAttributes(symbol)`
+- Updated `index.md` — page count 9 → 10; entity summary mentions both frontends; new `[[elaboration-frontends]]` concept entry; testing-strategy summary extended with "frontends" extension point

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -133,17 +133,16 @@ built is pluggable:
   write_json /tmp/out.json'`, then loads the JSON via `netlist.load`.
   This is the historical primary path and remains the default for
   `lint --frontend yosys` / `analyze --netlist file.json`.
-- **slang frontend** (`frontends/slang.py`) — in development (see
-  issue #5). Will elaborate SV sources via the
-  [pyslang](https://pypi.org/project/pyslang/) binding to
-  [slang](https://github.com/MikePopoloski/slang) and build a
+- **slang frontend** (`frontends/slang.py`) — elaborates SV sources
+  via the [pyslang](https://pypi.org/project/pyslang/) binding to
+  [slang](https://github.com/MikePopoloski/slang) and builds a
   `Module` directly from the elaborated `Compilation` — no
-  synthesis subprocess, no `flatten` step. Opt-in via the
-  `[slang]` install extra (`pip install 'rtl-buddy-cdc[slang]'`);
-  the default install stays `typer`-only. The current scaffolding
-  raises `SlangFrontendUnavailable` (with an install hint) when
-  pyslang is missing, and `NotImplementedError` once it's present
-  until the elaboration lands.
+  synthesis subprocess, no `flatten` step. Opt-in via the `[slang]`
+  install extra (`pip install 'rtl-buddy-cdc[slang]'`); the default
+  install stays `typer`-only. When pyslang is missing the frontend
+  raises `SlangFrontendUnavailable` with an install hint; fatal
+  pyslang diagnostics surface through a `TextDiagnosticClient`
+  (file:line:col + caret summaries — the usual compiler-error UX).
 
 The factory in `frontend.py` is the only orchestration:
 
@@ -166,13 +165,20 @@ Rules don't know which frontend produced a `Module` — the shape is
 the only coupling. New frontends only need to produce that shape;
 no other module changes.
 
-The slang frontend's elaboration lands in a follow-up PR (Stage 2
-of issue #5); this PR is the abstraction layer, the `--frontend`
-CLI flag, and the optional install extra only. The roadmap in
-`frontends/slang.py` covers the implementation chunks: elaboration
-setup, instance-tree walk, flop inference, net-bit allocation,
-primitive lowering, attribute propagation, and cross-instance
-flattening.
+The slang frontend's elaborator is the `_ModuleBuilder` inside
+`frontends/slang.py`. It walks the elaborated top instance in three
+passes (variables → ports → cells / continuous assigns / child
+instances), lowers procedural / continuous / expression shapes to
+Yosys-shape cells, and recurses into child `InstanceSymbol`s with
+hierarchical name prefixes (`u_b0.q`) that match Yosys-flatten
+output. Port connections alias the child's internal-port variables
+to the parent's connection expression bits so net identity is
+preserved across the hierarchy boundary; aliasing rewrites
+propagate globally across `_var_bits` / `_ports` / `_netnames` so
+chains like parent `a_q` ← child `q` collapse to a single net.
+Reaches parity with the Yosys frontend on every SDC-equipped
+fixture in the regression suite; the per-fixture matrix lives in
+the `frontends/slang.py` module docstring.
 
 ## 4. Data model
 


### PR DESCRIPTION
Stage 2 of #5. Builds on the frontend abstraction in PR #6 (now merged on main). The slang frontend is no longer a stub — it elaborates SystemVerilog via pyslang into a Yosys-shape `Module` and reaches **full parity with the Yosys frontend on every SDC-equipped fixture (25 / 25)**.

## What this PR delivers

The complete pipeline — `pyslang.Compilation` → walk elaborated symbols → lower to Yosys-shape cells → feed the unchanged rule pack:

- **Top-instance walk** — `_ModuleBuilder._walk_instance(inst, hier_prefix, bound_internals)` does a three-pass collect: variables → ports (top only) → cells / continuous assigns / child instances. Attributes are pulled via `Compilation.getAttributes(symbol)` (pyslang stores them on the compilation, not on the symbol itself).
- **Flop inference** — `always_ff` blocks lower to `$dff` / `$adff` with `CLK` / `D` / `Q` / `ARST` connections. Async-reset polarity comes from the event edge (`negedge rst_n` → active-low) confirmed against the conditional body's reset check.
- **Combinational primitive lowering** — `BinaryExpression`, `UnaryExpression`, `ConditionalExpression`, `IntegerLiteral`, `ConversionExpression` lower to `$and` / `$or` / `$xor` / `$mux` / `$not` / etc. with the Yosys A/B/Y/S pin convention. `always_comb` blocks alias their LHS variables to the lowered RHS bits.
- **Multi-bit LHS bit-selects** — `_lvalue_bits` handles `q[0] <= ...` (`ElementSelectExpression`) and `bus[3:0] <= ...` (`RangeSelectExpression`); the flop's Q connects to just the selected subset of the variable's bit tuple. Same shapes accepted on the RHS.
- **Cross-module hierarchy flattening** — child `InstanceSymbol`s walked recursively, port connections aliased so net identity is preserved across the boundary. Hierarchical cell + netname prefixes (`u_b0.q`, `u_b0.\$slang\$adff\$3`) match Yosys-flatten output. Aliasing rewrites propagate globally across `_var_bits` / `_ports` / `_netnames` so chains like parent `a_q` ← child `q` collapse to a single net.
- **Diagnostics** — fatal pyslang diagnostics surfaced through `TextDiagnosticClient` with file:line:col + caret summaries (the compiler-error UX users already recognise).

## Parity matrix — 25/25

Every SDC-equipped fixture produces the same violation set as the Yosys frontend:

| Bad case | Rule | | Good case |
|---|---|---|---|
| bad_single_ff_sync | CDC-001 | | good_2ff_sync |
| bad_port_no_sync | CDC-001 | | good_gray_counter_crossing |
| bad_comb_before_sync | CDC-003 | | good_registered_before_sync |
| bad_bus_crossing | CDC-004 | | good_registered_source |
| bad_reconvergent_sync | CDC-005 | | good_exclusive_clock_mux |
| bad_comb_source | CDC-006 | | good_false_path_pair |
| bad_input_delay_cross_domain | CDC-006 | | good_generated_clock_div2 |
| bad_reset_crossing | CDC-007 | | good_port_typed_sync |
| bad_reset_tree | CDC-007 (grouped) | | good_input_delay_domain |
| bad_clock_as_data | CDC-008 | | good_reset_sync |
| bad_source_sync_chain | CDC-001 × 4 (4-module) | | good_source_sync_chain |
| | | | marked_user_sync (attribute suppression) |

The two `*_source_sync_internal` fixtures embed Yosys-internal `\$_BUF_` primitives in their SV source — slang correctly rejects them as not legal SystemVerilog. They stay Yosys-frontend-only by design and are excluded from the parity count.

## CLI surface — unchanged from PR #6

```bash
pip install 'rtl-buddy-cdc[slang]'
rtl-buddy-cdc lint --frontend slang --top my_top --sdc design.sdc rtl/*.sv
```

`analyze --netlist file.json` continues to be Yosys-only — it's a pre-elaborated-JSON entry, not a frontend choice. Default `lint` behaviour stays Yosys.

## Out of scope (documented in `frontends/slang.py` docstring)

Non-blocking for the existing fixture suite; will land if a future fixture or downstream usage drives the need:

- Concat / part-select / replication on the RHS (today emit `\$_UNKNOWN_` placeholder drivers).
- `always_comb` with `if` / `case` bodies that write the same LHS in multiple branches (today the last-walked branch wins; full lowering would emit `$mux` per LHS).
- Source-location propagation into `Cell.attributes["src"]` — pyslang carries source ranges; threading them into the JSON / SARIF reporter is a follow-up.
- Width-N `\$dff` / `\$adff` parameters (partially populated today; not yet read by any rule).

## Test plan

- [x] `uv run ruff check && uv run ruff format --check` — passes
- [x] `uv run pytest -q` — 113 passed, 2 skipped (the skips are the yosys-not-on-PATH lint-wrapper tests; gated identically to today)
- [x] New `tests/test_slang_elaboration.py` — 18 tests covering every rule's parity case + hierarchy assertions on emitted cell names
- [x] Full fixture sweep: 25/25 SDC-equipped fixtures produce the expected violation set
- [ ] Re-verify downstream rtl-buddy-project-template CDC regression once this lands; tracked in [rtl-buddy-project-template#21](https://github.com/rtl-buddy/rtl-buddy-project-template/issues/21) / [rtl-buddy-project-template#22](https://github.com/rtl-buddy/rtl-buddy-project-template/pull/22)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

Closes #5. With PR #6 (frontend abstraction + Stage 1 scaffolding) already merged and this PR landing full pyslang elaboration with 25/25 fixture parity, the goal stated in the issue body — "make good on the architecture's frontend-swappable design intent so a pyslang backend can be added incrementally and reach parity rule-by-rule" — is achieved. Polish items (concat lowering, source-location propagation, multi-branch always_comb mux'ing) are non-blocking and tracked in the `frontends/slang.py` docstring; if they grow into real workstreams they'll get their own issues.
