### PR TITLE
feat(cli): version command reports pyslang version when installed (#25)

### DIFF
--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -220,7 +220,7 @@ def lint(
 
 @app.command()
 def version() -> None:
-    """Print yosys and tool versions."""
+    """Print tool, yosys, and (when installed) pyslang versions."""
     typer.echo("rtl-buddy-cdc 0.1.0")
     yosys = shutil.which("yosys")
     if yosys:
@@ -230,6 +230,17 @@ def version() -> None:
         typer.echo(out)
     else:
         typer.echo("yosys: not found on PATH")
+
+    # pyslang is the slang frontend's optional runtime dep. We probe via
+    # importlib.metadata (not the lazy import in frontends/slang.py)
+    # because we want the wheel version, not the slang C++ build the
+    # wheel wraps — bug-report diagnostics key on the former.
+    import importlib.metadata as _md
+
+    try:
+        typer.echo(f"pyslang: {_md.version('pyslang')}")
+    except _md.PackageNotFoundError:
+        typer.echo("pyslang: not installed (optional; install with the [slang] extra)")
 
 
 # --- shared analysis path ---------------------------------------------------

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -15,3 +15,14 @@ def test_version_runs() -> None:
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
     assert "rtl-buddy-cdc" in result.stdout
+
+
+def test_version_reports_pyslang_line() -> None:
+    """The version command must always emit a pyslang status line — a
+    bare ``pyslang: <version>`` when the optional extra is installed,
+    or ``pyslang: not installed`` otherwise. Bug reports involving
+    ``--frontend slang`` benefit from this diagnostic; the line being
+    *unconditional* is the contract (#25)."""
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "pyslang:" in result.stdout


### PR DESCRIPTION
## Summary

Adds a third line to `rtl-buddy-cdc version` covering the slang frontend's optional runtime dep. Bug reports involving `--frontend slang` benefit from this diagnostic — before this change there was no way to tell which pyslang wheel was in the env without poking around the venv.

### Example output

With `[slang]` extra installed:

```
rtl-buddy-cdc 0.1.0
Yosys 0.64+190 (...)
pyslang: 10.0.0
```

Without:

```
rtl-buddy-cdc 0.1.0
Yosys 0.64+190 (...)
pyslang: not installed (optional; install with the [slang] extra)
```

### Implementation

Probes via `importlib.metadata.version("pyslang")` rather than importing the module:

- Reports the **wheel** version (what `pip install pyslang==X` would reproduce), not the underlying slang C++ build that `pyslang.VersionInfo` exposes.
- Always prints either-or — never raises ImportError out of the version command itself.

### Tests

New `test_version_reports_pyslang_line` in `tests/test_smoke.py` asserts the `pyslang:` prefix appears unconditionally. Both CI jobs (`pytest (with slang)` matrix and `pytest-no-slang`) run the same test — the prefix is on both branches, so coverage falls out for free.

Suite: **154 → 155 passed**, 2 skipped, ruff clean.

Fixes #25.

## Test plan

- [x] Both CI jobs go green
- [ ] On the slang job: log shows `pyslang: 10.0.0` (or whatever's in `uv.lock`)
- [ ] On the no-slang job: log shows `pyslang: not installed (optional; install with the [slang] extra)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)