### PR TITLE
test: lock the JSON output schema with a contract test (#13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,9 @@ subprocess. The contract:
 - **JSON schema consumed today**: `summary.violations` (int),
   `summary.suppressed` (int), `summary.crossings` (int). Other
   fields can evolve freely; these three must keep their names and
-  types.
+  types. The contract is pinned in code by `reporter.JSON_CONTRACT`
+  plus `tests/test_reporter.py::test_json_contract_keys_present_and_typed`
+  — a rename or retype on either key fails the test.
 - **Exit codes**: 0 = clean (or fully waived), 1 = at least one
   unsuppressed violation, 2 = `lint`-only (yosys elaboration
   failed). The wrapper treats {0, 1} as "ran successfully" and

--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -30,6 +30,19 @@ TOOL_NAME = "rtl-buddy-cdc"
 TOOL_VERSION = "0.1.0"
 TOOL_INFO_URI = "https://github.com/rtl-buddy/rtl-buddy-cdc"
 
+# JSON output schema contract — these dotted keys are PUBLIC API.
+# Downstream ``rtl_buddy`` (sibling repo) parses them out of the JSON
+# report to populate its ``CdcResults`` summary. Renaming any key,
+# changing its type, or removing it from the payload is a
+# downstream-breaking change. Anything *else* in the JSON can evolve
+# freely. See AGENTS.md § "Cross-repo coupling" and
+# ``tests/test_reporter.py::test_json_contract_keys_are_stable``.
+JSON_CONTRACT: dict[str, type] = {
+    "summary.violations": int,
+    "summary.suppressed": int,
+    "summary.crossings": int,
+}
+
 # Short-form descriptions per rule. Keep this terse — the long-form
 # message is already attached to each result.
 _RULE_DESCRIPTIONS: dict[str, str] = {

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -13,12 +13,14 @@ from rtl_buddy_cdc.cli import _analyze_and_report  # noqa: PLC2701
 from rtl_buddy_cdc.cli import OutputFormat  # noqa: I001
 from rtl_buddy_cdc.domain import assign_domains, find_crossings
 from rtl_buddy_cdc.reporter import (
+    JSON_CONTRACT,
     AnalysisResult,
     render_json,
     render_sarif,
     render_text,
 )
 from rtl_buddy_cdc.rules import run_all as run_all_rules
+from rtl_buddy_cdc.waivers import apply as apply_waivers, parse as parse_waivers
 
 FIX_DIR = Path(__file__).parent / "fixtures" / "bad_single_ff_sync"
 JSON_PATH = FIX_DIR / "bad_single_ff_sync.json"
@@ -105,3 +107,115 @@ def test_cli_format_dispatch_to_file(tmp_path: Path) -> None:
     assert code == 1  # one CDC-001 violation
     payload = json.loads(out.read_text())
     assert payload["summary"]["violations"] == 1
+
+
+# --- JSON contract tests (issue #13) ----------------------------------------
+#
+# These pin the cross-repo JSON contract documented in AGENTS.md
+# "Cross-repo coupling". The downstream consumer (rtl_buddy via
+# rtl_buddy/src/rtl_buddy/tools/cdc_rtl_buddy.py) only depends on the
+# three keys named in ``JSON_CONTRACT``; everything else in the
+# payload can evolve freely. Renaming or retyping any of these is a
+# breaking change and must trip these tests.
+
+
+def _walk_dotted(payload: dict, dotted_path: str) -> object:
+    """Resolve ``"summary.violations"`` into ``payload["summary"]["violations"]``."""
+    node: object = payload
+    for part in dotted_path.split("."):
+        assert isinstance(node, dict), (
+            f"contract path {dotted_path!r}: expected dict at {part!r}, got {type(node).__name__}"
+        )
+        assert part in node, f"contract path {dotted_path!r}: missing key {part!r}"
+        node = node[part]
+    return node
+
+
+def test_json_contract_keys_present_and_typed(result: AnalysisResult) -> None:
+    """Every dotted key in ``JSON_CONTRACT`` must exist in the rendered
+    payload and resolve to the declared type. This is the load-bearing
+    test for the rtl-buddy ↔ rtl-buddy-cdc subprocess boundary; if it
+    fails, downstream ``CdcResults`` parsing will start blowing up."""
+    buf = io.StringIO()
+    render_json(result, buf)
+    payload = json.loads(buf.getvalue())
+    for dotted, expected_type in JSON_CONTRACT.items():
+        value = _walk_dotted(payload, dotted)
+        assert isinstance(value, expected_type), (
+            f"contract drift on {dotted!r}: expected {expected_type.__name__}, "
+            f"got {type(value).__name__} ({value!r})"
+        )
+
+
+def test_json_contract_includes_waived_run(result: AnalysisResult) -> None:
+    """``summary.violations`` decreases and ``summary.suppressed`` grows
+    when a matching waiver is applied — exercising BOTH contract keys
+    in one render. Without this, a regression that double-counts or
+    swaps the two could pass the previous test (each key is still an
+    int, just with the wrong value)."""
+    waivers = parse_waivers("waive CDC-001 procdff\\$9 reviewed\n")
+    kept, suppressed = apply_waivers(result.violations, waivers)
+    waived_result = AnalysisResult(
+        module=result.module,
+        domains=result.domains,
+        crossings=result.crossings,
+        async_crossings=result.async_crossings,
+        spec=result.spec,
+        violations=list(kept),
+        suppressed=list(suppressed),
+    )
+    buf = io.StringIO()
+    render_json(waived_result, buf)
+    payload = json.loads(buf.getvalue())
+    # All contract keys still typed correctly under a waivered run.
+    for dotted, expected_type in JSON_CONTRACT.items():
+        value = _walk_dotted(payload, dotted)
+        assert isinstance(value, expected_type), dotted
+    # And specifically: the single CDC-001 violation moved from the
+    # `violations` count to the `suppressed` count. This is the actual
+    # downstream semantics rtl-buddy keys off.
+    assert payload["summary"]["violations"] == 0
+    assert payload["summary"]["suppressed"] == 1
+    # The suppressed entry is preserved in the payload (not dropped)
+    # so SARIF and JSON consumers can show the waived alert.
+    assert len(payload["suppressed"]) == 1
+    assert payload["suppressed"][0]["rule_id"] == "CDC-001"
+    assert payload["suppressed"][0]["waiver"]["reason"] == "reviewed"
+
+
+def test_sarif_suppression_shape(result: AnalysisResult) -> None:
+    """SARIF emits suppressed findings with a ``suppressions`` field so
+    GitHub Code Scanning (and any other SARIF consumer) knows the alert
+    was intentionally hushed. The shape is fixed by SARIF 2.1.0 spec
+    + our convention; no test currently pins it."""
+    waivers = parse_waivers("waive CDC-001 procdff\\$9 reviewed by team\n")
+    kept, suppressed = apply_waivers(result.violations, waivers)
+    waived_result = AnalysisResult(
+        module=result.module,
+        domains=result.domains,
+        crossings=result.crossings,
+        async_crossings=result.async_crossings,
+        spec=result.spec,
+        violations=list(kept),
+        suppressed=list(suppressed),
+    )
+    buf = io.StringIO()
+    render_sarif(waived_result, buf)
+    data = json.loads(buf.getvalue())
+    results = data["runs"][0]["results"]
+    # The suppressed finding is still emitted (not dropped) so the
+    # alert exists; the suppressions field tells consumers not to fail
+    # the build on it.
+    assert len(results) == 1
+    entry = results[0]
+    assert entry["ruleId"] == "CDC-001"
+    assert "suppressions" in entry, (
+        "SARIF entry for a waived finding must carry a `suppressions` field"
+    )
+    supp = entry["suppressions"]
+    assert isinstance(supp, list) and len(supp) == 1
+    # Conventions: external waiver, accepted, with the user-provided
+    # reason copied into justification.
+    assert supp[0]["kind"] == "external"
+    assert supp[0]["status"] == "accepted"
+    assert supp[0]["justification"] == "reviewed by team"

--- a/wiki/concepts/waivers-and-reporting.md
+++ b/wiki/concepts/waivers-and-reporting.md
@@ -1,7 +1,7 @@
 ---
 title: Waivers and Reporting
 created: 2026-05-11
-updated: 2026-05-11
+updated: 2026-05-14
 type: concept
 tags: [waivers, reporting, cli, sarif, testing]
 sources: [raw/articles/rtl-buddy-cdc-architecture.md]
@@ -43,7 +43,7 @@ Three formatters share the same `AnalysisResult` input. Format selection is pure
 Human-readable. Module summary, domain counts, crossing list, then violations grouped by severity. Designed for terminal and CI-log review.
 
 ### `render_json`
-Full structured output with a stable schema. Used by `rb cdc` to extract violation counts and by custom dashboards. The downstream contract: `summary.violations` (int), `summary.suppressed` (int), `summary.crossings` (int).
+Full structured output with a stable schema. Used by `rb cdc` to extract violation counts and by custom dashboards. The downstream contract: `summary.violations` (int), `summary.suppressed` (int), `summary.crossings` (int). These three keys are pinned in code by `reporter.JSON_CONTRACT` and a paired test that fails on rename or retype — see `tests/test_reporter.py::test_json_contract_keys_present_and_typed`.
 
 ### `render_sarif`
 SARIF 2.1.0, GitHub Code Scanning compatible. Populates `tool.driver.rules` for every rule that fired. Each result carries `physicalLocation.region` parsed from `cell.attributes["src"]`. Suppressed findings emit with a `suppressions` field so the alert exists but doesn't fail the build.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -65,3 +65,9 @@
 - `README.md` — "MVP usable" framing → "Usable on IP-block-sized designs" with explicit mention of two frontends at parity; intro line names the slang frontend; refreshed Architecture ASCII diagram to show the `frontend.elaborate` factory with both backends (yosys + slang); new SARIF local-inspection pointer (VS Code SARIF Viewer + Microsoft's web component) at the end of the Output formats section
 - `pyproject.toml` — `description` rephrased from "Yosys-backed" to "with pluggable Yosys or slang (pyslang) frontend" (visible PyPI listing copy)
 - `src/rtl_buddy_cdc/cli.py` — `--frontend` Typer help no longer says slang is "in development — see issue #5"; replaced with the actual install hint (`pip install 'rtl-buddy-cdc[slang]'`)
+
+## [2026-05-14] update | JSON output schema contract pinned in code (#13)
+- New `reporter.JSON_CONTRACT` mapping (`summary.violations` / `summary.suppressed` / `summary.crossings` → `int`). Names the three load-bearing keys the rtl-buddy ↔ rtl-buddy-cdc subprocess boundary depends on — previously documented only in prose in AGENTS.md.
+- New tests in `tests/test_reporter.py`: `test_json_contract_keys_present_and_typed` (every contract key resolves to the declared type), `test_json_contract_includes_waived_run` (a waivered run exercises both `summary.violations` and `summary.suppressed` in the same render, catching value-swap regressions the first test alone would miss), `test_sarif_suppression_shape` (SARIF `suppressions: [{kind:external, status:accepted, justification:…}]` payload).
+- `concepts/waivers-and-reporting.md` — `render_json` section now cross-references the new constant + test.
+- `AGENTS.md` § "Cross-repo coupling" — JSON-schema bullet now points at the constant + test so a contributor changing the reporter knows where the contract is encoded.


### PR DESCRIPTION
## Summary

The rtl-buddy ↔ rtl-buddy-cdc subprocess boundary depends on three keys in the JSON report (``summary.violations`` / ``summary.suppressed`` / ``summary.crossings``). AGENTS.md documents this in prose; nothing in code or tests would fail if someone typoed `"violation"` in `render_json`. This PR pins the contract.

### Changes

- **`reporter.JSON_CONTRACT`** — public mapping from dotted-path → expected type. Three keys today; the same constant can grow as the contract grows.
- **Three new tests** in `tests/test_reporter.py`:
  - `test_json_contract_keys_present_and_typed` — walks every contract key and asserts presence + type. Catches renames and retypes.
  - `test_json_contract_includes_waived_run` — runs the same checks on a waivered `AnalysisResult` so BOTH `summary.violations` and `summary.suppressed` are exercised in one render. Without this, a swap of the two values would pass the first test (still ints, wrong meaning).
  - `test_sarif_suppression_shape` — pins the SARIF `suppressions: [{kind:external, status:accepted, justification:...}]` payload that no test previously covered.
- **Doc cross-links** — `AGENTS.md` § Cross-repo coupling + `wiki/concepts/waivers-and-reporting.md` now point at the new constant + test, so a contributor editing the reporter knows where the contract is encoded.
- **Wiki log entry** appended per SCHEMA.

### Verified

Manually corrupted the rendered payload to simulate two real regressions before committing — both caught:

```
GOOD (caught): contract path 'summary.violations': missing key 'violations'
GOOD (caught type drift on summary.violations): got str, expected int
```

Full suite: **143 passed / 2 skipped**, ruff clean.

Fixes #13.

## Test plan

- [x] Both CI jobs (`pytest (with slang)` matrix, `pytest-no-slang`) go green
- [x] The three new tests run and pass in both jobs (they don't depend on slang)
- [ ] If you locally typo a contract key in `reporter.render_json` — e.g. `"violation"` instead of `"violations"` — `test_json_contract_keys_present_and_typed` fails with a clear "missing key" message
- [x] AGENTS.md cross-link to the new constant resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)