### PR TITLE
Add --strict, --baseline, and Frontend.auto (#29, #30, #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--strict` flag** on `analyze` and `lint` (#29). Promotes every
+  `warning`-severity violation (CDC-002, CDC-005 today) to `error`
+  before reporters see it, so the text banner, JSON `severity`, and
+  SARIF `level` all render as `error`. Exit code is unchanged — any
+  kept violation already drives exit 1; the flag is reframing, not
+  gating. Suppressed findings and baseline-carried findings are left
+  alone (by definition they don't drive exit-code outcomes).
+- **`--baseline FILE.json` flag** on `analyze` and `lint` (#30).
+  Filters out findings present in a prior JSON report (matched on
+  `(rule_id, cell_name, message)`) and surfaces them as a separate
+  "Carried over from baseline" tally; the carryover set never drives
+  the exit code. JSON output gains `summary.baseline_carryover`
+  (int) and a top-level `baseline_carryover` list; SARIF emits each
+  carryover entry with a `suppressions` field tagged
+  `carried over from baseline`. Baseline chains: a finding already
+  in the baseline's `baseline_carryover` list stays carried over on
+  the next run too, so re-baselining doesn't re-flag inherited
+  findings.
+- **`Frontend.auto`** + `--frontend auto` (#31). Probes
+  `importlib.util.find_spec("pyslang")` at runtime and dispatches to
+  `slang` when pyslang is importable, falling back to `yosys`
+  otherwise. The default frontend stays `yosys` — `auto` is opt-in
+  via the CLI. The `lint` preamble shows the *resolved* frontend
+  (`frontend: yosys (auto)`) so log scrapers never see a third
+  value.
+
+### Changed
+
+- JSON output now exposes a `cell_name` field on every violation
+  entry. This is additive — existing `JSON_CONTRACT` keys keep their
+  names and types — and gives `--baseline` a stable per-cell handle
+  for the match key.
+
 ## [0.2.0] — 2026-05-15
 
 `0.2.0` is the first release after the slang frontend reached parity

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Primary mode (`analyze`):
 | Yosys netlist JSON | yes | Flattened design (output of `write_json`) |
 | **SDC** (`.sdc`) | recommended | Clock declarations + async groups; without it, rule checks are skipped and the run is just a structural summary |
 | Waiver file | optional | Per-violation suppression with reason (see [Waivers](#waivers)) |
+| `--baseline FILE.json` | optional | Filter out findings already present in a prior JSON report; the carried-over set is surfaced as a separate tally and never drives the exit code. Useful for "fail PR only on new findings". Matches on `(rule_id, cell_name, message)`. |
+| `--strict` | optional | Promote every `warning`-severity violation to `error` before reporting (see [Rules](#rules)). Exit code is unchanged — the flag is reframing, not gating. |
 
 Standalone wrapper (`lint`):
 
@@ -100,7 +102,7 @@ Standalone wrapper (`lint`):
 |---|---|---|
 | Verilog / SystemVerilog sources | yes | Design under analysis |
 | Top module name (`--top`) | yes | Elaboration root |
-| `--frontend {yosys,slang}` | optional | Elaboration frontend. `yosys` (default) shells out to `yosys` and runs `hierarchy; proc; flatten; opt_clean`. `slang` elaborates via the [pyslang](https://pypi.org/project/pyslang/) binding directly — no synth step, no Yosys runtime dependency. Reaches parity with the Yosys frontend on every paired *bad/good* fixture in the regression suite. |
+| `--frontend {yosys,slang,auto}` | optional | Elaboration frontend. `yosys` (default) shells out to `yosys` and runs `hierarchy; proc; flatten; opt_clean`. `slang` elaborates via the [pyslang](https://pypi.org/project/pyslang/) binding directly — no synth step, no Yosys runtime dependency. `auto` picks `slang` when pyslang is importable and falls back to `yosys` otherwise; useful in CI matrices where some jobs install the `[slang]` extra and others don't. Reaches parity with the Yosys frontend on every paired *bad/good* fixture in the regression suite. |
 | `--yosys PATH` | optional | Yosys frontend only: override the default yosys binary lookup |
 | `--keep-json PATH` | optional | Yosys frontend only: save the intermediate netlist for debugging or re-runs |
 
@@ -127,10 +129,10 @@ If no SDC is supplied, the tool prints a structural summary and skips all rule c
 | ID | Severity | What it catches |
 |---|---|---|
 | **CDC-001** | error | Unsynchronized control crossing — destination flop has no second-stage synchronizer (chain depth = 1). Fires on flop→flop and (when `set_input_delay -clock <c>` types the source) port→flop crossings. |
-| **CDC-002** | warning | Insufficient synchronizer depth — chain present but shorter than the project's `--sync-depth` (default 2 = silent; raise to 3+ for high-speed / low-MTBF designs). Fires on flop→flop and typed port→flop crossings. |
+| **CDC-002** | warning (`--strict` → error) | Insufficient synchronizer depth — chain present but shorter than the project's `--sync-depth` (default 2 = silent; raise to 3+ for high-speed / low-MTBF designs). Fires on flop→flop and typed port→flop crossings. |
 | **CDC-003** | error | Combinational logic between source flop and synchronizer first stage — gate output can glitch and be sampled |
 | **CDC-004** | error | Multi-bit bus crossing without recognized gating or gray-coding (canonical `g = b ^ (b >> 1)` pattern detected structurally; `(* cdc_gray *)` is the explicit escape hatch) |
-| **CDC-005** | warning | Reconvergent synchronizers — one source flop fans out to multiple sync chains with independent metastability resolution |
+| **CDC-005** | warning (`--strict` → error) | Reconvergent synchronizers — one source flop fans out to multiple sync chains with independent metastability resolution |
 | **CDC-006** | error | Glitchy combinational source — synchronizer is fed by combinational logic with no registering flop, reaching unregistered top-level ports. Suppressed when `set_input_delay -clock <my_clk>` types the port into the destination flop's own clock domain (port is asserted same-domain). |
 | **CDC-007** | error | Async reset crossing — flop's `ARST` is driven by a flop in a different async clock domain, no reset synchronizer. Violations are grouped by the shared async source: one report per source listing every destination flop it feeds (the typical reset-distribution-tree shape). |
 | **CDC-008** | error | Clock signal used as data — clock-network bit reaches a non-CLK input (flop `D`/`ARST`, comb input, etc.); cells that themselves drive a flop CLK are exempted (legitimate ICG / clock muxes / dividers) |

--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+import json
 import shutil
 import subprocess
 import sys
@@ -11,7 +13,7 @@ import typer
 
 from rtl_buddy_cdc import netlist, reporter, sdc as sdc_mod, waivers as waivers_mod
 from rtl_buddy_cdc.domain import Crossing, assign_domains, find_crossings
-from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.frontend import Frontend, elaborate, resolve_auto
 from rtl_buddy_cdc.frontends.slang import SlangFrontendUnavailable
 from rtl_buddy_cdc.frontends.yosys import YosysError
 from rtl_buddy_cdc.reporter import AnalysisResult
@@ -61,6 +63,25 @@ _COLOR_OPT = typer.Option(
     help="Force color on/off for the text report. Default: auto (color "
     "when stdout is a TTY and NO_COLOR is unset).",
 )
+_STRICT_OPT = typer.Option(
+    False,
+    "--strict",
+    help="Promote every `warning`-severity violation to `error` before "
+    "reporting. CDC-002 and CDC-005 are the rules affected today; the "
+    "exit code is unchanged (any kept violation already drives exit 1) "
+    "— the flag is reframing, not gating.",
+)
+_BASELINE_OPT = typer.Option(
+    None,
+    "--baseline",
+    exists=True,
+    readable=True,
+    help="Path to a baseline JSON report (a prior `--format json` "
+    "output). Violations matching baseline entries by "
+    "(rule_id, cell_name, message) are filtered out of the kept set "
+    "and surfaced as a 'Carried over from baseline' tally; they don't "
+    "drive the exit code. Useful for 'fail PR only on new findings'.",
+)
 
 
 @app.command()
@@ -96,6 +117,8 @@ def analyze(
     sync_depth: int = _SYNC_DEPTH_OPT,
     verbose: bool = _VERBOSE_OPT,
     color: bool | None = _COLOR_OPT,
+    strict: bool = _STRICT_OPT,
+    baseline_path: Path | None = _BASELINE_OPT,
 ) -> None:
     """Analyze a flattened netlist for CDC issues (primary entry point)."""
     code = _analyze_and_report(
@@ -107,6 +130,8 @@ def analyze(
         sync_depth,
         verbose=verbose,
         color=color,
+        strict=strict,
+        baseline_path=baseline_path,
     )
     if code != 0:
         raise typer.Exit(code=code)
@@ -137,7 +162,8 @@ def lint(
         "`yosys` and runs hierarchy/proc/flatten/opt_clean before "
         "analysis. 'slang' elaborates via pyslang directly with no "
         "synth step; install the optional extra with "
-        "`pip install 'rtl-buddy-cdc[slang]'`.",
+        "`pip install 'rtl-buddy-cdc[slang]'`. 'auto' picks slang when "
+        "pyslang is importable and falls back to yosys otherwise.",
     ),
     keep_json: Path | None = typer.Option(
         None,
@@ -172,16 +198,26 @@ def lint(
     sync_depth: int = _SYNC_DEPTH_OPT,
     verbose: bool = _VERBOSE_OPT,
     color: bool | None = _COLOR_OPT,
+    strict: bool = _STRICT_OPT,
+    baseline_path: Path | None = _BASELINE_OPT,
 ) -> None:
     """Convenience wrapper: elaborate the sources using the chosen
     frontend, then analyze. With ``--frontend yosys`` (the default)
     this is equivalent to ``yosys -p 'read_verilog ...; hierarchy -top
     X; proc; flatten; opt_clean; write_json /tmp/out.json' &&
     rtl-buddy-cdc analyze --netlist /tmp/out.json --sdc ...``."""
+    # ``auto`` resolves once at the CLI surface so the preamble shows
+    # the concrete frontend and downstream tooling parsing stdout
+    # ("frontend: yosys"/"frontend: slang") doesn't see a third value.
+    resolved_frontend = resolve_auto() if frontend is Frontend.auto else frontend
+
     if fmt is OutputFormat.text:
         # Preamble for human readers only — structured output mustn't
         # carry non-payload framing.
-        typer.echo(f"frontend: {frontend.value}")
+        if frontend is Frontend.auto:
+            typer.echo(f"frontend: {resolved_frontend.value} (auto)")
+        else:
+            typer.echo(f"frontend: {resolved_frontend.value}")
         typer.echo(f"top:      {top}")
         for s in sources:
             typer.echo(f"src:      {s}")
@@ -190,7 +226,7 @@ def lint(
         module = elaborate(
             sources,
             top,
-            frontend=frontend,
+            frontend=resolved_frontend,
             yosys_bin=yosys_bin,
             keep_json=keep_json,
             yosys_plugin=yosys_plugin,
@@ -209,7 +245,7 @@ def lint(
 
     if (
         fmt is OutputFormat.text
-        and frontend is Frontend.yosys
+        and resolved_frontend is Frontend.yosys
         and keep_json is not None
     ):
         typer.echo(f"netlist JSON kept at: {keep_json}")
@@ -223,6 +259,8 @@ def lint(
         sync_depth,
         verbose=verbose,
         color=color,
+        strict=strict,
+        baseline_path=baseline_path,
     )
     if code != 0:
         raise typer.Exit(code=code)
@@ -266,6 +304,8 @@ def _analyze_and_report(
     *,
     verbose: bool = False,
     color: bool | None = None,
+    strict: bool = False,
+    baseline_path: Path | None = None,
 ) -> int:
     """Load a Yosys JSON netlist and run the shared analyze+report path."""
     module = netlist.load(netlist_path)
@@ -278,6 +318,8 @@ def _analyze_and_report(
         sync_depth,
         verbose=verbose,
         color=color,
+        strict=strict,
+        baseline_path=baseline_path,
     )
 
 
@@ -291,12 +333,14 @@ def _analyze_module_and_report(
     *,
     verbose: bool = False,
     color: bool | None = None,
+    strict: bool = False,
+    baseline_path: Path | None = None,
 ) -> int:
     """Run the analyzer on an in-memory ``Module`` and dispatch to the
     chosen reporter. Returns a process-style exit code: 0 = clean (or
     no SDC so rule checks were skipped), 1 = at least one *unsuppressed*
-    rule violation. Waived findings are still reported but don't fail
-    the run."""
+    rule violation. Waived findings (and baseline-carried findings) are
+    still reported but don't fail the run."""
     spec: sdc_mod.ClockSpec | None = None
     async_crossings: list[Crossing] = []
     violations: list[Violation] = []
@@ -322,6 +366,30 @@ def _analyze_module_and_report(
         waivers = waivers_mod.parse_file(waivers_path)
         violations, suppressed = waivers_mod.apply(violations, waivers)
 
+    # --baseline filter: partition findings against a prior JSON report.
+    # Carryover entries stay in the report (separate tally) but never
+    # drive the exit code — auto-derived waivers, basically.
+    baseline_carryover: list[Violation] = []
+    if baseline_path is not None:
+        baseline_keys = _load_baseline_keys(baseline_path)
+        kept: list[Violation] = []
+        for v in violations:
+            if _violation_key(v) in baseline_keys:
+                baseline_carryover.append(v)
+            else:
+                kept.append(v)
+        violations = kept
+
+    # --strict: promote every kept ``warning`` to ``error`` before the
+    # reporter sees the list. Suppressed and baseline-carried findings
+    # are left alone — by definition they aren't driving exit-code
+    # outcomes that the user is asking to tighten.
+    if strict:
+        violations = [
+            dataclasses.replace(v, severity="error") if v.severity == "warning" else v
+            for v in violations
+        ]
+
     result = AnalysisResult(
         module=module,
         domains=domains,
@@ -330,6 +398,7 @@ def _analyze_module_and_report(
         spec=spec,
         violations=list(violations),
         suppressed=list(suppressed),
+        baseline_carryover=list(baseline_carryover),
     )
 
     out: IO[str]
@@ -355,6 +424,41 @@ def _analyze_module_and_report(
             out.close()
 
     return 1 if violations else 0
+
+
+# --- --baseline support ------------------------------------------------------
+#
+# The match key is keyed on JSON-contract fields exposed by
+# ``reporter._violation_to_dict``: ``rule_id``, ``cell_name`` (added
+# alongside this feature so each finding has a stable per-cell handle),
+# and ``message``. Two genuinely-identical findings collapse to one key;
+# that's the same coarseness waivers already accept.
+
+
+def _violation_key(v: Violation) -> tuple[str, str, str]:
+    return (v.rule_id, v.cell_name or "", v.message)
+
+
+def _load_baseline_keys(path: Path) -> set[tuple[str, str, str]]:
+    """Parse a baseline JSON report and return the set of match keys.
+
+    Reads both ``violations`` and ``baseline_carryover`` so chained
+    baselines stay stable: a finding that was carried over in the
+    baseline run is still treated as carried over here.
+    """
+    with path.open() as fh:
+        payload = json.load(fh)
+    keys: set[tuple[str, str, str]] = set()
+    for bucket in ("violations", "baseline_carryover"):
+        for entry in payload.get(bucket, []):
+            keys.add(
+                (
+                    entry.get("rule_id", ""),
+                    entry.get("cell_name") or "",
+                    entry.get("message", ""),
+                )
+            )
+    return keys
 
 
 def _filter_async(

--- a/src/rtl_buddy_cdc/frontend.py
+++ b/src/rtl_buddy_cdc/frontend.py
@@ -23,6 +23,7 @@ delegates. The implementations live in :mod:`rtl_buddy_cdc.frontends`.
 
 from __future__ import annotations
 
+import importlib.util
 from enum import Enum
 from pathlib import Path
 
@@ -34,6 +35,22 @@ class Frontend(str, Enum):
 
     yosys = "yosys"
     slang = "slang"
+    # Probe pyslang at runtime and prefer slang when available; fall back
+    # to yosys otherwise. The default stays ``yosys`` — ``auto`` is
+    # opt-in. See ``resolve_auto`` for the resolution rule.
+    auto = "auto"
+
+
+def resolve_auto() -> Frontend:
+    """Resolve ``Frontend.auto`` into a concrete frontend.
+
+    Returns :attr:`Frontend.slang` when pyslang is importable in the
+    current environment (the slang frontend has no subprocess overhead
+    and no Yosys runtime dependency), :attr:`Frontend.yosys` otherwise.
+    """
+    if importlib.util.find_spec("pyslang") is not None:
+        return Frontend.slang
+    return Frontend.yosys
 
 
 def elaborate(
@@ -52,6 +69,8 @@ def elaborate(
     are accepted as keyword arguments and silently ignored by frontends
     that don't use them (e.g. ``yosys_bin`` is meaningless for slang).
     """
+    if frontend is Frontend.auto:
+        frontend = resolve_auto()
     if frontend is Frontend.yosys:
         from rtl_buddy_cdc.frontends import yosys as yosys_fe
 

--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -69,6 +69,11 @@ class AnalysisResult:
     spec: ClockSpec | None
     violations: list[Violation]
     suppressed: list[SuppressedViolation] = field(default_factory=list)
+    # Findings filtered out by ``--baseline``: present in a baseline
+    # JSON report so they're not re-flagged on this run. Visible in the
+    # report (separate tally) but never drive the exit code — the
+    # "carried over" tally is auto-derived waivers, not new findings.
+    baseline_carryover: list[Violation] = field(default_factory=list)
 
 
 # --- text -------------------------------------------------------------------
@@ -148,6 +153,7 @@ def render_text(
         return
     _render_violations(result, out, s)
     _render_suppressed(result, out, s)
+    _render_baseline_carryover(result, out, s)
 
 
 def _render_header(result: AnalysisResult, out: IO[str], s: _Style) -> None:
@@ -285,6 +291,18 @@ def _render_suppressed(result: AnalysisResult, out: IO[str], s: _Style) -> None:
         )
 
 
+def _render_baseline_carryover(result: AnalysisResult, out: IO[str], s: _Style) -> None:
+    if not result.baseline_carryover:
+        return
+    out.write(
+        f"\n{s.bold}Carried over from baseline{s.reset} "
+        f"({len(result.baseline_carryover)})\n"
+    )
+    for v in result.baseline_carryover:
+        msg = v.message.splitlines()[0] if v.message else ""
+        out.write(f"  {s.dim}{v.rule_id}{s.reset}  {msg}\n")
+
+
 def _severity_counts(violations: list[Violation]) -> dict[str, int]:
     counts = {"error": 0, "warning": 0, "info": 0}
     for v in violations:
@@ -307,6 +325,7 @@ def render_json(result: AnalysisResult, out: IO[str]) -> None:
             "async_crossings": len(result.async_crossings),
             "violations": len(result.violations),
             "suppressed": len(result.suppressed),
+            "baseline_carryover": len(result.baseline_carryover),
         },
         "domains": [
             {"flop": fd.flop.cell.name, "clock": fd.clock} for fd in result.domains
@@ -324,6 +343,9 @@ def render_json(result: AnalysisResult, out: IO[str]) -> None:
                 },
             }
             for s in result.suppressed
+        ],
+        "baseline_carryover": [
+            _violation_to_dict(v, result.module) for v in result.baseline_carryover
         ],
     }
     json.dump(payload, out, indent=2)
@@ -351,6 +373,11 @@ def _violation_to_dict(v: Violation, module: Module) -> dict:
         "severity": v.severity,
         "message": v.message,
     }
+    # ``cell_name`` is part of the stable JSON contract so ``--baseline``
+    # has a unique key per violation (``rule_id`` alone collides for
+    # designs with many same-rule findings). Emitted as ``null`` when
+    # the rule didn't anchor on a single cell.
+    out["cell_name"] = v.cell_name
     if v.crossing is not None:
         out["crossing"] = _crossing_to_dict(v.crossing)
     loc = _source_location(module, v.cell_name)
@@ -398,6 +425,18 @@ def render_sarif(result: AnalysisResult, out: IO[str]) -> None:
                 "kind": "external",
                 "status": "accepted",
                 "justification": s.waiver.reason or "waived",
+            }
+        ]
+        sarif_results.append(entry)
+    # Baseline-carried findings: same shape, distinct justification so
+    # consumers can tell them apart from user-authored waivers.
+    for v in result.baseline_carryover:
+        entry = _violation_to_sarif(v, result.module)
+        entry["suppressions"] = [
+            {
+                "kind": "external",
+                "status": "accepted",
+                "justification": "carried over from baseline",
             }
         ]
         sarif_results.append(entry)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -20,8 +20,9 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from rtl_buddy_cdc import frontend as frontend_mod
 from rtl_buddy_cdc.cli import app
-from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.frontend import Frontend, elaborate, resolve_auto
 from rtl_buddy_cdc.frontends.slang import SlangFrontendUnavailable
 
 FIX_ROOT = Path(__file__).parent / "fixtures"
@@ -31,9 +32,9 @@ PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
 
 
 def test_frontend_enum_values() -> None:
-    """The two frontend names are the stable public API the CLI uses;
+    """The three frontend names are the stable public API the CLI uses;
     rename = breaking change."""
-    assert {f.value for f in Frontend} == {"yosys", "slang"}
+    assert {f.value for f in Frontend} == {"yosys", "slang", "auto"}
 
 
 def test_elaborate_unknown_frontend_raises() -> None:
@@ -129,3 +130,63 @@ def test_cli_lint_default_frontend_is_yosys() -> None:
     assert "CDC-001" in result.output
     # Frontend preamble appears in text-mode output.
     assert "frontend: yosys" in result.output
+
+
+# --- Frontend.auto (issue #31) ----------------------------------------------
+#
+# ``auto`` resolves at runtime via ``importlib.util.find_spec``. The two
+# tests below mock that probe to exercise both branches deterministically;
+# the CLI-level test then confirms the preamble surfaces the resolved
+# choice so downstream parsers don't see a third frontend name.
+
+
+def test_resolve_auto_prefers_slang_when_pyslang_available(monkeypatch) -> None:
+    """With pyslang importable, ``auto`` resolves to slang — no Yosys
+    subprocess, no synth step."""
+    monkeypatch.setattr(
+        frontend_mod.importlib.util,
+        "find_spec",
+        lambda name: object() if name == "pyslang" else None,
+    )
+    assert resolve_auto() is Frontend.slang
+
+
+def test_resolve_auto_falls_back_to_yosys_without_pyslang(monkeypatch) -> None:
+    """Without pyslang importable, ``auto`` falls back to yosys so
+    default installs (``typer`` only) still work."""
+    monkeypatch.setattr(
+        frontend_mod.importlib.util,
+        "find_spec",
+        lambda name: None,
+    )
+    assert resolve_auto() is Frontend.yosys
+
+
+@pytest.mark.skipif(YOSYS is None, reason="yosys not on PATH")
+def test_cli_lint_auto_frontend_resolves_in_preamble(monkeypatch) -> None:
+    """``--frontend auto`` should echo the *resolved* frontend in the
+    preamble (with an ``(auto)`` marker) so log scrapers see ``yosys``
+    or ``slang``, not a third value."""
+    # Force the resolution path to yosys regardless of whether pyslang
+    # happens to be installed in the test env.
+    monkeypatch.setattr(
+        frontend_mod.importlib.util,
+        "find_spec",
+        lambda name: None,
+    )
+    fix = FIX_ROOT / "bad_single_ff_sync"
+    result = runner.invoke(
+        app,
+        [
+            "lint",
+            "--frontend",
+            "auto",
+            "--top",
+            "bad_single_ff_sync",
+            "--sdc",
+            str(fix / "bad_single_ff_sync.sdc"),
+            str(fix / "bad_single_ff_sync.sv"),
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "frontend: yosys (auto)" in result.output

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -231,3 +231,269 @@ def test_tool_version_matches_pyproject() -> None:
     release conventions"; this sentinel catches a one-sided edit
     that would leave SARIF consumers pointing at the wrong wheel."""
     assert TOOL_VERSION == importlib.metadata.version("rtl-buddy-cdc")
+
+
+# --- --strict severity promotion (issue #29) --------------------------------
+#
+# CDC-002 fires at warning severity. With ``--strict`` it should render
+# as an error in every output format AND drive the same exit code (1 —
+# any kept violation already drives it). The fixture is good_2ff_sync
+# (depth-2 chain): silent at the default ``--sync-depth 2``, fires
+# CDC-002 once at ``--sync-depth 3``.
+
+_STRICT_FIX = Path(__file__).parent / "fixtures" / "good_2ff_sync"
+_STRICT_JSON = _STRICT_FIX / "good_2ff_sync.json"
+_STRICT_SDC = _STRICT_FIX / "good_2ff_sync.sdc"
+
+
+def _strict_skip_if_missing() -> None:
+    if not _STRICT_JSON.exists():
+        pytest.skip(f"fixture not built: {_STRICT_JSON}")
+
+
+def test_strict_promotes_cdc_002_in_text(tmp_path: Path) -> None:
+    _strict_skip_if_missing()
+    out = tmp_path / "report.txt"
+    code = _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.text,
+        out,
+        sync_depth=3,
+        strict=True,
+    )
+    assert code == 1
+    text = out.read_text()
+    assert "CDC-002" in text
+    # Promoted: the rendered severity for this finding is now ``error``,
+    # and the summary banner counts it as such.
+    assert "error" in text
+    assert "1 error" in text
+    # And no stray ``warning`` token (the rule's natural severity).
+    assert "warning" not in text
+
+
+def test_strict_promotes_cdc_002_in_json(tmp_path: Path) -> None:
+    _strict_skip_if_missing()
+    out = tmp_path / "report.json"
+    code = _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.json,
+        out,
+        sync_depth=3,
+        strict=True,
+    )
+    assert code == 1
+    payload = json.loads(out.read_text())
+    cdc_002 = [v for v in payload["violations"] if v["rule_id"] == "CDC-002"]
+    assert len(cdc_002) == 1
+    assert cdc_002[0]["severity"] == "error"
+
+
+def test_strict_promotes_cdc_002_in_sarif(tmp_path: Path) -> None:
+    _strict_skip_if_missing()
+    out = tmp_path / "report.sarif"
+    code = _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.sarif,
+        out,
+        sync_depth=3,
+        strict=True,
+    )
+    assert code == 1
+    payload = json.loads(out.read_text())
+    results = payload["runs"][0]["results"]
+    cdc_002 = [r for r in results if r["ruleId"] == "CDC-002"]
+    assert len(cdc_002) == 1
+    # SARIF maps internal severity ``error`` → level ``error`` (warning
+    # would have become ``warning``).
+    assert cdc_002[0]["level"] == "error"
+
+
+def test_strict_off_is_a_noop(tmp_path: Path) -> None:
+    """Without ``--strict``, CDC-002 stays at its natural warning
+    severity — promotion is opt-in, not a behaviour change."""
+    _strict_skip_if_missing()
+    out = tmp_path / "report.json"
+    code = _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.json,
+        out,
+        sync_depth=3,
+        strict=False,
+    )
+    assert code == 1  # CDC-002 is still a violation, just at warning level
+    payload = json.loads(out.read_text())
+    cdc_002 = [v for v in payload["violations"] if v["rule_id"] == "CDC-002"]
+    assert len(cdc_002) == 1
+    assert cdc_002[0]["severity"] == "warning"
+
+
+# --- --baseline filter (issue #30) ------------------------------------------
+#
+# Acceptance-criteria cases: identical baseline → empty, baseline subset
+# → only the new finding kept. The JSON payload exposes a
+# ``baseline_carryover`` tally / list; SARIF emits carryover entries with
+# a ``suppressions`` field tagged ``carried over from baseline``.
+
+
+def _run_baseline_test(
+    tmp_path: Path, baseline_json: Path | None, *, sync_depth: int = 3
+) -> dict:
+    out = tmp_path / "report.json"
+    _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.json,
+        out,
+        sync_depth=sync_depth,
+        baseline_path=baseline_json,
+    )
+    return json.loads(out.read_text())
+
+
+def test_baseline_identical_run_yields_zero_kept(tmp_path: Path) -> None:
+    """`--baseline <itself>` on the same fixture moves every finding to
+    the carryover tally — kept count is zero, exit code is zero."""
+    _strict_skip_if_missing()
+    # First run: emit a JSON report to use as the baseline.
+    baseline = tmp_path / "baseline.json"
+    code = _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.json,
+        baseline,
+        sync_depth=3,
+    )
+    assert code == 1  # one CDC-002 in the baseline run
+    baseline_payload = json.loads(baseline.read_text())
+    assert baseline_payload["summary"]["violations"] == 1
+
+    # Second run with the baseline applied: the CDC-002 finding moves
+    # from `violations` to `baseline_carryover`.
+    out = tmp_path / "second.json"
+    code = _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.json,
+        out,
+        sync_depth=3,
+        baseline_path=baseline,
+    )
+    payload = json.loads(out.read_text())
+    assert payload["summary"]["violations"] == 0
+    assert payload["summary"]["baseline_carryover"] == 1
+    assert payload["baseline_carryover"][0]["rule_id"] == "CDC-002"
+    # And the exit code drops to 0 — carryover doesn't fail the build.
+    assert code == 0
+
+
+def test_baseline_empty_keeps_every_finding(tmp_path: Path) -> None:
+    """`--baseline <empty-report>` is the same as no baseline — every
+    current finding stays in the kept set."""
+    _strict_skip_if_missing()
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"violations": []}))
+    payload = _run_baseline_test(tmp_path, baseline)
+    assert payload["summary"]["violations"] == 1
+    assert payload["summary"]["baseline_carryover"] == 0
+
+
+def test_baseline_filters_only_matching_keys(tmp_path: Path) -> None:
+    """A baseline that lists a DIFFERENT finding (different rule_id)
+    leaves the current finding untouched. The filter is exact-match on
+    (rule_id, cell_name, message), not blanket suppression."""
+    _strict_skip_if_missing()
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "violations": [
+                    {
+                        "rule_id": "CDC-999",
+                        "cell_name": "ghost",
+                        "message": "phantom finding",
+                    }
+                ]
+            }
+        )
+    )
+    payload = _run_baseline_test(tmp_path, baseline)
+    assert payload["summary"]["violations"] == 1
+    assert payload["summary"]["baseline_carryover"] == 0
+
+
+def test_baseline_sarif_marks_carryover_as_suppressed(tmp_path: Path) -> None:
+    """SARIF entries for baseline-carried findings carry a
+    ``suppressions`` field so GitHub Code Scanning doesn't fail the
+    build on a finding the PR already inherited from main."""
+    _strict_skip_if_missing()
+    baseline = tmp_path / "baseline.json"
+    _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.json,
+        baseline,
+        sync_depth=3,
+    )
+    out = tmp_path / "report.sarif"
+    _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.sarif,
+        out,
+        sync_depth=3,
+        baseline_path=baseline,
+    )
+    payload = json.loads(out.read_text())
+    results = payload["runs"][0]["results"]
+    assert len(results) == 1
+    entry = results[0]
+    assert entry["ruleId"] == "CDC-002"
+    assert "suppressions" in entry
+    assert entry["suppressions"][0]["justification"] == "carried over from baseline"
+
+
+def test_baseline_carryover_chains(tmp_path: Path) -> None:
+    """A finding already in the baseline's ``baseline_carryover`` list
+    stays carried over on the next run too. Without this, re-baselining
+    would re-flag inherited findings."""
+    _strict_skip_if_missing()
+    # Run once to capture a realistic violation entry, then transplant
+    # it into the carryover bucket of a synthesised baseline file. This
+    # avoids hard-coding the (rule-generated) message and cell_name.
+    real = tmp_path / "real.json"
+    _analyze_and_report(
+        _STRICT_JSON,
+        _STRICT_SDC,
+        None,
+        OutputFormat.json,
+        real,
+        sync_depth=3,
+    )
+    real_payload = json.loads(real.read_text())
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "violations": [],
+                "baseline_carryover": real_payload["violations"],
+            }
+        )
+    )
+    payload = _run_baseline_test(tmp_path, baseline)
+    # The current finding matches via the baseline's carryover bucket.
+    assert payload["summary"]["violations"] == 0
+    assert payload["summary"]["baseline_carryover"] == 1

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -143,6 +143,14 @@ built is pluggable:
   raises `SlangFrontendUnavailable` with an install hint; fatal
   pyslang diagnostics surface through a `TextDiagnosticClient`
   (file:line:col + caret summaries — the usual compiler-error UX).
+- **`Frontend.auto`** — at runtime probes
+  `importlib.util.find_spec("pyslang")` via `frontend.resolve_auto`
+  and dispatches to `slang` when pyslang is importable, else `yosys`.
+  The default frontend stays `yosys` — `auto` is opt-in via the CLI
+  (`lint --frontend auto`). The auto branch resolves at the CLI
+  surface so the preamble shows the *resolved* frontend
+  (`frontend: yosys (auto)`) and downstream log-scraping tools never
+  see a third value in the `frontend:` line.
 
 The factory in `frontend.py` is the only orchestration:
 
@@ -595,6 +603,14 @@ edit in `RULES` plus the function definition.
 A waiver moves a violation out of "kept" and into "suppressed"; only
 kept violations drive the exit code.
 
+`--strict` (CLI flag) reframes the kept set without re-gating it:
+every `warning` is promoted to `error` before the reporter renders,
+so the text banner, JSON `severity`, and SARIF `level` all show
+`error`. The exit code is unchanged — any kept violation already
+drives 1 — so `--strict` is documentation/UX, not policy. Suppressed
+and baseline-carried findings are left at their natural severity
+(they aren't driving exit-code outcomes by definition).
+
 ### 8.3 Recognition vs. annotation
 
 For each rule the analyzer faces a choice between **structural
@@ -643,6 +659,30 @@ This deliberately mimics the Spyglass `.swl` workflow at a much
 smaller surface — no scope qualifiers, no severity overrides, no
 expiry dates. Add those when a real project asks for them, not
 preemptively.
+
+### 9.1 Baseline filtering (`--baseline`)
+
+`--baseline FILE.json` is auto-derived waivers. The flag points at a
+prior JSON report (the same shape `render_json` emits); findings
+whose `(rule_id, cell_name, message)` tuple matches an entry in the
+baseline's `violations` or `baseline_carryover` lists are filtered
+out of the kept set and moved into a third bucket on
+`AnalysisResult.baseline_carryover`. The kept-vs-suppressed-vs-
+carryover partition is performed in `cli._analyze_module_and_report`
+after waivers and before `--strict` promotion (so a carryover
+warning isn't promoted; carryover findings never drive exit code).
+
+JSON output gains `summary.baseline_carryover` (int) and a top-level
+`baseline_carryover` list of `_violation_to_dict` entries; SARIF
+emits each carryover entry with a `suppressions` field whose
+`justification` is `"carried over from baseline"` (distinguishing it
+from waiver-suppressed entries). The match key reuses fields the
+JSON schema already exposes; `cell_name` is now part of every
+violation dict for this purpose.
+
+Baseline files chain — a finding already in the baseline's
+`baseline_carryover` list stays carried over on the next run too —
+so re-baselining doesn't re-flag inherited findings.
 
 ## 10. Reporting
 


### PR DESCRIPTION
## Summary

Three opt-in CLI additions, bundled because they're independent ~1hr features that all touch `cli.py`. All changes are additive — no existing flag, exit-code, or `JSON_CONTRACT` key changes shape, so the rtl-buddy ↔ rtl-buddy-cdc subprocess boundary keeps working unchanged.

Closes #29 
Closes #30 
Closes #31 

### #29 — \`--strict\` severity promotion

- New flag on \`analyze\` and \`lint\`. Promotes every \`warning\` violation to \`error\` before the reporter renders, so the text banner, JSON \`severity\`, and SARIF \`level\` all show \`error\`.
- Exit code unchanged — any kept violation already drives exit 1; the flag is reframing, not gating.
- Suppressed and baseline-carried findings are left alone (by definition they don't drive exit-code outcomes).

### #30 — \`--baseline FILE.json\` delta reporting

- New flag on \`analyze\` and \`lint\`. Reads a prior JSON report and filters out findings whose \`(rule_id, cell_name, message)\` tuple matches; carried-over findings are surfaced as a separate \"Carried over from baseline\" tally that never drives the exit code.
- JSON gains \`summary.baseline_carryover\` (int) and a top-level \`baseline_carryover\` list of \`_violation_to_dict\` entries.
- SARIF emits each carryover entry with a \`suppressions\` field tagged \`carried over from baseline\` so GitHub Code Scanning treats them like waivers.
- \`cell_name\` is now exposed on every violation entry in JSON output to give the match key a stable per-cell handle. Additive — \`JSON_CONTRACT\` keys are unchanged.
- Baseline files chain: a finding already in the baseline's \`baseline_carryover\` list stays carried over on the next run too, so re-baselining doesn't re-flag inherited findings.

### #31 — \`Frontend.auto\` (\`--frontend auto\`)

- New enum value + new \`frontend.resolve_auto()\` helper. Probes \`importlib.util.find_spec(\"pyslang\")\` at runtime and dispatches to \`slang\` when importable, \`yosys\` otherwise.
- Default frontend stays \`yosys\`; auto is opt-in via the CLI.
- The lint preamble shows the *resolved* frontend (\`frontend: yosys (auto)\`) so log scrapers never see a third value in the \`frontend:\` line.

### Docs

- README: updated Inputs table (\`--strict\`, \`--baseline\`, \`auto\` in \`--frontend\`); Rules table notes CDC-002 / CDC-005 promote under \`--strict\`.
- \`wiki/raw/articles/rtl-buddy-cdc-architecture.md\`: §3.1 frontend layer adds \`Frontend.auto\`, §8.2 severity policy describes \`--strict\` reframing, new §9.1 documents baseline filtering. Per AGENTS.md's contract-changes-update-the-spec rule.
- \`CHANGELOG.md\`: entries under \`[Unreleased]\`.

### Downstream impact

\`rtl_buddy\` (sibling repo) consumes this analyzer as a subprocess. The three load-bearing JSON keys (\`summary.violations\`, \`summary.suppressed\`, \`summary.crossings\`) and the six contract CLI flags (\`--netlist\`, \`--sdc\`, \`--top\`, \`--waivers\`, \`--sync-depth\`, \`--format\`, \`--output\`) are unchanged in name and type, so no rtl-buddy change is required to land this. The new \`baseline_carryover\` summary key and \`cell_name\` violation field are additive.

## Test plan

- [x] \`uv run ruff check\` — clean
- [x] \`uv run ruff format --check\` — clean
- [x] \`uv run mypy\` — clean
- [x] \`uv run pytest -q\` — 125 passed, 2 skipped (pyslang-not-installed conditional skips)
- [x] New tests cover all acceptance-criteria cases:
  - \`--strict\` promotion in text / JSON / SARIF, plus a no-op-when-off test
  - \`--baseline\` for identical, empty, and new-finding cases, plus SARIF suppression shape and baseline-chains-via-carryover
  - \`Frontend.auto\` dispatch in both branches (mocked \`find_spec\`) plus CLI preamble surfacing the resolved frontend
- [x] End-to-end smoke against \`rtl-buddy-project-template\`'s CDC regression with this branch installed in editable mode (recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)