### PR TITLE
fix(slang): walk generate-block bodies in scope traversal

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -266,21 +266,77 @@ class _ModuleBuilder:
         """
         self._hier_stack.append(hier_prefix)
         try:
-            for member in inst.body:
+            for member, prefix in self._iter_scope(inst.body, hier_prefix):
                 if (
                     self._kind_name(member) == "VariableSymbol"
                     and member not in bound_internals
                 ):
-                    self._collect_variable(member, hier_prefix)
+                    self._collect_variable(member, prefix)
             # Only the top module exposes ports in the flat ``Module``;
             # child ports get folded into their parents' connections.
+            # Ports always live directly on the instance body (SV
+            # disallows declaring them inside generates) so no
+            # scope-flattening is needed for this pass.
             if hier_prefix == "":
                 for member in inst.body:
                     self._collect_port(member)
-            for member in inst.body:
-                self._emit_for_member(member, hier_prefix)
+            for member, prefix in self._iter_scope(inst.body, hier_prefix):
+                # ``_fresh_cell_name`` reads ``_hier_stack[-1]`` when
+                # naming cells; for members inside a generate block
+                # that needs to include the ``g_label[i].`` segment so
+                # the emitted name matches Yosys-flatten.
+                self._hier_stack.append(prefix)
+                try:
+                    self._emit_for_member(member, prefix)
+                finally:
+                    self._hier_stack.pop()
         finally:
             self._hier_stack.pop()
+
+    def _iter_scope(self, container: Any, hier_prefix: str):
+        """Yield ``(member, prefix)`` for every emittable member of a
+        scope, recursively expanding SV ``generate`` blocks.
+
+        pyslang exposes two generate kinds:
+
+        - :class:`GenerateBlockSymbol` — one instantiated generate
+          body (an unconditional ``generate ... endgenerate``, or the
+          taken branch of ``generate if`` / ``generate case``).
+          Iterating the symbol yields its inner members. Untaken
+          branches are usually pruned from the parent body already,
+          but ``isUninstantiated`` is checked as defense-in-depth.
+        - :class:`GenerateBlockArraySymbol` — a labeled
+          ``for (genvar ...)`` array; its ``.entries`` list contains
+          one :class:`GenerateBlockSymbol` per iteration, each
+          carrying ``arrayIndex``.
+
+        Naming follows Yosys-flatten convention: ``g_label[i].`` for
+        array entries, ``g_label.`` for named single blocks, no
+        segment for anonymous blocks. Stable across the two frontends
+        so the rule pack's path reporting and any downstream waiver
+        regexes don't have to branch on the frontend.
+        """
+        for member in container:
+            kind = self._kind_name(member)
+            if kind == "GenerateBlockArraySymbol":
+                array_name = getattr(member, "name", "") or ""
+                for entry in getattr(member, "entries", []) or []:
+                    if getattr(entry, "isUninstantiated", False):
+                        continue
+                    idx = getattr(entry, "arrayIndex", None)
+                    if array_name and idx is not None:
+                        inner_prefix = f"{hier_prefix}{array_name}[{idx}]."
+                    else:
+                        inner_prefix = hier_prefix
+                    yield from self._iter_scope(entry, inner_prefix)
+            elif kind == "GenerateBlockSymbol":
+                if getattr(member, "isUninstantiated", False):
+                    continue
+                name = getattr(member, "name", "") or ""
+                inner_prefix = f"{hier_prefix}{name}." if name else hier_prefix
+                yield from self._iter_scope(member, inner_prefix)
+            else:
+                yield member, hier_prefix
 
     # -- helpers ---------------------------------------------------------
 
@@ -463,9 +519,10 @@ class _ModuleBuilder:
             self._emit_continuous_assign(member)
         elif kind == "InstanceSymbol":
             self._emit_child_instance(member, hier_prefix)
-        # GenerateBlockSymbol and other unmodelled kinds fall through
-        # silently — the lack of expected flops will be visible in
-        # `analyze` output, which is a better failure mode than
+        # GenerateBlock(Array)Symbol are pre-expanded by ``_iter_scope``
+        # before reaching this dispatch; any other unmodelled kind
+        # falls through silently — the missing flops surface in
+        # ``analyze`` output, which is a better failure mode than
         # crashing on an unrecognised member kind.
 
     def _emit_child_instance(self, child: Any, parent_prefix: str) -> None:
@@ -796,20 +853,52 @@ class _ModuleBuilder:
         """Best-effort: extract an ``int`` from a constant pyslang
         expression. Returns ``None`` if the expression isn't a
         compile-time constant — selectors on the LHS need to be
-        static for the flop-shape model to work."""
+        static for the flop-shape model to work.
+
+        Three shapes show up in practice:
+
+        - :class:`IntegerLiteral` — ``expr.value`` is an :class:`SVInt`
+          which :func:`int` accepts directly.
+        - :class:`NamedValueExpression` referring to a parameter or a
+          genvar iteration value — ``expr.constant`` is a
+          :class:`ConstantValue` wrapper; the inner scalar lives on
+          ``.value`` (also :class:`SVInt`) or comes back from
+          :meth:`ConstantValue.convertToInt`.
+        - Other constant-foldable expressions — ``.constant`` is
+          populated post-compilation; same unwrapping applies.
+        """
         if expr is None:
             return None
-        # pyslang exposes ``.constant`` (an SVInt) on most expressions
-        # once compilation has folded the operand; an IntegerLiteral
-        # additionally has ``.value``.
+
+        def _coerce(v: Any) -> int | None:
+            # Direct path (SVInt, IntegerLiteral.value, plain int).
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                pass
+            # ConstantValue → inner SVInt via ``.value``.
+            inner = getattr(v, "value", None)
+            if inner is not None and inner is not v:
+                try:
+                    return int(inner)
+                except (TypeError, ValueError):
+                    pass
+            # ConstantValue → explicit conversion.
+            convert = getattr(v, "convertToInt", None)
+            if callable(convert):
+                try:
+                    return int(convert())
+                except (TypeError, ValueError):
+                    pass
+            return None
+
         for attr in ("constant", "value"):
             v = getattr(expr, attr, None)
             if v is None:
                 continue
-            try:
-                return int(v)
-            except (TypeError, ValueError):
-                continue
+            n = _coerce(v)
+            if n is not None:
+                return n
         return None
 
     def _bits_of_expression(self, expr: Any) -> tuple[Bit, ...] | None:

--- a/tests/test_slang_generate_blocks.py
+++ b/tests/test_slang_generate_blocks.py
@@ -1,0 +1,247 @@
+"""Coverage tests for slang-frontend traversal of SV ``generate`` blocks.
+
+Issue: rtl-buddy-cdc#53 — ``slang.py:_emit_for_member`` silently drops
+``GenerateBlockSymbol`` and ``GenerateBlockArraySymbol``, so any
+``always_ff`` nested inside ``generate`` is invisible to the analyzer.
+On real designs (array-of-cores, parameterized fabrics) this produces a
+near-empty ``Module`` and a confident false PASS.
+
+The tests below pin the expected behaviour: every flop reachable from
+the top — regardless of how many generate levels enclose it — must
+appear in the produced ``Module.cells`` as a ``$dff`` / ``$adff`` cell.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang generate-block tests are gated on it",
+        allow_module_level=True,
+    )
+
+FLOP_TYPES = frozenset({"$dff", "$adff", "$dffe", "$adffe", "$sdff", "$sdffe"})
+
+
+def _flop_count(module) -> int:
+    return sum(1 for c in module.cells.values() if c.type in FLOP_TYPES)
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+# --- 1-D generate-for ------------------------------------------------------
+
+
+def test_generate_for_array_emits_all_flops(tmp_path: Path) -> None:
+    """``for (genvar i = 0; i < N; i++)`` array of flops — the slang
+    frontend must emit N $adff cells, one per index."""
+    src = """
+    module m #(parameter int N = 4) (
+        input  logic clk,
+        input  logic rst_n,
+        input  logic [N-1:0] d,
+        output logic [N-1:0] q
+    );
+        genvar i;
+        generate
+            for (i = 0; i < N; i++) begin : g_bit
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) q[i] <= 1'b0;
+                    else        q[i] <= d[i];
+                end
+            end
+        endgenerate
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 4, (
+        f"expected 4 flops from generate-for[N=4]; got {_flop_count(mod)} "
+        f"(cells: {sorted(c.type for c in mod.cells.values())})"
+    )
+
+
+def test_generate_for_uses_index_in_hier_prefix(tmp_path: Path) -> None:
+    """Flops inside ``begin : g_bit`` should carry the labeled index
+    in their cell name, matching yosys-flatten convention
+    ``g_bit[0].…`` / ``g_bit[1].…``."""
+    src = """
+    module m (
+        input  logic clk,
+        input  logic rst_n,
+        input  logic [1:0] d,
+        output logic [1:0] q
+    );
+        genvar i;
+        generate
+            for (i = 0; i < 2; i++) begin : g_bit
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) q[i] <= 1'b0;
+                    else        q[i] <= d[i];
+                end
+            end
+        endgenerate
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    names = sorted(mod.cells.keys())
+    has_idx0 = any("g_bit[0]" in n or "g_bit.0" in n for n in names)
+    has_idx1 = any("g_bit[1]" in n or "g_bit.1" in n for n in names)
+    assert has_idx0 and has_idx1, (
+        f"expected indexed labels g_bit[0]/g_bit[1] in cell names; got {names}"
+    )
+
+
+# --- 2-D nested generate-for (mimics MXP slice array) ----------------------
+
+
+def test_nested_generate_for_2d_emits_all_flops(tmp_path: Path) -> None:
+    """Nested 2-D generate matches the tiny-NPU MXP slice array shape.
+    For R=2, C=3 the body has 1 flop → expect 6 total."""
+    src = """
+    module m #(parameter int R = 2, parameter int C = 3) (
+        input  logic clk,
+        input  logic rst_n,
+        input  logic [R*C-1:0] d,
+        output logic [R*C-1:0] q
+    );
+        genvar r, c;
+        generate
+            for (r = 0; r < R; r++) begin : g_row
+                for (c = 0; c < C; c++) begin : g_col
+                    always_ff @(posedge clk or negedge rst_n) begin
+                        if (!rst_n) q[r*C + c] <= 1'b0;
+                        else        q[r*C + c] <= d[r*C + c];
+                    end
+                end
+            end
+        endgenerate
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 6, (
+        f"expected 6 flops from 2-D generate-for (R=2, C=3); got {_flop_count(mod)}"
+    )
+
+
+# --- conditional generate (generate-if) ------------------------------------
+
+
+def test_generate_if_taken_branch_emits_flops(tmp_path: Path) -> None:
+    """``generate if (cond) ... else ...`` — only the taken branch
+    contributes flops. cond=true here, so the if-branch's two flops
+    must appear and the else-branch's three must not."""
+    src = """
+    module m #(parameter bit USE_SYNC = 1) (
+        input  logic clk, rst_n, d,
+        output logic q
+    );
+        generate
+            if (USE_SYNC) begin : g_sync
+                logic meta_q, sync_q;
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) {sync_q, meta_q} <= '0;
+                    else        {sync_q, meta_q} <= {meta_q, d};
+                end
+                assign q = sync_q;
+            end else begin : g_passthrough
+                logic a, b, c;
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) {a, b, c} <= '0;
+                    else        {a, b, c} <= {d, d, d};
+                end
+                assign q = a;
+            end
+        endgenerate
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    n = _flop_count(mod)
+    # USE_SYNC=1: g_sync branch has {meta_q, sync_q} = 2 flops; g_passthrough
+    # is unelaborated and contributes 0.
+    assert n == 2, f"expected 2 flops from g_sync branch only; got {n}"
+
+
+def test_generate_if_untaken_branch_emits_zero(tmp_path: Path) -> None:
+    """Same shape with USE_SYNC=0 — the else-branch's three flops must
+    appear and the if-branch must not contribute."""
+    src = """
+    module m #(parameter bit USE_SYNC = 0) (
+        input  logic clk, rst_n, d,
+        output logic q
+    );
+        generate
+            if (USE_SYNC) begin : g_sync
+                logic meta_q, sync_q;
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) {sync_q, meta_q} <= '0;
+                    else        {sync_q, meta_q} <= {meta_q, d};
+                end
+                assign q = sync_q;
+            end else begin : g_passthrough
+                logic a, b, c;
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) {a, b, c} <= '0;
+                    else        {a, b, c} <= {d, d, d};
+                end
+                assign q = a;
+            end
+        endgenerate
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    n = _flop_count(mod)
+    assert n == 3, f"expected 3 flops from g_passthrough branch only; got {n}"
+
+
+# --- generate inside an instantiated child (depth-2 hierarchy) -------------
+
+
+def test_child_module_generate_for_visible_from_top(tmp_path: Path) -> None:
+    """The headline tiny-NPU shape: top instantiates a child, child
+    body has a generate-for. The top elaboration must see the
+    generate-for flops of the child through its instance."""
+    src = """
+    module child #(parameter int N = 4) (
+        input  logic clk,
+        input  logic rst_n,
+        input  logic [N-1:0] d,
+        output logic [N-1:0] q
+    );
+        genvar i;
+        generate
+            for (i = 0; i < N; i++) begin : g_bit
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) q[i] <= 1'b0;
+                    else        q[i] <= d[i];
+                end
+            end
+        endgenerate
+    endmodule
+
+    module m (
+        input  logic clk, rst_n,
+        input  logic [3:0] d,
+        output logic [3:0] q
+    );
+        child #(.N(4)) u_child (.*);
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    n = _flop_count(mod)
+    assert n == 4, (
+        f"expected 4 flops from child's generate-for through u_child; got {n}"
+    )
+    assert any("u_child" in name for name in mod.cells.keys()), (
+        f"expected u_child prefix on inlined cell names; got {sorted(mod.cells.keys())}"
+    )

--- a/tests/test_slang_generate_blocks.py
+++ b/tests/test_slang_generate_blocks.py
@@ -150,15 +150,27 @@ def test_generate_if_taken_branch_emits_flops(tmp_path: Path) -> None:
             if (USE_SYNC) begin : g_sync
                 logic meta_q, sync_q;
                 always_ff @(posedge clk or negedge rst_n) begin
-                    if (!rst_n) {sync_q, meta_q} <= '0;
-                    else        {sync_q, meta_q} <= {meta_q, d};
+                    if (!rst_n) meta_q <= 1'b0;
+                    else        meta_q <= d;
+                end
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) sync_q <= 1'b0;
+                    else        sync_q <= meta_q;
                 end
                 assign q = sync_q;
             end else begin : g_passthrough
                 logic a, b, c;
                 always_ff @(posedge clk or negedge rst_n) begin
-                    if (!rst_n) {a, b, c} <= '0;
-                    else        {a, b, c} <= {d, d, d};
+                    if (!rst_n) a <= 1'b0;
+                    else        a <= d;
+                end
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) b <= 1'b0;
+                    else        b <= d;
+                end
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) c <= 1'b0;
+                    else        c <= d;
                 end
                 assign q = a;
             end
@@ -167,7 +179,7 @@ def test_generate_if_taken_branch_emits_flops(tmp_path: Path) -> None:
     """
     mod = _elaborate(tmp_path, src)
     n = _flop_count(mod)
-    # USE_SYNC=1: g_sync branch has {meta_q, sync_q} = 2 flops; g_passthrough
+    # USE_SYNC=1: g_sync branch has meta_q + sync_q = 2 flops; g_passthrough
     # is unelaborated and contributes 0.
     assert n == 2, f"expected 2 flops from g_sync branch only; got {n}"
 
@@ -184,15 +196,27 @@ def test_generate_if_untaken_branch_emits_zero(tmp_path: Path) -> None:
             if (USE_SYNC) begin : g_sync
                 logic meta_q, sync_q;
                 always_ff @(posedge clk or negedge rst_n) begin
-                    if (!rst_n) {sync_q, meta_q} <= '0;
-                    else        {sync_q, meta_q} <= {meta_q, d};
+                    if (!rst_n) meta_q <= 1'b0;
+                    else        meta_q <= d;
+                end
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) sync_q <= 1'b0;
+                    else        sync_q <= meta_q;
                 end
                 assign q = sync_q;
             end else begin : g_passthrough
                 logic a, b, c;
                 always_ff @(posedge clk or negedge rst_n) begin
-                    if (!rst_n) {a, b, c} <= '0;
-                    else        {a, b, c} <= {d, d, d};
+                    if (!rst_n) a <= 1'b0;
+                    else        a <= d;
+                end
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) b <= 1'b0;
+                    else        b <= d;
+                end
+                always_ff @(posedge clk or negedge rst_n) begin
+                    if (!rst_n) c <= 1'b0;
+                    else        c <= d;
                 end
                 assign q = a;
             end


### PR DESCRIPTION
## Summary

Fixes [#53](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/53) — the slang frontend's `_walk_instance` iterated `inst.body` directly, so every member that lived inside an SV `generate` block was silently invisible to the analyzer. On the real ~170k-gate `ip_demo_tiny_npu` top (N×N MXP generate-for array, per-row VXP, per-channel forwarded-clock fabric) the frontend reported **28 flops and 0 crossings in 0.98 s** — a confident PASS that was a false negative. After this PR, the same design elaborates to **~230 flops** under the slang frontend (and ~950 once [#54](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/...) lands on top); the false-PASS goes away.

## Approach

Factor the body traversal through a new `_iter_scope(container, hier_prefix)` generator that recursively expands the two pyslang generate kinds while accumulating naming-segment prefixes:

- `GenerateBlockArraySymbol` — labeled `for (genvar i = ...)` array. Each entry is a `GenerateBlockSymbol` with `arrayIndex` set; prefix gets `g_label[<idx>].` appended.
- `GenerateBlockSymbol` — single unconditional block, or the elaborated arm of `generate if` / `generate case`. Named blocks contribute `<name>.`; anonymous blocks collapse into the parent scope.

Naming follows Yosys-flatten convention (`g_label[i].$adff$N`), so cell names stay stable across the two frontends — the rule pack's path reporting and any downstream waiver regexes don't have to branch on the frontend.

`_walk_instance` now runs each of its three passes (variables, ports, cells) over the flattened scope. For pass 3, the per-member `prefix` gets pushed onto `_hier_stack` while emitting so `_fresh_cell_name` produces `g_label[i].$slang$adff$N` instead of the active instance's prefix.

## Drive-by

`_const_int` now correctly unwraps pyslang's `ConstantValue` wrapper (returned by `NamedValueExpression.constant` on a folded genvar reference) via `.value` / `convertToInt()`. Before this, `int(ConstantValue)` raised `TypeError`, the helper caught it, and `_element_select_bits` returned `None` → procedural assignments to `q[i]` inside a generate-for were dropped even after the body walker reached them. Without this fix, the generate-block traversal would still emit zero flops for the canonical array-of-flops shape.

## Test plan

- [x] 6 new tests in `tests/test_slang_generate_blocks.py` cover 1-D generate-for, indexed labels, 2-D nested (mimics MXP slice array), generate-if (taken / untaken branches), and a child module whose body has a generate-for visible from the parent's elaboration.
- [x] Full pytest suite: `161 passed, 2 skipped` (no regression — slang elaboration tests, yosys-frontend tests, fixture parity all green).
- [x] End-to-end on `ip_demo_tiny_npu` full-top: flop count rises from 28 → ~230, walk time stays under 2 s. Sub-block `ip_dtnpu_credit_cdc` at full slang/yosys parity (4 flops both).
- [x] Downstream cross-validation: rtl-buddy-project-template CDC regression matches released-baseline counts (3 / 11 / 4) — fix is contained to the slang frontend, yosys path unchanged.

## Out of scope

- Statement-walker coverage inside `always_ff` (case / nested if) — separate gap, follow-up PR.
- Concatenation LHS lowering, gray-code shape recognition under slang, and clock identity propagation through `ip_dtnpu_clk_buf` — independent issues, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
