### PR TITLE
test: cover four targeted rule-pack corners (#14)

### DIFF
--- a/tests/test_rule_corners.py
+++ b/tests/test_rule_corners.py
@@ -1,0 +1,204 @@
+"""Targeted regression tests for rule-pack code paths no committed
+fixture exercises (issue #14).
+
+The paired bad/good fixtures under ``tests/fixtures/`` give us broad
+coverage, but a handful of internal branches don't naturally fall out
+of any of them. Rather than build full SystemVerilog + SDC + Yosys-
+JSON fixtures for each, we construct the netlist directly as
+``netlist.Module`` dataclasses — same approach as
+``tests/test_rules_perf.py``. Self-contained, no toolchain dependency.
+"""
+
+from __future__ import annotations
+
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.netlist import Cell, Module, Port
+from rtl_buddy_cdc.rules import run_all
+from rtl_buddy_cdc.sdc import parse as parse_sdc
+
+
+# --- CDC-006 clock-port suppression (issue #14, gap 2) ----------------------
+
+
+def _build_clock_as_comb_to_sync_module() -> Module:
+    """A clock signal reaches a synchronizer's D pin through a single
+    combinational cell. Layout:
+
+        src_clk ──[$buf]──> sync_ff_A.D ──> sync_ff_A.Q ──> sync_ff_B.D
+        dst_clk ────────────> sync_ff_A.CLK
+        dst_clk ────────────> sync_ff_B.CLK
+        sync_ff_B.Q ────────> dst_q (output)
+
+    Both sync_ff_* flops are clocked by ``dst_clk`` and form a depth-2
+    sync chain. The path from sync_ff_A's D backward through the buffer
+    lands on the ``src_clk`` top-level *clock* port — exactly the shape
+    that ``rules.check_cdc_006``'s ``if p in clock_ports: continue``
+    branch is meant to suppress. CDC-008 separately fires on the
+    buffer reading a clock bit on its A pin.
+    """
+    src_clk_bit = 2
+    dst_clk_bit = 3
+    mid_bit = 4
+    q_a_bit = 5
+    output_bit = 6
+
+    ports: dict[str, Port] = {
+        "src_clk": Port(name="src_clk", direction="input", bits=(src_clk_bit,)),
+        "dst_clk": Port(name="dst_clk", direction="input", bits=(dst_clk_bit,)),
+        "dst_q": Port(name="dst_q", direction="output", bits=(output_bit,)),
+    }
+    cells: dict[str, Cell] = {
+        "clk_data_buf": Cell(
+            name="clk_data_buf",
+            type="$buf",
+            connections={"A": (src_clk_bit,), "Y": (mid_bit,)},
+        ),
+        "sync_ff_A": Cell(
+            name="sync_ff_A",
+            type="$dff",
+            connections={
+                "CLK": (dst_clk_bit,),
+                "D": (mid_bit,),
+                "Q": (q_a_bit,),
+            },
+        ),
+        "sync_ff_B": Cell(
+            name="sync_ff_B",
+            type="$dff",
+            connections={
+                "CLK": (dst_clk_bit,),
+                "D": (q_a_bit,),
+                "Q": (output_bit,),
+            },
+        ),
+    }
+    return Module(name="clock_as_comb_to_sync", ports=ports, cells=cells, netnames={})
+
+
+_CLOCK_AS_DATA_SDC = """
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+"""
+
+
+def test_cdc_006_suppresses_clock_port_in_fanin() -> None:
+    """CDC-006 fans backward from a synchronizer's D pin and reports
+    any unregistered top-level port it reaches. The rule deliberately
+    *suppresses* ports declared as clocks in the SDC: a clock signal
+    arriving on a flop's D pin via comb is a CDC-008 finding ("clock
+    used as data"), not a CDC-006 finding ("glitchy comb source").
+
+    Without this branch the analyzer would double-report every clock-
+    as-data shape — once correctly as CDC-008 and once incorrectly as
+    CDC-006. This test guards the de-duplication.
+    """
+    module = _build_clock_as_comb_to_sync_module()
+    spec = parse_sdc(_CLOCK_AS_DATA_SDC)
+    crossings = find_crossings(module)
+    violations = run_all(module, crossings, spec)
+    rule_ids = sorted({v.rule_id for v in violations})
+    assert "CDC-008" in rule_ids, (
+        f"expected CDC-008 to fire on the buffer reading src_clk; got rules: {rule_ids}"
+    )
+    assert "CDC-006" not in rule_ids, (
+        "CDC-006 must NOT fire — its fanin reaches only a clock port, "
+        "which the rule suppresses to avoid double-reporting with "
+        f"CDC-008. Got: {rule_ids}"
+    )
+
+
+# --- find_crossings hop budget (issue #14, gap 3) ---------------------------
+
+
+def _build_deep_comb_module(num_buffers: int) -> Module:
+    """Two flops in different domains connected by ``num_buffers``
+    chained ``$buf`` cells. The shortest combinational distance between
+    the source flop's Q and the destination flop's D pin equals
+    ``num_buffers``; ``find_crossings``'s ``max_hops`` budget must be
+    at least that value for the crossing to be discovered.
+    """
+    src_clk_bit = 2
+    dst_clk_bit = 3
+    src_d_bit = 4
+    src_q_bit = 5
+    # One intermediate bit per buffer output.
+    buf_out_bits = list(range(6, 6 + num_buffers))
+    dst_q_bit = buf_out_bits[-1] + 1
+
+    ports: dict[str, Port] = {
+        "src_clk": Port(name="src_clk", direction="input", bits=(src_clk_bit,)),
+        "dst_clk": Port(name="dst_clk", direction="input", bits=(dst_clk_bit,)),
+        "src_d": Port(name="src_d", direction="input", bits=(src_d_bit,)),
+        "dst_q": Port(name="dst_q", direction="output", bits=(dst_q_bit,)),
+    }
+    cells: dict[str, Cell] = {
+        "src_ff": Cell(
+            name="src_ff",
+            type="$dff",
+            connections={
+                "CLK": (src_clk_bit,),
+                "D": (src_d_bit,),
+                "Q": (src_q_bit,),
+            },
+        ),
+    }
+    # Chain of buffers: src_q_bit → buf0 → buf1 → ... → buf{N-1} → dst_ff.D
+    prev = src_q_bit
+    for i, out_bit in enumerate(buf_out_bits):
+        cells[f"buf_{i}"] = Cell(
+            name=f"buf_{i}",
+            type="$buf",
+            connections={"A": (prev,), "Y": (out_bit,)},
+        )
+        prev = out_bit
+    cells["dst_ff"] = Cell(
+        name="dst_ff",
+        type="$dff",
+        connections={
+            "CLK": (dst_clk_bit,),
+            "D": (prev,),
+            "Q": (dst_q_bit,),
+        },
+    )
+    return Module(name="deep_comb_chain", ports=ports, cells=cells, netnames={})
+
+
+def test_find_crossings_hop_budget_drops_paths_beyond_default() -> None:
+    """The default ``max_hops=4`` budget caps comb-cone walks. A
+    crossing reached only via a 5-buffer chain is correctly classified
+    as "no longer directly connecting" — important load-bearing
+    contract because we don't want a rule false-fire on a path that
+    Yosys' synthesis might restructure beyond recognition.
+    """
+    module = _build_deep_comb_module(num_buffers=5)
+    crossings = find_crossings(module)  # default max_hops=4
+    assert crossings == [], (
+        "expected zero crossings at default max_hops=4 with a 5-buffer "
+        f"chain; got {[(c.src_name, c.dst_flop.name, c.min_hops) for c in crossings]}"
+    )
+
+
+def test_find_crossings_hop_budget_finds_path_when_raised() -> None:
+    """Raising ``max_hops`` to ≥5 reveals the same crossing the default
+    budget hid. Pins the contract that the budget is the *only* knob
+    controlling discovery depth — there's no hidden second cap."""
+    module = _build_deep_comb_module(num_buffers=5)
+    crossings = find_crossings(module, max_hops=5)
+    assert len(crossings) == 1, (
+        f"expected exactly one crossing at max_hops=5; got {len(crossings)}"
+    )
+    c = crossings[0]
+    assert c.src_flop is not None and c.src_flop.cell.name == "src_ff"
+    assert c.dst_flop.cell.name == "dst_ff"
+    assert c.min_hops == 5  # 5 buffers between them
+
+
+def test_find_crossings_hop_budget_boundary_at_exact_match() -> None:
+    """At a chain length exactly equal to ``max_hops``, the crossing is
+    detected. Pins the inclusive boundary — easy to flip by an off-by-
+    one in the BFS frontier check."""
+    module = _build_deep_comb_module(num_buffers=4)
+    crossings = find_crossings(module)  # default max_hops=4
+    assert len(crossings) == 1
+    assert crossings[0].min_hops == 4

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -163,6 +163,23 @@ def test_false_path_pin_endpoint_is_partial_warning() -> None:
     assert any("non-clock endpoints" in w for w in spec.partial_warnings)
 
 
+def test_false_path_rise_from_fall_to_recognized() -> None:
+    """``-rise_from`` and ``-fall_to`` are recognised endpoint flags
+    (sdc.py ``_ENDPOINT_FLAGS``). A path declared via the edge-specific
+    variants must produce the same async pair as plain ``-from``/``-to``
+    — the rule pack doesn't model edge phase, so the edge qualifier is
+    informational only (issue #14, gap 4)."""
+    spec = parse(
+        """
+        create_clock -name a -period 10 [get_ports a]
+        create_clock -name b -period 7  [get_ports b]
+        set_false_path -rise_from [get_clocks a] -fall_to [get_clocks b]
+        """
+    )
+    assert spec.are_async("a", "b")
+    assert spec.are_async("b", "a")
+
+
 # ---- exclusive groups -------------------------------------------------------
 
 
@@ -190,6 +207,31 @@ def test_physically_exclusive_groups() -> None:
         """
     )
     assert spec.is_unreachable_crossing("ck0", "ck1")
+
+
+def test_set_clock_groups_brace_with_spaces_inside() -> None:
+    """When braces have spaces inside (``{ ck0 } -group { ck1 }``)
+    shlex splits ``{`` and ``ck0`` into separate tokens. The handler's
+    brace-split re-glob fallback (sdc.py ``_extract_clock_list(args[i+1]
+    + " " + args[i+2])``) recovers the clock name from the next token
+    instead of dropping the group (issue #14, gap 4).
+
+    Note: today the fallback recovers only the *first* clock when a
+    multi-clock group has internal spaces (``{ ck0 ck1 }``); that
+    quirk is a parser limitation, not a target of this regression
+    sentinel. This test pins the single-clock case the fallback was
+    written for."""
+    spec = parse(
+        """
+        create_clock -name ck0 -period 10 [get_ports ck0]
+        create_clock -name ck1 -period 7  [get_ports ck1]
+        set_clock_groups -asynchronous -group { ck0 } -group { ck1 }
+        """
+    )
+    # Both clocks declared and async-grouped despite the brace-padding
+    # that splits the tokens. Without the re-glob fallback, both groups
+    # would collapse to empty and `are_async` would return False.
+    assert spec.are_async("ck0", "ck1")
 
 
 def test_set_clock_groups_without_kind_warns() -> None:

--- a/tests/test_waivers.py
+++ b/tests/test_waivers.py
@@ -102,6 +102,63 @@ def test_cli_waiver_drops_exit_code(tmp_path: Path) -> None:
     assert "reviewed" in text
 
 
+def test_cli_waiver_drops_exit_code_json(tmp_path: Path) -> None:
+    """End-to-end with ``--format json`` (issue #14, gap 1).
+
+    The text-format equivalent above doesn't exercise the JSON dispatch
+    branch in ``cli._analyze_module_and_report`` or the JSON reporter's
+    ``suppressed[]`` array — a regression that swapped the json/text
+    dispatch or dropped the ``waiver`` payload would slip through with
+    only the text test in place.
+    """
+    if not JSON_PATH.exists():
+        pytest.skip(f"fixture not built: {JSON_PATH}")
+    import json as _json
+
+    waiver_file = tmp_path / "cdc.waivers"
+    waiver_file.write_text("waive CDC-001 procdff\\$9 reviewed\n")
+    out = tmp_path / "report.json"
+    code = _analyze_and_report(JSON_PATH, SDC_PATH, waiver_file, OutputFormat.json, out)
+    assert code == 0  # fully waived → exit 0 same as text path
+    payload = _json.loads(out.read_text())
+    assert payload["summary"]["violations"] == 0
+    assert payload["summary"]["suppressed"] == 1
+    assert len(payload["suppressed"]) == 1
+    assert payload["suppressed"][0]["rule_id"] == "CDC-001"
+    assert payload["suppressed"][0]["waiver"]["reason"] == "reviewed"
+
+
+def test_cli_waiver_drops_exit_code_sarif(tmp_path: Path) -> None:
+    """End-to-end with ``--format sarif`` (issue #14, gap 1).
+
+    SARIF consumers (GitHub Code Scanning, etc.) key off the
+    ``suppressions`` field to decide whether an alert fails the
+    build. This test pins the CLI plumbing: a waiver matching the only
+    violation should leave the alert in the SARIF output but flag it as
+    suppressed, and drive the exit code to 0.
+    """
+    if not JSON_PATH.exists():
+        pytest.skip(f"fixture not built: {JSON_PATH}")
+    import json as _json
+
+    waiver_file = tmp_path / "cdc.waivers"
+    waiver_file.write_text("waive CDC-001 procdff\\$9 reviewed by team\n")
+    out = tmp_path / "report.sarif"
+    code = _analyze_and_report(
+        JSON_PATH, SDC_PATH, waiver_file, OutputFormat.sarif, out
+    )
+    assert code == 0
+    data = _json.loads(out.read_text())
+    results = data["runs"][0]["results"]
+    assert len(results) == 1
+    entry = results[0]
+    assert entry["ruleId"] == "CDC-001"
+    assert "suppressions" in entry
+    assert entry["suppressions"][0]["kind"] == "external"
+    assert entry["suppressions"][0]["status"] == "accepted"
+    assert entry["suppressions"][0]["justification"] == "reviewed by team"
+
+
 def test_cli_no_waiver_still_fails(tmp_path: Path) -> None:
     if not JSON_PATH.exists():
         pytest.skip(f"fixture not built: {JSON_PATH}")

--- a/wiki/concepts/cdc-testing-strategy.md
+++ b/wiki/concepts/cdc-testing-strategy.md
@@ -31,6 +31,8 @@ Each CDC rule has at least one **bad fixture** (designed to fire it) and one **g
 | `test_slang_elaboration.py` | Rule-parity tests for the [[elaboration-frontends\|slang frontend]] on every SDC-equipped fixture |
 | `test_slang_lowering.py` | Operator-coverage tests for slang lowering (binary/unary/conditional/concat/replication/`always_comb`) |
 | `test_smoke.py` | `--help` and `version` CLI smoke |
+| `test_rule_corners.py` | Hand-built synthetic `Module`s exercising rule-pack branches no fixture naturally hits (CDC-006 clock-port suppression, `find_crossings` hop-budget boundary) |
+| `test_rules_perf.py` | Synthetic 500-flop micro-benchmark — regression sentinel for the `_RuleContext` memoisation |
 
 ### JSON Fixtures
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -78,3 +78,12 @@
 - New tests in `tests/test_reporter.py`: `test_json_contract_keys_present_and_typed` (every contract key resolves to the declared type), `test_json_contract_includes_waived_run` (a waivered run exercises both `summary.violations` and `summary.suppressed` in the same render, catching value-swap regressions the first test alone would miss), `test_sarif_suppression_shape` (SARIF `suppressions: [{kind:external, status:accepted, justification:…}]` payload).
 - `concepts/waivers-and-reporting.md` — `render_json` section now cross-references the new constant + test.
 - `AGENTS.md` § "Cross-repo coupling" — JSON-schema bullet now points at the constant + test so a contributor changing the reporter knows where the contract is encoded.
+
+## [2026-05-14] update | targeted coverage for rule-pack corners (#14)
+- New `tests/test_waivers.py::test_cli_waiver_drops_exit_code_json` + `..._sarif` — end-to-end CLI plumbing for waivered runs in JSON and SARIF formats. The pre-existing text-format test left both dispatches unverified; a swap or drop of the `suppressed[]` / `suppressions` payload would have slipped through.
+- New `tests/test_rule_corners.py` (file added) — hand-built synthetic `Module`s exercising:
+  - **CDC-006's clock-port suppression** (rules.py `if p in clock_ports: continue`): a clock signal reaches a synchronizer's D pin through a `$buf`; CDC-008 fires, CDC-006 must stay quiet. Verified before commit that the test goes red if the suppression branch is bypassed (manually re-ran with an empty `ClockSpec` and observed a CDC-006 false-positive).
+  - **`find_crossings` hop budget**: three boundary cases — 5-buffer chain hidden at default `max_hops=4`, revealed at `max_hops=5`, exact-match at `max_hops=4` with a 4-buffer chain (inclusive boundary).
+- New `tests/test_sdc.py::test_false_path_rise_from_fall_to_recognized` — `_ENDPOINT_FLAGS` covers `-rise_from` / `-fall_from` / `-rise_to` / `-fall_to` but no test exercised the edge-qualified variants.
+- New `tests/test_sdc.py::test_set_clock_groups_brace_with_spaces_inside` — pins the brace-split re-glob fallback in `_handle_set_clock_groups` (the `_extract_clock_list(args[i+1] + " " + args[i+2])` path) for the single-clock case it currently handles. The fallback's multi-clock case has a known limitation (only the first clock survives) documented in the test docstring — separate concern.
+- `concepts/cdc-testing-strategy.md` — Test Files table extended with `test_rule_corners.py` and `test_rules_perf.py` (the latter was added in #12 but missed in the table refresh).


### PR DESCRIPTION
## Summary

Closes the four targeted coverage gaps named in #14. Each was a code path the existing 25-fixture suite walks past; none needed new fixtures — the new rule-pack tests construct synthetic ``netlist.Module`` dataclasses directly (same approach as ``tests/test_rules_perf.py`` from #12).

Suite: **144 → 152 passed** (+8 new tests), 2 skipped, ruff clean.

### Gap 1 — CLI dispatch for waivers in JSON/SARIF

Existing ``test_cli_waiver_drops_exit_code`` only covered ``--format text``. New tests mirror it for JSON and SARIF:

- `test_cli_waiver_drops_exit_code_json` — asserts `summary.violations` drops to 0, `summary.suppressed` grows to 1, and the `suppressed[]` payload carries the rule_id + waiver reason.
- `test_cli_waiver_drops_exit_code_sarif` — asserts the SARIF result entry carries `suppressions: [{kind:external, status:accepted, justification:...}]`.

### Gap 2 — CDC-006 clock-port suppression

`rules.check_cdc_006` deliberately suppresses fanin ports that are declared as clocks in the SDC (to avoid double-reporting with CDC-008). No fixture wires a clock port through comb into a sync's D pin, so the branch was untested. New test `test_cdc_006_suppresses_clock_port_in_fanin` builds the synthetic shape:

```
src_clk ──[$buf]──> sync_ff_A.D ──> sync_ff_A.Q ──> sync_ff_B.D
dst_clk ────────────> sync_ff_A.CLK + sync_ff_B.CLK
```

Asserts CDC-008 fires (clock-as-data on the buffer), CDC-006 stays silent. **Verified before commit that the test goes red if the suppression branch is bypassed** (re-ran the same module with an empty `ClockSpec` and observed a CDC-006 false-positive reaching `src_clk`).

### Gap 3 — `find_crossings` hop budget

Three new cases pin the boundary on the default `max_hops=4`:
- 5-buffer chain at default budget → no crossings detected ✓
- Same chain at `max_hops=5` → exactly one crossing, `min_hops=5` ✓
- 4-buffer chain at `max_hops=4` → crossing detected (inclusive boundary) ✓

### Gap 4 — SDC parser corners

- `test_false_path_rise_from_fall_to_recognized` — `-rise_from` / `-fall_to` (and the two other edge-qualified variants in `_ENDPOINT_FLAGS`) recognised as async-pair hints same as plain `-from` / `-to`.
- `test_set_clock_groups_brace_with_spaces_inside` — pins the brace-split re-glob fallback in `_handle_set_clock_groups` for the single-clock case it handles (`-group { ck0 } -group { ck1 }`).

### Known limitation surfaced (not fixed here)

While investigating gap 4 I confirmed `_handle_set_clock_groups` loses all clocks after the first when a multi-clock brace group has internal spaces (`-group { ck0 ck1 }` ⇒ only `ck0` recovered). This is a separate parser issue — documented inline in the new test's docstring; not addressed in this PR.

Fixes #14.

## Test plan

- [ ] Both CI jobs (`pytest (with slang)` matrix, `pytest-no-slang`) go green
- [ ] All 8 new tests run on both jobs (no slang dependency)
- [ ] Locally bypassing the CDC-006 clock-port suppression (e.g. removing the `if p in clock_ports: continue` line) makes `test_cdc_006_suppresses_clock_port_in_fanin` fail with a "CDC-006 must NOT fire" message — confirms the test is meaningful, not vacuous

🤖 Generated with [Claude Code](https://claude.com/claude-code)