### PR TITLE
ci: run slang frontend tests on CI (#9)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,12 @@ on:
       - 'tests/**/*.py'
 
 jobs:
+  # Primary job: install with the [slang] extra so the pyslang-backed
+  # frontend tests (tests/test_slang_elaboration.py,
+  # tests/test_slang_lowering.py) actually run instead of skipping.
+  # Without --extra slang they're ~700 LOC of dead CI weight — see #9.
   pytest:
+    name: pytest (with slang) — py${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -32,8 +37,29 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
-      - name: Install test dependencies
-        run: uv sync --group test --python ${{ matrix.python-version }}
+      - name: Install test dependencies (with [slang] extra)
+        run: uv sync --extra slang --group test --python ${{ matrix.python-version }}
+
+      - name: Run pytest
+        run: uv run pytest -q
+
+  # Companion job: install WITHOUT the [slang] extra to verify the
+  # AGENTS.md "default install stays typer-only" promise. Specifically
+  # exercises the install-hint path in tests/test_frontend.py — the two
+  # tests skipped by PYSLANG_INSTALLED above run here.
+  pytest-no-slang:
+    name: pytest (default install, no pyslang)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install test dependencies (no extras)
+        run: uv sync --group test --python 3.13
 
       - name: Run pytest
         run: uv run pytest -q


### PR DESCRIPTION
## Summary

- Adds `--extra slang` to the existing `pytest` matrix job so ~700 LOC of slang-specific tests (`test_slang_elaboration.py`, `test_slang_lowering.py`) actually run on CI instead of skipping at module load.
- Adds a companion `pytest-no-slang` job on a single Python version (3.13) that installs the default (typer-only) deps. This keeps coverage of the install-hint path in `test_frontend.py` (the two `skipif(PYSLANG_INSTALLED)` tests) and gates the AGENTS.md "default install stays typer-only" promise.

The two existing skips are naturally symmetric — each job runs the tests the other skips:

| Job | Tests run | Tests skipped |
|---|---|---|
| `pytest (with slang)` matrix | 138 (incl. all slang frontend tests) | 2 install-hint tests |
| `pytest-no-slang` | 97 | 2 slang frontend modules |

Verified locally on a fresh `uv sync` against this branch's pyproject in a scratch dir:

- slang job: `138 passed, 2 skipped in 1.27s`
- no-slang job: `97 passed, 2 skipped in 0.39s`

pyslang 10.0.0 has manylinux x86_64 wheels for cp311/12/13, so the slang job uses prebuilt wheels (no C++ build on CI).

Fixes #9.

## Test plan

- [ ] Both jobs go green on this PR
- [ ] `pytest (with slang)` job log shows the slang tests run (not skip) — look for output from `test_slang_elaboration.py` / `test_slang_lowering.py`
- [ ] `pytest-no-slang` job log shows the install-hint tests run — look for `test_slang_frontend_missing_pyslang_errors_cleanly` and `test_cli_lint_slang_frontend_errors_cleanly_when_missing` actually executing
- [ ] No "pyslang not installed" or "pyslang is installed" skip lines that should have run

🤖 Generated with [Claude Code](https://claude.com/claude-code)