### PR TITLE
fix(slang): allocate distinct bits per unpacked-array element

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -447,11 +447,18 @@ class _ModuleBuilder:
         t = getattr(var_sym, "type", None)
         if t is None:
             return 1
-        # bitWidth is present on integral types; non-integral types
-        # (e.g. interfaces, modports) aren't supported yet — width 1
-        # is a safe placeholder that surfaces as a malformed cell
-        # downstream rather than crashing the build.
-        return int(getattr(t, "bitWidth", 1) or 1)
+        # ``selectableWidth`` is the total number of bits the type
+        # spans, including any unpacked dimensions. pyslang reports
+        # ``bitWidth = 0`` on unpacked-array types and the full
+        # storage count on ``selectableWidth``; for packed types and
+        # scalars the two agree, so this is the right number to use
+        # uniformly. Non-integral types (interfaces, modports) report
+        # 0 / no attribute — fall back to 1 as a placeholder that
+        # surfaces as a malformed cell downstream rather than
+        # crashing the build.
+        return int(
+            getattr(t, "selectableWidth", None) or getattr(t, "bitWidth", None) or 1
+        )
 
     def _fresh_cell_name(self, type_str: str) -> str:
         # Yosys autogen names look like "$procdff$3" — we don't need
@@ -1033,7 +1040,20 @@ class _ModuleBuilder:
         return None
 
     def _element_select_bits(self, expr: Any) -> tuple[Bit, ...] | None:
-        """``var[i]`` — return the single-bit subset of ``var``'s bits.
+        """``var[i]`` — return the bit subset of ``var`` that the
+        index picks out.
+
+        Stride is the element type's storage width:
+
+        - For packed arrays (``logic [W-1:0] data``) the element type
+          is a scalar and the stride is 1 — ``data[i]`` returns one
+          bit.
+        - For unpacked arrays (``logic chain [N]``) the element type
+          is the inner type and the stride is its ``selectableWidth``
+          — ``chain[i]`` returns one stripe.
+        - For packed-and-unpacked (``logic [W-1:0] chain [STAGES]``)
+          the outer type is the unpacked array, its element type is
+          the packed type, so each ``chain[i]`` returns W bits.
 
         Falls back to ``None`` when the underlying value isn't a bare
         named variable (e.g. nested selects, slices of expressions),
@@ -1047,10 +1067,30 @@ class _ModuleBuilder:
         idx = self._const_int(getattr(expr, "selector", None))
         if idx is None:
             return None
-        var_bits = self._alloc_bits(inner.symbol)
-        if not (0 <= idx < len(var_bits)):
+        var_sym = inner.symbol
+        var_bits = self._alloc_bits(var_sym)
+        # Stride = element type's selectableWidth. For scalar-element
+        # cases (packed arrays where the element is ``logic`` etc.)
+        # this is 1, matching the original single-bit semantics.
+        var_type = getattr(var_sym, "type", None)
+        elem_type = getattr(var_type, "elementType", None) if var_type else None
+        stride = 1
+        if elem_type is not None:
+            stride = int(
+                getattr(elem_type, "selectableWidth", None)
+                or getattr(elem_type, "bitWidth", None)
+                or 1
+            )
+        # The element-select index counts in *elements*, not bits.
+        # For an unpacked-then-packed type the outer ``range`` runs
+        # over the unpacked dimension; pyslang folds the constant to
+        # the unpacked index. Bits are stored low-element-first
+        # (matching how Yosys-flatten lays out the unpacked dim).
+        start = idx * stride
+        end = start + stride
+        if start < 0 or end > len(var_bits):
             return None
-        return (var_bits[idx],)
+        return tuple(var_bits[start:end])
 
     def _range_select_bits(self, expr: Any) -> tuple[Bit, ...] | None:
         """``var[hi:lo]`` — return the contiguous bit subset.

--- a/tests/test_slang_unpacked_array.py
+++ b/tests/test_slang_unpacked_array.py
@@ -148,7 +148,6 @@ def test_ip_cdc_sync_shape_under_for_loop(tmp_path: Path) -> None:
         "(if 1 → unpacked-array collapse; if 0 → for-loop unroll missing)"
     )
     q_bits = [f.connections["Q"][0] for f in flops]
-    d_bits = [f.connections["D"][0] for f in flops]
     assert len(set(q_bits)) == 2, (
         f"sync stages must have distinct Q bits; got Qs={q_bits}"
     )

--- a/tests/test_slang_unpacked_array.py
+++ b/tests/test_slang_unpacked_array.py
@@ -1,0 +1,162 @@
+"""Coverage tests for slang-frontend handling of SV unpacked arrays.
+
+Issue: rtl-buddy-cdc#62 — :meth:`_width_of` sizes a variable's bit
+pool from its packed width only, so unpacked-dim variables
+(``logic chain [N]`` or the production
+``logic [W-1:0] sync_chain [STAGES]`` shape used by ``ip_cdc_sync``)
+collapse to a single shared bit pool. ``chain[0]`` and ``chain[1]``
+alias to the same bit; downstream the rule pack sees a sync chain
+of "depth = 1" and CDC-001 false-positives for every standard
+synchronizer instance in a design.
+
+The tests below pin the contract: an N-element unpacked array
+(possibly with a packed inner dim) allocates ``N * inner_width``
+distinct bits, and element selects on it pick the right
+``inner_width``-bit stripe.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang unpacked-array tests are gated on it",
+        allow_module_level=True,
+    )
+
+FLOP_TYPES = frozenset({"$dff", "$adff", "$dffe", "$adffe", "$sdff", "$sdffe"})
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _flops(module) -> list:
+    return [c for c in module.cells.values() if c.type in FLOP_TYPES]
+
+
+# --- bit allocation -------------------------------------------------------
+
+
+def test_unpacked_scalar_array_allocates_distinct_bits(tmp_path: Path) -> None:
+    """``logic chain [N]`` — N single-bit elements. Each element
+    select must land on its own bit, otherwise a chain of length-N
+    synchronizers collapses to one flop."""
+    src = """
+    module m (input logic clk, d, output logic q);
+        logic chain [3];
+        always_ff @(posedge clk) begin
+            chain[0] <= d;
+            chain[1] <= chain[0];
+            chain[2] <= chain[1];
+        end
+        assign q = chain[2];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 3, f"expected 3 flops, got {len(flops)}"
+    # The three flops must have three *distinct* Q bits.
+    q_bits = {f.connections.get("Q", ())[0] for f in flops}
+    assert len(q_bits) == 3, (
+        f"expected three distinct Q bits; got {q_bits} "
+        "(collapse implies unpacked-array elements alias)"
+    )
+    # And each successive flop's D must equal the previous flop's Q —
+    # this is the cascade that makes a sync chain *be* a sync chain.
+    sorted_flops = sorted(flops, key=lambda c: c.name)
+    for prev, curr in zip(sorted_flops, sorted_flops[1:]):
+        prev_q = prev.connections["Q"][0]
+        curr_d = curr.connections["D"][0]
+        assert prev_q == curr_d, (
+            f"cascade broken: {curr.name}.D={curr_d} ≠ {prev.name}.Q={prev_q}"
+        )
+
+
+def test_packed_and_unpacked_array_correct_stride(tmp_path: Path) -> None:
+    """``logic [W-1:0] chain [STAGES]`` — the production ip_cdc_sync
+    shape. Each unpacked element holds W packed bits; an element
+    select must return W bits, and consecutive elements occupy
+    non-overlapping W-bit stripes."""
+    src = """
+    module m #(parameter int W = 4, parameter int STAGES = 3) (
+        input  logic clk,
+        input  logic [W-1:0] d,
+        output logic [W-1:0] q
+    );
+        logic [W-1:0] chain [STAGES];
+        always_ff @(posedge clk) begin
+            chain[0] <= d;
+            chain[1] <= chain[0];
+            chain[2] <= chain[1];
+        end
+        assign q = chain[STAGES-1];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    # Each flop is multi-bit (WIDTH=W). Width-4 flops at 3 sites = 3
+    # cells (each flop is a single ``$dff`` of width W with W-bit Q/D).
+    assert len(flops) == 3, f"expected 3 flops (one per chain entry); got {len(flops)}"
+    for f in flops:
+        q = f.connections.get("Q", ())
+        d = f.connections.get("D", ())
+        assert len(q) == 4, f"flop {f.name} Q width = {len(q)}, expected 4"
+        assert len(d) == 4, f"flop {f.name} D width = {len(d)}, expected 4"
+    # Distinct stripes: each flop's Q bits must be a disjoint 4-bit set.
+    q_sets = [set(f.connections["Q"]) for f in flops]
+    all_q = set().union(*q_sets)
+    assert len(all_q) == 12, (
+        f"expected 12 distinct Q bits across the 3 stripes; got {len(all_q)}: {all_q}"
+    )
+
+
+def test_ip_cdc_sync_shape_under_for_loop(tmp_path: Path) -> None:
+    """Matches the production ``ip_cdc_sync`` body verbatim: packed-
+    and-unpacked array iterated by a procedural for-loop. Crosses
+    issue #59 (for-loop unroll) and #62 (unpacked bit allocation) —
+    one flop per stage, each W bits wide, with the cascade
+    connecting consecutive stripes."""
+    src = """
+    module m #(parameter int W = 1, parameter int STAGES = 2) (
+        input  logic clk,
+        input  logic [W-1:0] d,
+        output logic [W-1:0] q
+    );
+        logic [W-1:0] chain [STAGES];
+        always_ff @(posedge clk) begin
+            chain[0] <= d;
+            for (int i = 1; i < STAGES; i++)
+                chain[i] <= chain[i-1];
+        end
+        assign q = chain[STAGES-1];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 2, (
+        f"expected STAGES=2 flops; got {len(flops)} "
+        "(if 1 → unpacked-array collapse; if 0 → for-loop unroll missing)"
+    )
+    q_bits = [f.connections["Q"][0] for f in flops]
+    d_bits = [f.connections["D"][0] for f in flops]
+    assert len(set(q_bits)) == 2, (
+        f"sync stages must have distinct Q bits; got Qs={q_bits}"
+    )
+    # The two D bits must include one external (the d port bit) and
+    # one internal (the first stage's Q). Validates the cascade.
+    sorted_flops = sorted(flops, key=lambda c: c.name)
+    stage0_q = sorted_flops[0].connections["Q"][0]
+    stage1_d = sorted_flops[1].connections["D"][0]
+    assert stage0_q == stage1_d, (
+        f"cascade broken: stage1.D={stage1_d} should equal stage0.Q={stage0_q}"
+    )


### PR DESCRIPTION
## Summary

Fixes [#62](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/62). `_width_of` sized variables by `bitWidth` only — pyslang reports `bitWidth = 0` on unpacked-array types and the full storage count on `selectableWidth`. Result: `logic chain [N]` got 1 bit total (falling back through `... or 1`), every element select aliased to that bit, and a width-N synchronizer chain collapsed to a width-1 self-loop. Downstream, the rule pack saw `depth = 1` sync chains and fired 18 false CDC-001 violations on `ip_demo_tiny_npu`'s full-top (every `ip_cdc_sync` instance in the design).

Follow-up to [#53](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/57), [#54](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/58), [#59](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/61) — same architectural concern (slang-frontend completeness on real designs).

## Approach

Two coordinated changes:

- **`_width_of`** now reads `selectableWidth` first (total bits including unpacked dims), falling back to `bitWidth` for scalar / packed-only types where the two agree. The bit pool for `logic [W-1:0] chain [STAGES]` is now `W × STAGES` bits, laid out one stripe per unpacked element.
- **`_element_select_bits`** computes its stride from the element type's `selectableWidth` so `chain[i]` returns one full element's bits — 1 bit for scalar elements (matching the original single-bit semantics for packed arrays where the element is `logic`), W bits for `[W-1:0]`-typed elements.

Range selects across unpacked elements (`chain[1:0]`) are rare in `always_ff` bodies; the existing `_range_select_bits` keeps its single-bit-stride semantics for now. Multi-dim unpacked arrays (`logic chain [N][M]`) also stay out — flag-and-skip via the `None`-return path until a real design hits them.

## Test plan

- [x] 3 new tests in `tests/test_slang_unpacked_array.py`: scalar unpacked array with cascade (distinct bits + cascade integrity), packed-and-unpacked with W-bit stripes (3 × 4 = 12 distinct bits), and the production `ip_cdc_sync` body under a procedural for-loop (crosses #59).
- [x] Full pytest suite: `188 passed, 2 skipped, 1 xfailed` (strict-xfail on [#55](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/55) still fires; no other regressions).
- [x] Lint + format + mypy clean.
- [x] End-to-end on `ip_demo_tiny_npu`: violations drop from 23 → **5**. Specifically:
  - **All 18 CDC-001 sync-depth false-positives cleared** (`ip_cdc_sync` instances now correctly seen as 2-stage).
  - Flop count rises 1035 → **1073** (the per-stripe flops inside sync chains are now visible).
  - 5 CDC-004 violations remain on bus crossings through `u_dma_rd_cmd_cdc` / `u_dma_wr_cmd_cdc`. Those are handshake-toggle-gated buses (`ip_cdc_handshake`'s 4-phase req/ack), which the rule pack's CDC-004 detector doesn't structurally recognize today — different gap, separate detector.

## Iteration arc

| Stage | Flops | Resolved | Crossings | Async | Violations |
|---|---:|---:|---:|---:|---:|
| Baseline | 28 | 28 | 0 | 0 | 0 (false PASS) |
| After #53 (generates) | 228 | 96 | 0 | 0 | 0 |
| After #54 (case/if) | 949 | 433 | 0 | 0 | 0 |
| After SDC `create_generated_clock` | 949 | 949 | 56 | 0 | 0 |
| After #59 (for-loop) | 1035 | 1035 | 95 | 27 | 23 (false-pos from #62) |
| **After this PR** | **1073** | **1073** | **95** | **27** | **5** (real handshake-gated buses) |

## Out of scope

- Range selects across multiple unpacked elements — flag-and-skip; rare in `always_ff`.
- Multi-dim unpacked arrays (`logic [N][M]`) — same.
- Dynamic / associative arrays — synth doesn't model these; same flag-and-skip policy.
- Handshake-toggle gating detection for CDC-004 — separate gap; will file follow-up.
- Yosys frontend, rule semantics, JSON schema — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
