### PR TITLE
fix(slang): infer hold-feedback mux from `if (cond) q <= ...`

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -244,6 +244,16 @@ class _ModuleBuilder:
         # selects like ``chain[i]`` fold to the per-iteration bit while
         # the for-loop body is being walked. See ``_emit_for_loop``.
         self._loop_bindings: dict[Any, int] = {}
+        # Stack of single-bit enable signals active in the current
+        # always_ff walk. Pushed when entering the ifTrue arm of a
+        # no-else ``ConditionalStatement`` (the canonical
+        # ``if (cond) q <= ...;`` load gate); consulted by
+        # ``_emit_assignment_expression`` to wrap the flop's D in a
+        # hold-feedback mux. Yosys's ``proc_dff`` pass infers the same
+        # mux from the if/else structure; matching that lets the rule
+        # pack's ``_is_gated_bus_crossing`` recognise handshake-gated
+        # buses. See issue #64.
+        self._enable_stack: list[Bit] = []
 
     # -- public ----------------------------------------------------------
 
@@ -787,13 +797,43 @@ class _ModuleBuilder:
         if kind == "ConditionalStatement":
             # Nested if/else inside the data branch (or an if/else-if
             # chain that pyslang represents as recursive Conditionals).
-            # Both arms are clocked data paths — walk both. Conditions
-            # themselves are pure combinational, only their bodies
-            # contribute flops.
-            for arm in (statement.ifTrue, statement.ifFalse):
-                self._emit_assignments_in(
-                    arm, clk_sym, reset_sym, reset_active_low, src_node
-                )
+            #
+            # For the simple ``if (cond) q <= ...;`` shape with no
+            # else, push ``cond`` onto the enable stack while walking
+            # the ifTrue arm so ``_emit_assignment_expression`` can
+            # wrap the flop's D in a hold-feedback mux. This is the
+            # canonical handshake-gated bus shape — ``ip_cdc_handshake``
+            # consumers latch the bus only when a synchronized
+            # ``cmd_valid`` pulses, and Yosys's ``proc_dff`` pass
+            # infers the same mux automatically.
+            #
+            # If/else with an explicit else: both arms walked
+            # unconditionally (current behavior). Proper handling of
+            # both-arms-write-same-LHS needs deferred emission and a
+            # mux tree per LHS — separate follow-up. Most CDC-relevant
+            # shapes (FSM-loaded bus, capture-on-valid, handshake
+            # bypass) use the no-else form.
+            if statement.ifFalse is None:
+                cond_bit = self._lower_condition_to_bit(statement.conditions)
+                pushed = cond_bit is not None
+                if cond_bit is not None:
+                    self._enable_stack.append(cond_bit)
+                try:
+                    self._emit_assignments_in(
+                        statement.ifTrue,
+                        clk_sym,
+                        reset_sym,
+                        reset_active_low,
+                        src_node,
+                    )
+                finally:
+                    if pushed:
+                        self._enable_stack.pop()
+            else:
+                for arm in (statement.ifTrue, statement.ifFalse):
+                    self._emit_assignments_in(
+                        arm, clk_sym, reset_sym, reset_active_low, src_node
+                    )
             return
         if kind == "CaseStatement":
             # Each item is an ``ItemGroup`` with the match expressions
@@ -990,6 +1030,15 @@ class _ModuleBuilder:
             # input as opaque (no upstream flops trace through it).
             d_bits = self._unknown_driver(width=len(q_bits))
 
+        # If we're inside a ``if (cond) q <= ...;`` body (no else),
+        # wrap D in a hold-feedback mux: ``D = mux(S=cond, A=Q, B=rhs)``.
+        # Yosys's proc_dff infers the same shape from the SV
+        # if/else structure. The rule pack's gated-bus detector
+        # (``_is_gated_bus_crossing``) checks for this mux when
+        # deciding whether a multi-bit crossing is handshake-protected.
+        if self._enable_stack:
+            d_bits = self._wrap_d_with_enable_mux(d_bits, q_bits)
+
         connections: dict[str, tuple[Bit, ...]] = {
             "CLK": self._alloc_bits(clk_sym),
             "D": d_bits,
@@ -1026,6 +1075,104 @@ class _ModuleBuilder:
             parameters=parameters,
             attributes=attrs,
         )
+
+    def _lower_condition_to_bit(self, conditions: Any) -> Bit | None:
+        """Lower a ``ConditionalStatement``'s condition list to a
+        single Yosys-shape bit suitable for use as a mux ``S`` input.
+
+        pyslang represents the conditions as a list of
+        ``ConditionalPattern`` entries; for the canonical
+        ``if (expr)`` form there is exactly one entry whose ``.expr``
+        is the bool/scalar expression. Returns ``None`` if the
+        condition can't be lowered to a single bit (multi-pattern
+        match, anything ``_bits_of_expression`` doesn't model yet) —
+        the caller treats that as "no enable inferred" and falls
+        back to the unconditional emit path.
+        """
+        condition_list = list(conditions) if conditions else []
+        if len(condition_list) != 1:
+            return None
+        expr = getattr(condition_list[0], "expr", None)
+        if expr is None:
+            return None
+        bits = self._bits_of_expression(expr)
+        if bits is None:
+            return None
+        # ``if (expr)`` treats the expression as a boolean. For a
+        # single-bit signal that's already correct; for a multi-bit
+        # signal SV semantics are "non-zero is true", but in practice
+        # always_ff conditions in production RTL are single-bit
+        # qualifiers. Bail when the width doesn't fit.
+        if len(bits) != 1:
+            return None
+        return bits[0]
+
+    def _wrap_d_with_enable_mux(
+        self, d_bits: tuple[Bit, ...], q_bits: tuple[Bit, ...]
+    ) -> tuple[Bit, ...]:
+        """Wrap ``d_bits`` in a hold-feedback mux gated by the AND of
+        every enable currently on ``_enable_stack``.
+
+        Returns the mux output bits, which become the flop's new D
+        connection: ``D = mux(S = AND(enables), A = Q_feedback,
+        B = original_D)``. The mux's A operand is the flop's own Q —
+        when the enable is false, the flop holds its previous value;
+        when true, it captures ``original_D``. That's exactly the
+        shape Yosys's ``proc_dff`` infers from ``if (en) q <= ...;``.
+
+        For multiple stacked enables (nested ``if (a) if (b) ...``),
+        chain ``$and`` cells: the deepest enable bit is the most
+        recently pushed, and AND'ing them yields a single select bit.
+        """
+        # Combine all stacked enables via ``$and``. Single-enable
+        # case: just use the bit directly, no AND needed.
+        if len(self._enable_stack) == 1:
+            select_bit: Bit = self._enable_stack[0]
+        else:
+            select_bit = self._enable_stack[0]
+            for next_bit in self._enable_stack[1:]:
+                and_y = self._alloc_anon_bits(1)
+                cell_name = self._fresh_cell_name("$and")
+                self._cells[cell_name] = Cell(
+                    name=cell_name,
+                    type="$and",
+                    connections={
+                        "A": (select_bit,),
+                        "B": (next_bit,),
+                        "Y": and_y,
+                    },
+                    parameters={},
+                    attributes={},
+                )
+                select_bit = and_y[0]
+
+        # Allocate fresh output bits for the mux. Width matches the
+        # original D / Q width (they must match — Q drives the hold
+        # path).
+        width = len(d_bits)
+        mux_y = self._alloc_anon_bits(width)
+        mux_name = self._fresh_cell_name("$mux")
+        self._cells[mux_name] = Cell(
+            name=mux_name,
+            type="$mux",
+            connections={
+                "A": q_bits,
+                "B": d_bits,
+                "S": (select_bit,),
+                "Y": mux_y,
+            },
+            parameters={},
+            attributes={},
+        )
+        return mux_y
+
+    def _alloc_anon_bits(self, width: int) -> tuple[Bit, ...]:
+        """Allocate ``width`` fresh anonymous bits for a comb cell's
+        output. Same allocator pool as named variables; no Symbol is
+        registered because these aren't user-visible nets."""
+        bits = tuple(range(self._next_bit_id, self._next_bit_id + width))
+        self._next_bit_id += width
+        return bits
 
     def _lvalue_bits(self, expr: Any) -> tuple[Bit, ...] | None:
         """Resolve an LHS expression to the variable-bit subset it

--- a/tests/test_slang_enable_inference.py
+++ b/tests/test_slang_enable_inference.py
@@ -1,0 +1,172 @@
+"""Coverage tests for slang-frontend enable inference on conditional
+nonblocking assignments.
+
+Issue: rtl-buddy-cdc#64 — when an ``always_ff`` body contains a
+conditional load like ``if (cond) q <= rhs;``, the slang frontend
+emits ``$adff(D=rhs, Q=q)`` directly, ignoring the surrounding
+``cond`` enable. Yosys's ``proc_dff`` pass infers a hold-feedback mux
+(``$mux(S=cond, A=q-feedback, B=rhs)``) driving D so the rule pack's
+``_is_gated_bus_crossing`` can recognise handshake-protected buses.
+Without the inference, every conditionally-loaded multi-bit register
+fanned out from a synchronizer hits CDC-004 — and the production
+``ip_cdc_handshake`` shape generates the textbook example.
+
+The tests below pin the contract: a conditional nonblocking assign
+inside an ``always_ff`` body emits a ``$mux`` whose ``S`` traces back
+to the condition expression.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang enable-inference tests are gated on it",
+        allow_module_level=True,
+    )
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _build_drivers(mod) -> dict:
+    """Bit → (cell_name, port_name) for every cell output bit."""
+    drv = {}
+    for name, cell in mod.cells.items():
+        for port, bits in cell.connections.items():
+            if port in ("Q", "Y"):
+                for b in bits:
+                    if isinstance(b, int):
+                        drv[b] = (name, port)
+    return drv
+
+
+def _flop_d_driver(mod, flop_name: str):
+    """Cell that drives the first D-bit of ``flop_name``."""
+    cell = mod.cells[flop_name]
+    d_bits = cell.connections.get("D", ())
+    drivers = _build_drivers(mod)
+    return drivers.get(d_bits[0]) if d_bits else None
+
+
+# --- single-level enable inference ----------------------------------------
+
+
+def test_simple_if_enable_emits_mux(tmp_path: Path) -> None:
+    """``if (en) q <= d;`` — emit a ``$mux`` with the enable on
+    ``S``, the hold-feedback (from Q) on ``A``, and the RHS on
+    ``B``. Without enable inference, the dst flop's D is wired
+    straight to the source-domain ``d`` port and the rule pack's
+    gated-bus detector can't recognise the protection."""
+    src = """
+    module m (input logic clk, rst_n, en, input logic [3:0] d, output logic [3:0] q);
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 4'd0;
+            else if (en) q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = [c for c in mod.cells.values() if c.type.startswith("$adff")]
+    assert len(flops) == 1, f"expected one $adff for q; got {len(flops)}"
+    flop = flops[0]
+    drv = _flop_d_driver(mod, flop.name)
+    assert drv is not None, "no driver found for the flop's D"
+    drv_cell = mod.cells[drv[0]]
+    assert drv_cell.type == "$mux", (
+        f"expected $mux driving D; got {drv_cell.type}. "
+        "Without enable inference, the rule pack's gated-bus detector "
+        "can't recognise handshake-protected crossings."
+    )
+    # S input should resolve to a single bit (the en port).
+    s_bits = drv_cell.connections.get("S", ())
+    assert len(s_bits) == 1, f"$mux S width = {len(s_bits)}, expected 1"
+
+
+def test_nested_if_anded_enables(tmp_path: Path) -> None:
+    """``if (a) if (b) q <= d;`` — nested enables AND together. The
+    leaf mux's S must depend on both ``a`` and ``b``."""
+    src = """
+    module m (input logic clk, rst_n, a, b, d, output logic q);
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 1'b0;
+            else if (a)
+                if (b) q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = [c for c in mod.cells.values() if c.type.startswith("$adff")]
+    assert len(flops) == 1
+    drv = _flop_d_driver(mod, flops[0].name)
+    assert drv is not None
+    drv_cell = mod.cells[drv[0]]
+    assert drv_cell.type == "$mux", f"expected $mux driving D; got {drv_cell.type}"
+    # The mux S should connect (transitively) to BOTH a and b. The
+    # simplest way to express that: the mux's S fanin (one level back)
+    # should land on an $and cell whose inputs reach the two port bits.
+    s_drv = _build_drivers(mod).get(drv_cell.connections["S"][0])
+    assert s_drv is not None, "mux S has no driver"
+    s_cell = mod.cells[s_drv[0]]
+    assert s_cell.type == "$and", (
+        f"nested if must AND its conditions; got driver type {s_cell.type}"
+    )
+
+
+# If/else with both arms writing the same LHS needs deferred-emission
+# (one flop per LHS with a mux tree built from the per-arm tuples) —
+# out of scope for #64. Tracked as a follow-up; the simple-if case
+# below covers every shape the production handshake-gated buses use.
+
+
+# --- the production handshake-protected-bus shape -------------------------
+
+
+def test_handshake_protected_bus_gets_mux(tmp_path: Path) -> None:
+    """Mimics the ip_demo_tiny_npu DMA's `rd_addr_q` capture: a
+    multi-bit register loaded only when a synchronized cmd_valid
+    pulses. After this fix, the dst flop's D should be driven by a
+    mux gated by cmd_valid."""
+    src = """
+    module m (
+        input  logic       a_clk, a_rst_n,
+        input  logic       cmd_valid,
+        input  logic [3:0] cmd_addr,
+        output logic [3:0] addr_q
+    );
+        always_ff @(posedge a_clk or negedge a_rst_n) begin
+            if (!a_rst_n) addr_q <= 4'd0;
+            else if (cmd_valid) addr_q <= cmd_addr;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = [c for c in mod.cells.values() if c.type.startswith("$adff")]
+    assert len(flops) == 1
+    drv = _flop_d_driver(mod, flops[0].name)
+    assert drv is not None
+    drv_cell = mod.cells[drv[0]]
+    assert drv_cell.type == "$mux", (
+        f"expected $mux driving D for handshake-gated bus; got {drv_cell.type}"
+    )
+    # Mux S = cmd_valid (single bit), B = cmd_addr, A = current Q.
+    s_bits = drv_cell.connections.get("S", ())
+    a_bits = drv_cell.connections.get("A", ())
+    b_bits = drv_cell.connections.get("B", ())
+    assert len(s_bits) == 1
+    assert len(a_bits) == 4 and len(b_bits) == 4
+    # The hold-feedback shape: A must equal the flop's own Q bits.
+    q_bits = tuple(flops[0].connections["Q"])
+    assert tuple(a_bits) == q_bits, (
+        f"hold-feedback mux must wire A back to Q; got A={a_bits} Q={q_bits}"
+    )


### PR DESCRIPTION
## Summary

Fixes [#64](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/64). `_emit_assignment_expression` wired the destination flop's `D` directly to the RHS of the nonblocking assignment, ignoring any surrounding `if (cond) q <= ...;` enable. Yosys's `proc_dff` pass infers a hold-feedback mux (`$mux(S=cond, A=Q, B=rhs)`) on the same SV shape; matching that mux is what lets the rule pack's `_is_gated_bus_crossing` recognise handshake-gated buses.

Without enable inference, every conditionally-loaded multi-bit register fanned out from a synchronizer hit CDC-004. On `ip_demo_tiny_npu` after [#62](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/63) landed: the 5 remaining CDC-004 violations were all canonical `rd_addr_q <= a_rd_cmd_addr` captures gated by `a_rd_cmd_valid` (the `dst_valid` output of `ip_cdc_handshake`).

Companion to [#53](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/53), [#54](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/54), [#59](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/59), [#62](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/62) — same architectural concern (slang-frontend completeness on real designs).

## Approach

- `_enable_stack` (new instance state) tracks single-bit conditions active in the current `always_ff` walk. Pushed by `_emit_assignments_in` when entering the `ifTrue` arm of a no-else `ConditionalStatement`.
- `_lower_condition_to_bit` lowers a pyslang `ConditionalPattern` list to a single bit via the existing `_bits_of_expression`. Bails on multi-pattern or non-single-bit conditions — handled conservatively (no enable inferred, falls back to the current emit path).
- `_emit_assignment_expression` consults `_enable_stack` before wiring the flop's D. When non-empty, wraps D in `$mux(S=AND(enables), A=Q, B=original_D)` via `_wrap_d_with_enable_mux`. Multiple stacked enables chain `$and` cells (nested `if (a) if (b)` ANDs both conditions onto the mux select).

`if/else` with both arms writing the same LHS needs deferred-emission (one flop per LHS with a mux tree per RHS) — separate follow-up; doesn't gate the production handshake-gated bus shape this PR targets.

## Test plan

- [x] 3 new tests in `tests/test_slang_enable_inference.py`: single-level if-enable emits mux, nested if ANDs its conditions, the handshake-protected-bus shape (the exact DMA `rd_addr_q` capture) emits the hold-feedback mux with A wired to Q.
- [x] Full pytest suite: `191 passed, 2 skipped, 1 xfailed` (strict-xfail on [#55](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/55) still fires; no other regressions).
- [x] Lint + format + mypy clean.
- [x] End-to-end on `ip_demo_tiny_npu` full-top: **violations drop from 5 → 0, the design now PASSes**. 1073 flops, 95 crossings, 27 async — same totals as #62, all classified correctly.

## Iteration arc (closing)

| Stage | Flops | Resolved | Crossings | Async | Violations | Result |
|---|---:|---:|---:|---:|---:|---|
| Baseline | 28 | 28 | 0 | 0 | 0 | false PASS |
| After [#53](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/53) | 228 | 96 | 0 | 0 | 0 | partial |
| After [#54](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/54) | 949 | 433 | 0 | 0 | 0 | partial |
| After SDC `create_generated_clock` | 949 | 949 | 56 | 0 | 0 | partial |
| After [#59](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/59) | 1035 | 1035 | 95 | 27 | 23 | partial |
| After [#62](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/62) | 1073 | 1073 | 95 | 27 | 5 | partial |
| **After this PR** | **1073** | **1073** | **95** | **27** | **0** | **PASS** |

## Out of scope

- `if/else` with both arms writing the same LHS — needs deferred emission. Separate follow-up.
- Case-arm enable inference — not gating the tiny-NPU report; deferrable.
- Multi-bit conditions (`if (vec)` treating vec as bool) — bail rather than wrong shape; SV semantics are "non-zero is true", but production always_ff conditions are single-bit qualifiers.
- Yosys frontend, rule semantics, JSON schema — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
