### PR TITLE
feat(slang): lower always_comb if/else and case into per-LHS $mux

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -29,6 +29,8 @@ fixture                             expected rules
 bad_single_ff_sync                  CDC-001
 bad_port_no_sync                    CDC-001
 bad_comb_before_sync                CDC-003
+bad_comb_before_sync_with_if        CDC-003 (if/else → $mux)
+bad_comb_case_before_sync           CDC-003 (case → chained $mux)
 bad_bus_crossing                    CDC-004
 bad_reconvergent_sync               CDC-005
 bad_comb_source                     CDC-006
@@ -82,6 +84,13 @@ What currently works
   expression operators round-trip to the Yosys cell zoo
   (``$and``/``$or``/``$xor``/``$mux``/…), so the rule pack walks
   the comb cone correctly.
+- ``always_comb`` procedural ``if`` / ``case`` selection — see
+  :meth:`_walk_conditional_statement` and
+  :meth:`_walk_case_statement`. Each LHS written across multiple
+  branches lowers to a real ``$mux`` (chained for ``case``, with
+  first-match-wins priority and ``default`` as the innermost
+  fallback); LHS written in only one branch keeps the existing
+  single-branch aliasing.
 - LHS bit-selects (``q[0] <= ...``) and contiguous ranges
   (``bus[3:0] <= ...``) — see :meth:`_lvalue_bits`. Same shapes
   accepted on the RHS via :meth:`_bits_of_expression`.
@@ -101,11 +110,10 @@ What currently works
 
 What is NOT yet implemented (next slices)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- **``always_comb`` with ``if`` / ``case``.** Body walks descend into
-  both branches and may produce inconsistent aliasing when each
-  branch writes the same variable. The full lowering builds a
-  ``$mux`` per LHS that appears in both branches; today we
-  conservatively pass through whichever branch wrote last.
+- **``casex`` / ``casez`` wildcard cases** — the
+  :meth:`_walk_case_statement` lowering treats every label as a
+  full ``$eq`` match, so wildcard bits in the label aren't honored.
+  Uncommon in CDC-sensitive code and not yet wired up.
 - **Width-N $dff / $adff parameters** (``WIDTH``, ``ARST_VALUE``)
   — partially populated today; not yet read by any rule but should
   reach full Yosys parity for future rule extensions.
@@ -1520,17 +1528,238 @@ class _ModuleBuilder:
             self._alias_assign(stmt.expr)
             return
         if kind == "ConditionalStatement":
-            # if/else in an always_comb is a selection between two
-            # assignments. The full lowering would build a $mux per LHS
-            # variable that appears in both branches; that's a follow-up
-            # — for now we descend into both branches so any unconditional
-            # writes get aliased and any conditional-only writes are
-            # missed (conservative).
+            self._walk_conditional_statement(stmt)
+            return
+        if kind == "CaseStatement":
+            self._walk_case_statement(stmt)
+            return
+        # for/while loops etc. → ignore for now.
+
+    def _walk_conditional_statement(self, stmt: Any) -> None:
+        """Lower an ``always_comb`` ``if`` / ``else`` into a per-LHS
+        ``$mux``.
+
+        Strategy: snapshot the alias state, walk each branch
+        independently, capture the per-branch result for every LHS
+        that was written, then merge:
+
+        - Written in **both** branches → emit ``$mux(S=cond, A=false,
+          B=true)`` and alias the LHS to the mux output.
+        - Written in **only one** branch → keep the single-branch
+          aliasing. Per SV ``always_comb`` semantics the unwritten side
+          is undefined, but the conservative choice (no mux) keeps the
+          rule pack's data-cone walk honest — we don't pretend the
+          condition gates the value when no real gate exists.
+
+        Cells emitted while walking each branch (e.g. ``$and`` for a
+        ``y = a & b`` body) are preserved across the snapshot/restore
+        — only the alias maps are rolled back, so the bits returned
+        by ``_bits_of_expression`` still resolve to a real Yosys cell.
+        """
+        conds = getattr(stmt, "conditions", None) or []
+        sel_bits = (
+            self._bits_of_expression(conds[0].expr)
+            if conds and conds[0].expr is not None
+            else None
+        )
+        if sel_bits is None:
+            # Can't lower the selector → conservative descend. Matches
+            # pre-mux behaviour: unconditional writes get aliased, any
+            # branch-mismatched LHS picks "whichever wrote last".
             self._walk_comb_statement(stmt.ifTrue)
             if stmt.ifFalse is not None:
                 self._walk_comb_statement(stmt.ifFalse)
             return
-        # case statements, for/while loops, etc. → ignore for now.
+
+        base_var_bits = dict(self._var_bits)
+        base_ports = dict(self._ports)
+        base_netnames = dict(self._netnames)
+
+        self._walk_comb_statement(stmt.ifTrue)
+        true_var_bits = dict(self._var_bits)
+        self._var_bits = dict(base_var_bits)
+        self._ports = dict(base_ports)
+        self._netnames = dict(base_netnames)
+
+        if stmt.ifFalse is not None:
+            self._walk_comb_statement(stmt.ifFalse)
+            false_var_bits = dict(self._var_bits)
+            self._var_bits = dict(base_var_bits)
+            self._ports = dict(base_ports)
+            self._netnames = dict(base_netnames)
+        else:
+            # No else → the false side is the prior value.
+            false_var_bits = dict(base_var_bits)
+
+        all_vars: set[Any] = set()
+        for k, v in true_var_bits.items():
+            if base_var_bits.get(k) != v:
+                all_vars.add(k)
+        for k, v in false_var_bits.items():
+            if base_var_bits.get(k) != v:
+                all_vars.add(k)
+
+        for var in all_vars:
+            base_v = base_var_bits.get(var)
+            t = true_var_bits.get(var)
+            f = false_var_bits.get(var)
+            t_changed = t is not None and t != base_v
+            f_changed = f is not None and f != base_v
+            if t_changed and f_changed:
+                assert t is not None and f is not None
+                if t == f:
+                    # Both branches assigned the same value — no mux
+                    # needed, just alias to the common bits.
+                    self._merge_canonical_var(var, base_v, t)
+                    continue
+                width = max(len(t), len(f))
+                y_bits = self._emit_comb_cell(
+                    cell_type="$mux",
+                    inputs={"A": f, "B": t, "S": sel_bits[:1]},
+                    output_width=width,
+                    src_node=stmt,
+                )
+                self._merge_canonical_var(var, base_v, y_bits)
+            elif t_changed:
+                # Only the true branch wrote → keep single-branch
+                # aliasing (issue #36 spec).
+                assert t is not None
+                self._merge_canonical_var(var, base_v, t)
+            elif f_changed:
+                assert f is not None
+                self._merge_canonical_var(var, base_v, f)
+
+    def _walk_case_statement(self, stmt: Any) -> None:
+        """Lower an ``always_comb`` ``case`` into a chained ``$mux``
+        per LHS, with item arms wrapped highest-priority-outermost.
+
+        For each LHS, the chain starts at the ``default`` arm's
+        contribution (or the prior value, if no default) and folds in
+        each item arm that writes the LHS, in reverse order — item 0
+        ends up as the outermost mux, matching SV's first-match-wins
+        priority semantics. Selector bits for each arm are ``$eq``
+        comparisons against ``stmt.expr``; multi-label arms OR the
+        per-label matches together.
+
+        LHS written in only one arm keeps single-arm aliasing (no
+        mux), matching the conservative shape used by
+        :meth:`_walk_conditional_statement`.
+        """
+        sel_bits = self._bits_of_expression(stmt.expr)
+        items = list(getattr(stmt, "items", []) or [])
+        default_arm = getattr(stmt, "defaultCase", None)
+        if sel_bits is None or not items:
+            for item in items:
+                self._walk_comb_statement(getattr(item, "stmt", None))
+            if default_arm is not None:
+                self._walk_comb_statement(default_arm)
+            return
+
+        base_var_bits = dict(self._var_bits)
+        base_ports = dict(self._ports)
+        base_netnames = dict(self._netnames)
+
+        def restore() -> None:
+            self._var_bits = dict(base_var_bits)
+            self._ports = dict(base_ports)
+            self._netnames = dict(base_netnames)
+
+        arms: list[tuple[list[Any], dict[Any, tuple[Bit, ...]]]] = []
+        for item in items:
+            self._walk_comb_statement(getattr(item, "stmt", None))
+            arms.append(
+                (list(getattr(item, "expressions", []) or []), dict(self._var_bits))
+            )
+            restore()
+
+        if default_arm is not None:
+            self._walk_comb_statement(default_arm)
+            default_state = dict(self._var_bits)
+            restore()
+        else:
+            default_state = dict(base_var_bits)
+
+        def writes(state: dict[Any, tuple[Bit, ...]]) -> set[Any]:
+            return {k for k, v in state.items() if base_var_bits.get(k) != v}
+
+        arm_writes = [writes(s) for _, s in arms]
+        default_writes = writes(default_state)
+        all_written: set[Any] = set(default_writes)
+        for w in arm_writes:
+            all_written |= w
+
+        for var in all_written:
+            base_v = base_var_bits.get(var)
+            writer_indices = [i for i, w in enumerate(arm_writes) if var in w]
+            default_has = var in default_writes
+            total_writers = len(writer_indices) + (1 if default_has else 0)
+
+            if total_writers == 1:
+                # Only one arm (or only default) writes → single-branch
+                # aliasing.
+                if writer_indices:
+                    self._merge_canonical_var(
+                        var, base_v, arms[writer_indices[0]][1][var]
+                    )
+                else:
+                    self._merge_canonical_var(var, base_v, default_state[var])
+                continue
+
+            # 2+ writers → build a chained $mux, default (or prior
+            # value) as the innermost fallback, item-arm 0 outermost.
+            chain = default_state.get(var) if default_has else base_v
+            if chain is None:
+                continue
+            for i in range(len(arms) - 1, -1, -1):
+                if var not in arm_writes[i]:
+                    continue
+                label_exprs, arm_state = arms[i]
+                arm_bits = arm_state[var]
+                sel_match = self._lower_case_arm_selector(sel_bits, label_exprs, stmt)
+                if sel_match is None:
+                    continue
+                width = max(len(arm_bits), len(chain))
+                chain = self._emit_comb_cell(
+                    cell_type="$mux",
+                    inputs={"A": chain, "B": arm_bits, "S": sel_match[:1]},
+                    output_width=width,
+                    src_node=stmt,
+                )
+            self._merge_canonical_var(var, base_v, chain)
+
+    def _lower_case_arm_selector(
+        self,
+        sel_bits: tuple[Bit, ...],
+        label_exprs: list[Any],
+        src_node: Any,
+    ) -> tuple[Bit, ...] | None:
+        """Build the 1-bit ``$mux.S`` selector for a single case arm:
+        OR of ``(case_expr == label_i)`` ``$eq`` cells.
+
+        Returns ``None`` if none of the labels could be lowered, so
+        the caller can drop the arm rather than emit a broken mux.
+        """
+        sel_match: tuple[Bit, ...] | None = None
+        for label_expr in label_exprs:
+            lb = self._bits_of_expression(label_expr)
+            if lb is None:
+                continue
+            eq_y = self._emit_comb_cell(
+                cell_type="$eq",
+                inputs={"A": sel_bits, "B": lb},
+                output_width=1,
+                src_node=src_node,
+            )
+            if sel_match is None:
+                sel_match = eq_y
+            else:
+                sel_match = self._emit_comb_cell(
+                    cell_type="$or",
+                    inputs={"A": sel_match, "B": eq_y},
+                    output_width=1,
+                    src_node=src_node,
+                )
+        return sel_match
 
     def _alias_assign(self, expr: Any) -> None:
         """For a blocking assignment ``lhs = rhs``, rewrite ``lhs``'s
@@ -1578,26 +1807,41 @@ class _ModuleBuilder:
         every one of those aliases needs to follow — not just the
         child's own a_q entry — or the parent's reader sees stale bits.
 
+        Thin shim over :meth:`_merge_canonical_var`; the
+        canonical-keyed variant is the one used by branch-merge sites
+        like :meth:`_walk_conditional_statement` that don't have a
+        live LHS expression to read ``.symbol`` from.
+        """
+        canonical = self._canonical_var(lhs.symbol)
+        self._merge_canonical_var(canonical, self._var_bits.get(canonical), rhs_bits)
+
+    def _merge_canonical_var(
+        self,
+        canonical: Any,
+        old_bits: tuple[Bit, ...] | None,
+        new_bits: tuple[Bit, ...],
+    ) -> None:
+        """Alias-propagation primitive: rewrite every map entry whose
+        bits equal ``old_bits`` to point at ``new_bits``.
+
         We do the cheap thing: scan ``_var_bits`` / ``_ports`` /
         ``_netnames`` for entries whose bits equal the old tuple and
         rewrite them. O(n) per assign, fine for the design sizes the
         analyzer targets.
         """
-        canonical = self._canonical_var(lhs.symbol)
-        old_bits = self._var_bits.get(canonical)
-        self._var_bits[canonical] = rhs_bits
-        if old_bits is None or old_bits == rhs_bits:
+        self._var_bits[canonical] = new_bits
+        if old_bits is None or old_bits == new_bits:
             return
         for sym, bits in list(self._var_bits.items()):
             if bits == old_bits:
-                self._var_bits[sym] = rhs_bits
+                self._var_bits[sym] = new_bits
         for name, port in list(self._ports.items()):
             if port.bits == old_bits:
                 self._ports[name] = Port(
-                    name=port.name, direction=port.direction, bits=rhs_bits
+                    name=port.name, direction=port.direction, bits=new_bits
                 )
         for name, nn in list(self._netnames.items()):
             if nn.bits == old_bits:
                 self._netnames[name] = Netname(
-                    name=nn.name, bits=rhs_bits, attributes=nn.attributes
+                    name=nn.name, bits=new_bits, attributes=nn.attributes
                 )

--- a/tests/fixtures/bad_comb_before_sync_with_if/bad_comb_before_sync_with_if.json
+++ b/tests/fixtures/bad_comb_before_sync_with_if/bad_comb_before_sync_with_if.json
@@ -1,0 +1,488 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_comb_before_sync_with_if": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "bad_comb_before_sync_with_if.sv:10.1-55.10"
+      },
+      "ports": {
+        "src_clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "dst_clk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "sel": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "a": {
+          "direction": "input",
+          "bits": [ 6 ]
+        },
+        "b": {
+          "direction": "input",
+          "bits": [ 7 ]
+        },
+        "q_out": {
+          "direction": "output",
+          "bits": [ 8 ]
+        }
+      },
+      "cells": {
+        "$auto$proc_dff.cc:220:proc_dff$14": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 9 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$19": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 10 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$24": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 11 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$9": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 12 ]
+          }
+        },
+        "$logic_not$bad_comb_before_sync_with_if.sv:23$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:23.13-23.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 13 ]
+          }
+        },
+        "$logic_not$bad_comb_before_sync_with_if.sv:44$5": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:44.13-44.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 14 ]
+          }
+        },
+        "$procdff$13": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_before_sync_with_if.sv:43.5-51.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 15 ],
+            "Q": [ 16 ]
+          }
+        },
+        "$procdff$18": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_before_sync_with_if.sv:43.5-51.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 16 ],
+            "Q": [ 8 ]
+          }
+        },
+        "$procdff$23": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_before_sync_with_if.sv:22.5-30.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 6 ],
+            "Q": [ 17 ]
+          }
+        },
+        "$procdff$28": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_before_sync_with_if.sv:22.5-30.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 7 ],
+            "Q": [ 18 ]
+          }
+        },
+        "$procmux$7": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "full_case": "00000000000000000000000000000001",
+            "src": "bad_comb_before_sync_with_if.sv:35.13-35.16|bad_comb_before_sync_with_if.sv:35.9-38.30"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 18 ],
+            "B": [ 17 ],
+            "S": [ 5 ],
+            "Y": [ 15 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\glitchy[0:0]": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:34.16-34.16"
+          }
+        },
+        "$0\\src_q1[0:0]": {
+          "hide_name": 1,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:22.5-30.8"
+          }
+        },
+        "$0\\src_q2[0:0]": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:22.5-30.8"
+          }
+        },
+        "$0\\sync_stage0[0:0]": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:43.5-51.8"
+          }
+        },
+        "$0\\sync_stage1[0:0]": {
+          "hide_name": 1,
+          "bits": [ 16 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:43.5-51.8"
+          }
+        },
+        "$1\\glitchy[0:0]": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:34.16-34.16"
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$10": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$15": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$20": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$25": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$12": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$17": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$22": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$27": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$logic_not$bad_comb_before_sync_with_if.sv:23$2_Y": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:23.13-23.19"
+          }
+        },
+        "$logic_not$bad_comb_before_sync_with_if.sv:44$5_Y": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:44.13-44.19"
+          }
+        },
+        "$procmux$7_Y": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+          }
+        },
+        "$procmux$8_CMP": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+          }
+        },
+        "a": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:15.18-15.19"
+          }
+        },
+        "b": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:16.18-16.19"
+          }
+        },
+        "dst_clk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:12.18-12.25"
+          }
+        },
+        "glitchy": {
+          "hide_name": 0,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:33.11-33.18"
+          }
+        },
+        "q_out": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:17.18-17.23"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:13.18-13.23"
+          }
+        },
+        "sel": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:14.18-14.21"
+          }
+        },
+        "src_clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:11.18-11.25"
+          }
+        },
+        "src_q1": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:20.11-20.17"
+          }
+        },
+        "src_q2": {
+          "hide_name": 0,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:20.19-20.25"
+          }
+        },
+        "sync_stage0": {
+          "hide_name": 0,
+          "bits": [ 16 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:41.11-41.22"
+          }
+        },
+        "sync_stage1": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "bad_comb_before_sync_with_if.sv:41.24-41.35"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_comb_before_sync_with_if/bad_comb_before_sync_with_if.sdc
+++ b/tests/fixtures/bad_comb_before_sync_with_if/bad_comb_before_sync_with_if.sdc
@@ -1,0 +1,3 @@
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}

--- a/tests/fixtures/bad_comb_before_sync_with_if/bad_comb_before_sync_with_if.sv
+++ b/tests/fixtures/bad_comb_before_sync_with_if/bad_comb_before_sync_with_if.sv
@@ -1,0 +1,55 @@
+// Negative-case fixture: the bad_comb_before_sync shape but written
+// with an always_comb if/else instead of a continuous assign. Both
+// source flops fan into the synchronizer first stage through the
+// branch-selecting mux, so two CDC-003 violations should fire — one
+// per source flop. The fixture exists primarily to drive the slang
+// frontend's ConditionalStatement → $mux lowering (issue #36); the
+// Yosys frontend also flattens this shape into a $mux post-proc, so
+// it's a natural parity target.
+
+module bad_comb_before_sync_with_if (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic sel,
+    input  logic a,
+    input  logic b,
+    output logic q_out
+);
+
+    logic src_q1, src_q2;
+
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            src_q1 <= 1'b0;
+            src_q2 <= 1'b0;
+        end else begin
+            src_q1 <= a;
+            src_q2 <= b;
+        end
+    end
+
+    // BAD: branch-selecting comb on the way to the synchronizer.
+    logic glitchy;
+    always_comb begin
+        if (sel)
+            glitchy = src_q1;
+        else
+            glitchy = src_q2;
+    end
+
+    logic sync_stage0, sync_stage1;
+
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            sync_stage0 <= 1'b0;
+            sync_stage1 <= 1'b0;
+        end else begin
+            sync_stage0 <= glitchy;
+            sync_stage1 <= sync_stage0;
+        end
+    end
+
+    assign q_out = sync_stage1;
+
+endmodule

--- a/tests/fixtures/bad_comb_case_before_sync/bad_comb_case_before_sync.json
+++ b/tests/fixtures/bad_comb_case_before_sync/bad_comb_case_before_sync.json
@@ -1,0 +1,623 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_comb_case_before_sync": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "bad_comb_case_before_sync.sv:8.1-57.10"
+      },
+      "ports": {
+        "src_clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "dst_clk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "sel": {
+          "direction": "input",
+          "bits": [ 5, 6 ]
+        },
+        "a": {
+          "direction": "input",
+          "bits": [ 7 ]
+        },
+        "b": {
+          "direction": "input",
+          "bits": [ 8 ]
+        },
+        "c": {
+          "direction": "input",
+          "bits": [ 9 ]
+        },
+        "q_out": {
+          "direction": "output",
+          "bits": [ 10 ]
+        }
+      },
+      "cells": {
+        "$auto$proc_dff.cc:220:proc_dff$10": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 11 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$15": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 12 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$20": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 13 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$25": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 14 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$30": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 15 ]
+          }
+        },
+        "$logic_not$bad_comb_case_before_sync.sv:22$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:22.13-22.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 16 ]
+          }
+        },
+        "$logic_not$bad_comb_case_before_sync.sv:46$5": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:46.13-46.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 17 ]
+          }
+        },
+        "$procdff$14": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_case_before_sync.sv:45.5-53.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 18 ],
+            "Q": [ 19 ]
+          }
+        },
+        "$procdff$19": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_case_before_sync.sv:45.5-53.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 19 ],
+            "Q": [ 10 ]
+          }
+        },
+        "$procdff$24": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_case_before_sync.sv:21.5-31.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 7 ],
+            "Q": [ 20 ]
+          }
+        },
+        "$procdff$29": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_case_before_sync.sv:21.5-31.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 8 ],
+            "Q": [ 21 ]
+          }
+        },
+        "$procdff$34": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_comb_case_before_sync.sv:21.5-31.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 9 ],
+            "Q": [ 22 ]
+          }
+        },
+        "$procmux$7": {
+          "hide_name": 1,
+          "type": "$pmux",
+          "parameters": {
+            "S_WIDTH": "00000000000000000000000000000010",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "full_case": "00000000000000000000000000000001",
+            "src": "bad_comb_case_before_sync.sv:37.39-37.39|bad_comb_case_before_sync.sv:36.9-40.16"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 22 ],
+            "B": [ 21, 20 ],
+            "S": [ 23, 24 ],
+            "Y": [ 18 ]
+          }
+        },
+        "$procmux$8_CMP0": {
+          "hide_name": 1,
+          "type": "$eq",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000010",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000010",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "full_case": "00000000000000000000000000000001",
+            "src": "bad_comb_case_before_sync.sv:37.39-37.39|bad_comb_case_before_sync.sv:36.9-40.16"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 5, 6 ],
+            "B": [ "1", "0" ],
+            "Y": [ 23 ]
+          }
+        },
+        "$procmux$9_CMP0": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000010",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "full_case": "00000000000000000000000000000001",
+            "src": "bad_comb_case_before_sync.sv:36.19-36.19|bad_comb_case_before_sync.sv:36.9-40.16"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 5, 6 ],
+            "Y": [ 24 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\glitchy[0:0]": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:35.16-35.16"
+          }
+        },
+        "$0\\src_q1[0:0]": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:21.5-31.8"
+          }
+        },
+        "$0\\src_q2[0:0]": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:21.5-31.8"
+          }
+        },
+        "$0\\src_q3[0:0]": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:21.5-31.8"
+          }
+        },
+        "$0\\sync_stage0[0:0]": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:45.5-53.8"
+          }
+        },
+        "$0\\sync_stage1[0:0]": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:45.5-53.8"
+          }
+        },
+        "$1\\glitchy[0:0]": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:35.16-35.16"
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$11": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$16": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$21": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$26": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$31": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$13": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$18": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$23": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$28": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$33": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+          }
+        },
+        "$logic_not$bad_comb_case_before_sync.sv:22$2_Y": {
+          "hide_name": 1,
+          "bits": [ 16 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:22.13-22.19"
+          }
+        },
+        "$logic_not$bad_comb_case_before_sync.sv:46$5_Y": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:46.13-46.19"
+          }
+        },
+        "$procmux$7_Y": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$procmux$8_CMP": {
+          "hide_name": 1,
+          "bits": [ 23 ],
+          "attributes": {
+          }
+        },
+        "$procmux$9_CMP": {
+          "hide_name": 1,
+          "bits": [ 24 ],
+          "attributes": {
+          }
+        },
+        "a": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:13.24-13.25"
+          }
+        },
+        "b": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:14.24-14.25"
+          }
+        },
+        "c": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:15.24-15.25"
+          }
+        },
+        "dst_clk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:10.24-10.31"
+          }
+        },
+        "glitchy": {
+          "hide_name": 0,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:34.11-34.18"
+          }
+        },
+        "q_out": {
+          "hide_name": 0,
+          "bits": [ 10 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:16.24-16.29"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:11.24-11.29"
+          }
+        },
+        "sel": {
+          "hide_name": 0,
+          "bits": [ 5, 6 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:12.24-12.27"
+          }
+        },
+        "src_clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:9.24-9.31"
+          }
+        },
+        "src_q1": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:19.11-19.17"
+          }
+        },
+        "src_q2": {
+          "hide_name": 0,
+          "bits": [ 21 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:19.19-19.25"
+          }
+        },
+        "src_q3": {
+          "hide_name": 0,
+          "bits": [ 22 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:19.27-19.33"
+          }
+        },
+        "sync_stage0": {
+          "hide_name": 0,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:43.11-43.22"
+          }
+        },
+        "sync_stage1": {
+          "hide_name": 0,
+          "bits": [ 10 ],
+          "attributes": {
+            "src": "bad_comb_case_before_sync.sv:43.24-43.35"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_comb_case_before_sync/bad_comb_case_before_sync.sdc
+++ b/tests/fixtures/bad_comb_case_before_sync/bad_comb_case_before_sync.sdc
@@ -1,0 +1,3 @@
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}

--- a/tests/fixtures/bad_comb_case_before_sync/bad_comb_case_before_sync.sv
+++ b/tests/fixtures/bad_comb_case_before_sync/bad_comb_case_before_sync.sv
@@ -1,0 +1,57 @@
+// Negative-case fixture: the bad_comb_before_sync shape but written
+// with an always_comb case instead of a continuous assign. Multiple
+// source flops fan into the synchronizer first stage through a
+// case-mux chain, so CDC-003 should fire — one violation per source
+// flop that reaches the sync cone. Drives the slang frontend's
+// CaseStatement → chained-$mux lowering (issue #37).
+
+module bad_comb_case_before_sync (
+    input  logic       src_clk,
+    input  logic       dst_clk,
+    input  logic       rst_n,
+    input  logic [1:0] sel,
+    input  logic       a,
+    input  logic       b,
+    input  logic       c,
+    output logic       q_out
+);
+
+    logic src_q1, src_q2, src_q3;
+
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            src_q1 <= 1'b0;
+            src_q2 <= 1'b0;
+            src_q3 <= 1'b0;
+        end else begin
+            src_q1 <= a;
+            src_q2 <= b;
+            src_q3 <= c;
+        end
+    end
+
+    // BAD: case-mux on the way to the synchronizer first stage.
+    logic glitchy;
+    always_comb begin
+        case (sel)
+            2'b00:   glitchy = src_q1;
+            2'b01:   glitchy = src_q2;
+            default: glitchy = src_q3;
+        endcase
+    end
+
+    logic sync_stage0, sync_stage1;
+
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            sync_stage0 <= 1'b0;
+            sync_stage1 <= 1'b0;
+        end else begin
+            sync_stage0 <= glitchy;
+            sync_stage1 <= sync_stage0;
+        end
+    end
+
+    assign q_out = sync_stage1;
+
+endmodule

--- a/tests/test_bad_comb_before_sync_with_if.py
+++ b/tests/test_bad_comb_before_sync_with_if.py
@@ -1,0 +1,66 @@
+"""Negative-case fixture: comb-mux between src flops and sync → CDC-003.
+
+Mirrors :mod:`test_bad_comb_before_sync` but the comb is an
+``always_comb if/else`` rather than a continuous assign. Drives the
+slang frontend's ConditionalStatement → ``$mux`` lowering (issue #36).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_comb_before_sync_with_if"
+JSON = FIX_DIR / "bad_comb_before_sync_with_if.json"
+SDC = FIX_DIR / "bad_comb_before_sync_with_if.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    crossings = find_crossings(module)
+    async_crossings = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    return module, async_crossings
+
+
+def test_two_async_crossings_through_mux(context) -> None:
+    """Both src flops fan into the sync first stage through the
+    branch-selecting mux, so we expect two crossings each with
+    ``min_hops==1``."""
+    _module, async_crossings = context
+    assert len(async_crossings) == 2
+    assert all(c.min_hops == 1 for c in async_crossings)
+    assert all(c.width == 1 for c in async_crossings)
+
+
+def test_cdc_003_fires(context) -> None:
+    module, async_crossings = context
+    violations = run_all_rules(module, async_crossings)
+    cdc_003 = [v for v in violations if v.rule_id == "CDC-003"]
+    assert len(cdc_003) == 2
+    assert all(
+        "combinational logic between source flop and synchronizer" in v.message
+        for v in cdc_003
+    )
+    assert all(v.severity == "error" for v in cdc_003)
+
+
+def test_no_cdc_001_fires(context) -> None:
+    module, async_crossings = context
+    violations = run_all_rules(module, async_crossings)
+    assert [v for v in violations if v.rule_id == "CDC-001"] == []

--- a/tests/test_bad_comb_case_before_sync.py
+++ b/tests/test_bad_comb_case_before_sync.py
@@ -1,0 +1,66 @@
+"""Negative-case fixture: comb case-mux between src flops and sync.
+
+Mirrors :mod:`test_bad_comb_before_sync` but the comb is an
+``always_comb case`` rather than a continuous assign. Drives the
+slang frontend's CaseStatement → chained-``$mux`` lowering (#37).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_comb_case_before_sync"
+JSON = FIX_DIR / "bad_comb_case_before_sync.json"
+SDC = FIX_DIR / "bad_comb_case_before_sync.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    crossings = find_crossings(module)
+    async_crossings = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    return module, async_crossings
+
+
+def test_three_async_crossings_through_case_mux(context) -> None:
+    """All three src flops fan into the sync first stage through the
+    case-mux chain, so we expect three crossings each with
+    ``min_hops>=1``."""
+    _module, async_crossings = context
+    assert len(async_crossings) == 3
+    assert all(c.min_hops >= 1 for c in async_crossings)
+    assert all(c.width == 1 for c in async_crossings)
+
+
+def test_cdc_003_fires(context) -> None:
+    module, async_crossings = context
+    violations = run_all_rules(module, async_crossings)
+    cdc_003 = [v for v in violations if v.rule_id == "CDC-003"]
+    assert len(cdc_003) == 3
+    assert all(
+        "combinational logic between source flop and synchronizer" in v.message
+        for v in cdc_003
+    )
+    assert all(v.severity == "error" for v in cdc_003)
+
+
+def test_no_cdc_001_fires(context) -> None:
+    module, async_crossings = context
+    violations = run_all_rules(module, async_crossings)
+    assert [v for v in violations if v.rule_id == "CDC-001"] == []

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -124,6 +124,21 @@ def test_cdc_003_fires_on_bad_comb_before_sync() -> None:
     assert _run("bad_comb_before_sync") == ["CDC-003"]
 
 
+def test_cdc_003_fires_on_bad_comb_before_sync_with_if() -> None:
+    """Same shape, but the comb is an ``always_comb if/else``.
+    Exercises the ConditionalStatement → ``$mux`` lowering added for
+    issue #36 — without it both branches alias the same LHS and only
+    the last-walked source flop reaches the synchronizer cone."""
+    assert _run("bad_comb_before_sync_with_if") == ["CDC-003"]
+
+
+def test_cdc_003_fires_on_bad_comb_case_before_sync() -> None:
+    """Same shape, but the comb is an ``always_comb case``. Exercises
+    the CaseStatement → chained-``$mux`` lowering added for issue
+    #37."""
+    assert _run("bad_comb_case_before_sync") == ["CDC-003"]
+
+
 def test_cdc_006_fires_on_bad_comb_source() -> None:
     """Synchronizer fed directly by comb of top-level inputs
     (``a & b``) with no registering flop. Confirms the lowering also


### PR DESCRIPTION
Closes #36, closes #37.

## Summary

- **`_walk_conditional_statement`** — pyslang `ConditionalStatement` now lowers to a real `$mux` per LHS written in both branches (`S=cond`, `A=false`, `B=true`). LHS written in only one branch keeps single-branch aliasing per the #36 spec. No-else falls back to the prior value as the false side. Selector that can't be lowered falls back to the pre-existing conservative descend.
- **`_walk_case_statement`** — `CaseStatement` lowers to a chained `$mux` per LHS written in 2+ arms (or 1 arm + default). The chain starts at the default arm's bits (or the prior value if no default) and folds in each item arm in reverse order — arm 0 ends up outermost to match SV's first-match-wins priority. Per-arm selectors are `$eq` against `stmt.expr`; multi-label arms OR the `$eq` results together. LHS written in only one arm keeps single-arm aliasing.
- **Shared snapshot/restore** — both walkers snapshot `_var_bits` / `_ports` / `_netnames` before each branch walk and reset after, so per-branch state is independent. Cells emitted during the walk are preserved (real hardware) — only the alias maps roll back.
- **`_merge_canonical_var`** — factored out of `_rewrite_aliased` so the merge sites can rewrite by canonical symbol without needing a live LHS expression.
- **Fixtures** — `bad_comb_before_sync_with_if/` mirrors `bad_comb_before_sync` with an `always_comb if/else`; `bad_comb_case_before_sync/` does the same with `case`. Both pre-built JSONs committed (Yosys ≥ 0.64) and the slang parity matrix gains two rows.
- **Docstring** — module docstring now documents the new combinational selection lowering; the `case` follow-up note in "NOT yet implemented" is replaced with a `casex`/`casez` wildcard caveat (the only remaining shape we don't model).

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy` — no issues
- [x] `uv run pytest -q` — 202 passed, 2 skipped, 1 xfailed (no regressions on existing CDC-003 fixture)
- [x] New `tests/test_bad_comb_before_sync_with_if.py` (Yosys JSON) — 3 passed
- [x] New `tests/test_bad_comb_case_before_sync.py` (Yosys JSON) — 3 passed
- [x] New slang parity assertions — both fixtures resolve to `["CDC-003"]` via the slang frontend
- [x] Re-run the project-template regression suite from `dev/local-rtl-buddy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)