### PR TITLE
fix(slang): emit child-instance port netnames (#15)

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -486,6 +486,23 @@ class _ModuleBuilder:
             # instantiations of the same module don't share bits.
             self._var_bits[self._canonical_var(internal)] = parent_bits
             bound.add(internal)
+            # Also emit a netname for the port at ``<child_prefix><port_name>``
+            # so SDC pin paths like ``[get_pins u_a/clk_out_b0]`` resolve
+            # in domain.py's ``_build_bit_to_clock``. Yosys-flatten +
+            # opt_clean preserves both the port netname and the driving
+            # variable's netname as aliases of the same bits; without
+            # this, ``create_generated_clock`` declarations on internal
+            # pins are silently dropped (see issue #15).
+            #
+            # Bits are the parent-side connection bits at this point; if
+            # the body's continuous-assign aliasing later rewrites them
+            # (e.g. ``assign clk_out = div`` collapses both to ``div``'s
+            # freshly-allocated bits), ``_rewrite_aliased`` walks
+            # ``_netnames`` and updates this entry too.
+            port_netname = f"{parent_prefix}{child.name}.{port.name}"
+            self._netnames[port_netname] = Netname(
+                name=port_netname, bits=parent_bits, attributes={}
+            )
 
         child_prefix = f"{parent_prefix}{child.name}."
         self._walk_instance(

--- a/tests/fixtures/good_gen_clock_internal_pin/good_gen_clock_internal_pin.sdc
+++ b/tests/fixtures/good_gen_clock_internal_pin/good_gen_clock_internal_pin.sdc
@@ -1,0 +1,13 @@
+# SDC for good_gen_clock_internal_pin (regression fixture for issue #15).
+#
+# `ck_div` is forwarded from u_c's internal divider via a continuous
+# assign on the output port `clk_out`. The gen-clock target is the
+# child instance's output port pin — the case the slang frontend was
+# originally dropping.
+
+create_clock -name ck_in -period 10.0 [get_ports clk]
+
+create_generated_clock -name ck_div -source [get_ports clk] \
+    -master_clock ck_in -divide_by 2 [get_pins u_c/clk_out]
+
+set_input_delay -clock ck_in 0.0 [get_ports d]

--- a/tests/fixtures/good_gen_clock_internal_pin/good_gen_clock_internal_pin.sv
+++ b/tests/fixtures/good_gen_clock_internal_pin/good_gen_clock_internal_pin.sv
@@ -1,0 +1,58 @@
+// Regression fixture for issue #15: gen-clock target on a child
+// instance's output port pin must resolve under both frontends.
+//
+// The child module's output port is driven by an internal divider
+// flop via a continuous assign. After flattening, the SDC's
+// `[get_pins u_c/clk_out]` must resolve to a netname that the
+// `_build_bit_to_clock` lookup can find. Yosys-flatten + opt_clean
+// preserves both the port netname (`u_c.clk_out`) and the driver
+// (`u_c.div`) as aliases of the same bits; the slang frontend
+// originally only emitted the driver, which silently dropped the
+// gen-clock and collapsed the downstream flop's domain back to
+// `ck_in`. This fixture exists to prevent that regression.
+//
+// Topology: a 1-deep clock-divider chain with one downstream flop.
+//
+//   ck_in ──► u_c (div2) ──► ck_div ──► q_out
+//                ▲
+//                │ create_generated_clock at u_c/clk_out
+//
+// Expected (under both frontends):
+//   - 3 flops total (2 on ck_in inside u_c, 1 on ck_div for q_out).
+//   - 2 cross-domain crossings detected (the div feedback + the data
+//     hop into q_out).
+//   - 0 violations (synchronous via -master_clock chain back to ck_in).
+
+module child (
+  input  logic clk_in,
+  input  logic rst_n,
+  output logic clk_out,
+  input  logic d,
+  output logic q
+);
+  logic div;
+  always_ff @(posedge clk_in or negedge rst_n) begin
+    if (!rst_n) div <= 1'b0;
+    else        div <= ~div;
+  end
+  assign clk_out = div;          // alias output port to internal var
+
+  always_ff @(posedge clk_in or negedge rst_n) begin
+    if (!rst_n) q <= 1'b0;
+    else        q <= d;
+  end
+endmodule
+
+module good_gen_clock_internal_pin (
+  input  logic clk,
+  input  logic rst_n,
+  input  logic d,
+  output logic q_out
+);
+  logic ck_div, qmid;
+  child u_c (.clk_in(clk), .rst_n(rst_n), .clk_out(ck_div), .d(d), .q(qmid));
+  always_ff @(posedge ck_div or negedge rst_n) begin
+    if (!rst_n) q_out <= 1'b0;
+    else        q_out <= qmid;
+  end
+endmodule

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -258,3 +258,74 @@ def test_elaborated_module_has_expected_yosys_shape() -> None:
                 # Constant bits would be the string "0" / "1" / "x"
                 # / "z"; the canonical case here is all-integer.
                 assert isinstance(bit, (int, str))
+
+
+# --- Issue #15 regression: child-port netnames preserved as aliases --------
+
+
+def test_child_instance_port_netnames_emitted() -> None:
+    """Regression guard for issue #15: a child instance's output port
+    must appear in ``module.netnames`` keyed as ``<inst>.<port>``, even
+    when the port is driven by a continuous-assign aliasing pass that
+    collapses it to an internal variable's bits.
+
+    Without this, SDC pin paths like ``[get_pins u_c/clk_out]`` —
+    used by ``create_generated_clock`` declarations on internal pins —
+    silently miss the netname lookup in
+    :func:`rtl_buddy_cdc.domain._build_bit_to_clock`, every downstream
+    flop traces back to the master clock, and the analyzer reports
+    zero crossings on a design that should have several.
+    """
+    fix = FIX / "good_gen_clock_internal_pin"
+    module = elaborate(
+        [fix / "good_gen_clock_internal_pin.sv"],
+        "good_gen_clock_internal_pin",
+        frontend=Frontend.slang,
+    )
+    # The child's output port must be queryable as u_c.clk_out.
+    assert "u_c.clk_out" in module.netnames, sorted(module.netnames)
+    # And it must alias the inner driver bits — the whole point of
+    # preserving the netname is that the bits resolve to the same
+    # net the SDC declared the gen-clock on.
+    assert module.netnames["u_c.clk_out"].bits == module.netnames["u_c.div"].bits
+
+
+def test_internal_pin_gen_clock_resolves_under_slang() -> None:
+    """End-to-end: the same fixture + an SDC with a
+    ``create_generated_clock`` at the internal pin must reach the
+    domain assignment so that crossings are correctly identified.
+
+    Pre-fix slang would report 0 crossings here (all flops collapse
+    to ``ck_in``). Post-fix it must agree with yosys: 3 flops
+    distributed across 2 domains, 2 crossings, 0 violations
+    (synchronous via ``-master_clock`` chain — same-domain crossings
+    after resolve)."""
+    from rtl_buddy_cdc.domain import assign_domains, find_crossings
+
+    fix = FIX / "good_gen_clock_internal_pin"
+    module = elaborate(
+        [fix / "good_gen_clock_internal_pin.sv"],
+        "good_gen_clock_internal_pin",
+        frontend=Frontend.slang,
+    )
+    spec = sdc_mod.parse_file(fix / "good_gen_clock_internal_pin.sdc")
+    domains = assign_domains(module, pin_clocks=spec.pin_clocks)
+    # ``assign_domains`` returns the *top-level port name* for plain
+    # traces and the *gen-clock SDC name* when a tagged bit halts the
+    # walk. The SDC names the port `clk` as `ck_in`, but the trace
+    # surfaces the port name. The load-bearing assertion is that
+    # `ck_div` shows up at all — pre-fix, every flop collapsed to
+    # the port name and `ck_div` never appeared.
+    clocks = sorted({fd.clock for fd in domains})
+    assert clocks == ["ck_div", "clk"], clocks
+    # 3 flops: 2 inside u_c on the port-name domain, 1 on ck_div
+    # for the parent's q_out flop.
+    by_clock = {c: sum(1 for fd in domains if fd.clock == c) for c in clocks}
+    assert by_clock == {"ck_div": 1, "clk": 2}, by_clock
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    assert len(crossings) == 2, [(c.src_clock, c.dst_clock) for c in crossings]
+    # Synchronous via the gen-clock chain back to ck_in — no rule
+    # violations expected.
+    assert run_all(module, _filter_async(crossings, spec), spec) == []


### PR DESCRIPTION
Fixes #15.

## Root cause (from #15's investigation comment)

The slang frontend's `_emit_child_instance` aliases each port's internal-variable bits to the parent's connection expression but only emits a netname for the alias *target* (the inner driver, e.g. `u_a.div_b0`). The alias *source* (the port name, e.g. `u_a.clk_out_b0`) was never registered.

`domain.py:_build_bit_to_clock` consumes SDC pin paths like `[get_pins u_a/clk_out_b0]` by looking them up in `module.netnames`. With the port netname missing, the lookup silently returned None, no bits got tagged with the gen-clock, every flop downstream of an internal-pin `create_generated_clock` traced back to the master clock, and the analyzer reported zero crossings on designs that should have several.

The yosys frontend (post-flatten + opt_clean) preserves both the port netname and the driver as aliases of the same bits, which is why it didn't see this.

## Fix

In `_emit_child_instance`, after each port-connection alias, also emit `<child_prefix><port_name>` as a netname pointing at the parent's connection bits. Three things make this work without further plumbing:

1. The body's continuous-assign aliasing pass (`_rewrite_aliased`, line 1186) already walks `_netnames` and updates entries whose bits match the rewrite source, so the new netname stays synchronised when `assign clk_out = div` later collapses both to `div`'s freshly-allocated bits.
2. The patch lives entirely in `slang.py` — no pyslang or upstream slang change needed; the parent-side bits are already being computed for the existing aliasing.
3. `_collect_variable` skips port-internal vars that are in `bound_internals`, so there's no duplicate-netname collision: the port-backing variable inside the child body never re-emits a netname under its own name.

## Verification

### Self-test (the reproducer from #15)

End-to-end against the original repro (`demo_cdc_src_sync` in [rtl-buddy-project-template](https://github.com/rtl-buddy/rtl-buddy-project-template)):

| | flops | crossings |
|---|---|---|
| pre-fix slang | 9 (9 ck_a) | **0** |
| post-fix slang | 9 (3 ck_a, 2 ck_b0, 2 ck_b1, 1 ck_c0, 1 ck_c1) | **4** |
| yosys (unchanged) | same as post-fix slang | same |

Exact parity restored.

### Downstream verification against rtl-buddy-project-template#22

Built the template's [PR #22](https://github.com/rtl-buddy/rtl-buddy-project-template/pull/22) (the source of the original report) with this branch as an editable override, alongside [rtl_buddy#90](https://github.com/rtl-buddy/rtl_buddy/pull/90)'s branch (which adds the `rb cdc` per-analysis `frontend:` selector). With `frontend: "slang"` set on `demo_cdc_src_sync_lint`:

```
uv run rb cdc-regression -c lint/cdc/cdc_regression.yaml
```

|  CDC Analysis              | Result | Violations | Suppressed | Crossings | Frontend |
|----------------------------|--------|------------|------------|-----------|----------|
| ip_cdc_handshake_lint      | PASS   | 0          | 0          | 3         | yosys (default) |
| demo_tiny_alu_subsys_lint  | PASS   | 0          | 2          | 11        | yosys (default) |
| demo_cdc_src_sync_lint     | PASS   | 0          | 0          | **4**     | **slang** |

4 crossings on `demo_cdc_src_sync_lint` (was 0 pre-fix). The internal-pin gen-clock chain in `demo_cdc_src_sync.sdc` resolves correctly, per-analysis scoping is unaffected (the other two stay on yosys with their canonical numbers), and removing the `frontend:` field falls back cleanly to the yosys default with identical canonical counts.

## Tests

- **`tests/fixtures/good_gen_clock_internal_pin/`** — minimal SV+SDC reproducer (1-deep clock-divider chain with one downstream flop; child output port aliased to internal divider, gen-clock declared at the internal pin via `create_generated_clock -source [get_ports clk] -master_clock ck_in -divide_by 2 [get_pins u_c/clk_out]`).
- **`test_child_instance_port_netnames_emitted`** — pinpoint regression guard. Asserts `u_c.clk_out` is in `module.netnames` and shares bits with `u_c.div`. If the patch is reverted, this test fails immediately and points at the exact gap.
- **`test_internal_pin_gen_clock_resolves_under_slang`** — end-to-end. `assign_domains` returns 2 distinct clocks for the 3 flops, `find_crossings` returns 2 crossings, `run_all` returns no violations.

## Test plan

- [x] `uv run pytest -q` — 140 passed (+2 new), 2 skipped.
- [x] `uv run ruff check` + `ruff format --check` — clean.
- [x] Standalone `rtl-buddy-cdc lint --frontend slang` against the original `demo_cdc_src_sync` repro — yosys parity confirmed.
- [x] Downstream end-to-end against rtl-buddy-project-template#22 + rtl_buddy#90 — `--frontend slang` on `demo_cdc_src_sync_lint` reports 4 crossings (yosys parity); no-frontend baseline unchanged.
- [x] Reviewer to confirm the fix doesn't break port-name vs internal-var disambiguation in any of the existing slang fixtures (the 18 currently passing slang tests already exercise child instances with port aliasing — none broke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)