### PR TITLE
fix(slang): resolve nested element-select chains for 2-D port aliasing

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -1285,57 +1285,87 @@ class _ModuleBuilder:
         return None
 
     def _element_select_bits(self, expr: Any) -> tuple[Bit, ...] | None:
-        """``var[i]`` — return the bit subset of ``var`` that the
-        index picks out.
+        """``var[i]`` (and ``var[i][j]``, ``var[i][j][k]``, ...) —
+        return the bit subset that the chain picks out of the
+        underlying named variable.
 
-        Stride is the element type's storage width:
+        Walks an ``ElementSelectExpression`` chain inward through
+        ``.value`` until it reaches a ``NamedValueExpression``, then
+        slices the allocated bit pool at the linearised offset.
+        Stride at each level is the inner type's
+        ``selectableWidth``:
 
-        - For packed arrays (``logic [W-1:0] data``) the element type
-          is a scalar and the stride is 1 — ``data[i]`` returns one
-          bit.
-        - For unpacked arrays (``logic chain [N]``) the element type
-          is the inner type and the stride is its ``selectableWidth``
-          — ``chain[i]`` returns one stripe.
-        - For packed-and-unpacked (``logic [W-1:0] chain [STAGES]``)
-          the outer type is the unpacked array, its element type is
-          the packed type, so each ``chain[i]`` returns W bits.
+        - Packed array ``logic [W-1:0] data``: scalar element,
+          stride 1 — ``data[i]`` returns one bit.
+        - Unpacked array ``logic chain [N]``: scalar element,
+          stride 1 — ``chain[i]`` returns one bit.
+        - Packed-and-unpacked ``logic [W-1:0] chain [STAGES]``:
+          W-bit element, stride W — ``chain[i]`` returns W bits.
+        - 2-D unpacked ``logic [W-1:0] arr [R][C]``: outer
+          ``arr[i]`` returns the C*W-bit row, inner ``arr[i][j]``
+          returns the W-bit element.
 
-        Falls back to ``None`` when the underlying value isn't a bare
-        named variable (e.g. nested selects, slices of expressions),
-        and when the selector isn't a constant integer — dynamic
-        indexing would require muxing across all possible bits, which
-        no rule today is worth.
+        Falls back to ``None`` when any selector isn't a compile-time
+        constant or the chain bottoms out somewhere other than a
+        bare named variable (e.g. a hierarchical or virtual-interface
+        select).
         """
-        inner = expr.value
-        if type(inner).__name__ != "NamedValueExpression":
+        base_sym, base_bits, offset, stride = self._resolve_select_chain(expr)
+        if base_sym is None:
             return None
-        idx = self._const_int(getattr(expr, "selector", None))
-        if idx is None:
+        start = offset
+        end = offset + stride
+        if start < 0 or end > len(base_bits):
             return None
-        var_sym = inner.symbol
-        var_bits = self._alloc_bits(var_sym)
-        # Stride = element type's selectableWidth. For scalar-element
-        # cases (packed arrays where the element is ``logic`` etc.)
-        # this is 1, matching the original single-bit semantics.
-        var_type = getattr(var_sym, "type", None)
-        elem_type = getattr(var_type, "elementType", None) if var_type else None
-        stride = 1
-        if elem_type is not None:
+        return tuple(base_bits[start:end])
+
+    def _resolve_select_chain(
+        self, expr: Any
+    ) -> tuple[Any | None, tuple[Bit, ...], int, int]:
+        """Walk an ``ElementSelectExpression`` chain inward to the
+        underlying named variable, accumulating a linearised bit
+        offset and current stride.
+
+        Returns ``(base_sym, base_bits, offset_in_bits, stride_in_bits)``.
+        ``base_sym`` is ``None`` when the chain can't be resolved
+        (non-constant selector, non-NamedValueExpression base, …).
+        """
+        kind = type(expr).__name__
+        if kind == "NamedValueExpression":
+            sym = getattr(expr, "symbol", None)
+            if sym is None:
+                return None, (), 0, 0
+            bits = self._alloc_bits(sym)
+            t = getattr(sym, "type", None)
             stride = int(
-                getattr(elem_type, "selectableWidth", None)
-                or getattr(elem_type, "bitWidth", None)
+                getattr(t, "selectableWidth", None)
+                or getattr(t, "bitWidth", None)
+                or len(bits)
                 or 1
             )
-        # The element-select index counts in *elements*, not bits.
-        # For an unpacked-then-packed type the outer ``range`` runs
-        # over the unpacked dimension; pyslang folds the constant to
-        # the unpacked index. Bits are stored low-element-first
-        # (matching how Yosys-flatten lays out the unpacked dim).
-        start = idx * stride
-        end = start + stride
-        if start < 0 or end > len(var_bits):
-            return None
-        return tuple(var_bits[start:end])
+            return sym, bits, 0, stride
+        if kind == "ElementSelectExpression":
+            inner_sym, inner_bits, inner_offset, inner_stride = (
+                self._resolve_select_chain(expr.value)
+            )
+            if inner_sym is None:
+                return None, (), 0, 0
+            idx = self._const_int(getattr(expr, "selector", None))
+            if idx is None:
+                return None, (), 0, 0
+            # Stride at this level = the inner type's element width.
+            inner_type = getattr(expr.value, "type", None)
+            elem_type = getattr(inner_type, "elementType", None)
+            new_stride = 1
+            if elem_type is not None:
+                new_stride = int(
+                    getattr(elem_type, "selectableWidth", None)
+                    or getattr(elem_type, "bitWidth", None)
+                    or 1
+                )
+            new_offset = inner_offset + idx * new_stride
+            return inner_sym, inner_bits, new_offset, new_stride
+        return None, (), 0, 0
 
     def _range_select_bits(self, expr: Any) -> tuple[Bit, ...] | None:
         """``var[hi:lo]`` — return the contiguous bit subset.

--- a/tests/test_slang_2d_port_alias.py
+++ b/tests/test_slang_2d_port_alias.py
@@ -1,0 +1,186 @@
+"""Coverage tests for slang-frontend 2-D unpacked-array port aliasing
+through generates.
+
+Issue: rtl-buddy-cdc#69 — ``_element_select_bits`` expects the
+inner ``.value`` to be a bare ``NamedValueExpression`` and bails on
+nested element selects (``arr[i][j]``). When such a select appears
+in a port connection inside a generate instantiation, the child
+instance's port-internal bits get fresh allocations instead of
+aliasing to the parent's bit pool, severing the bit chain through
+a tile array.
+
+The tests below pin the contract: an ``ElementSelectExpression``
+whose ``.value`` is itself an ``ElementSelectExpression`` resolves
+to the correct slice of the underlying named variable, and port
+connections using that shape propagate bit identity from parent to
+child.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang 2-D port-alias tests are gated on it",
+        allow_module_level=True,
+    )
+
+FLOP_TYPES = frozenset({"$dff", "$adff", "$dffe", "$adffe", "$sdff", "$sdffe"})
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _flops(module) -> list:
+    return [c for c in module.cells.values() if c.type in FLOP_TYPES]
+
+
+# --- nested element-select resolution -------------------------------------
+
+
+def test_nested_element_select_returns_correct_slice(tmp_path: Path) -> None:
+    """``arr[i][j]`` where arr is ``logic [W-1:0] arr [R][C]`` must
+    resolve to the right ``W``-bit slice. The flop captures the
+    selected element and its D bits should match the slice that
+    ``arr[i][j]`` picks out of the underlying variable."""
+    src = """
+    module m (
+        input  logic       clk,
+        input  logic [3:0] in_data,
+        input  logic [1:0] sel_r, sel_c,
+        output logic [3:0] out_data
+    );
+        logic [3:0] arr [2][2];
+        // Constant-folded select — element [1][0] of the 2x2 array.
+        always_ff @(posedge clk) out_data <= arr[1][0];
+        assign arr[0][0] = in_data;
+        assign arr[0][1] = in_data;
+        assign arr[1][0] = in_data;
+        assign arr[1][1] = in_data;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1, f"expected one flop; got {len(flops)}"
+    d_bits = flops[0].connections["D"]
+    # The D bits should not be a fresh allocation — they should match
+    # the underlying ``arr`` variable's bits for the [1][0] slice.
+    arr_nn = mod.netnames.get("arr")
+    assert arr_nn is not None, "arr netname not allocated"
+    # arr layout: bits 0..3 are [0][0], 4..7 are [0][1], 8..11 are [1][0],
+    # 12..15 are [1][1] (4-bit element, C=2 inner stride, 2 row stride).
+    expected_slice = arr_nn.bits[8:12]
+    assert tuple(d_bits) == tuple(expected_slice), (
+        f"expected D to be the [1][0] slice {expected_slice}; "
+        f"got {d_bits} (suggests nested select wasn't resolved)"
+    )
+
+
+# --- child-port aliasing through generate ---------------------------------
+
+
+def test_child_port_aliases_2d_unpacked_through_generate(tmp_path: Path) -> None:
+    """The headline tiny-NPU shape: a generate-for instantiates a
+    chain of children; each child's input port is wired to a 2-D
+    unpacked-array element parameterised by the genvar. The child's
+    Q (a flop) at iteration ``c`` must alias to its D's source at
+    iteration ``c-1``, so a ripple chain's bit identity propagates."""
+    src = """
+    module child (input logic clk, input logic d, output logic q);
+        always_ff @(posedge clk) q <= d;
+    endmodule
+
+    module m (input logic clk, input logic d_in, output logic q_out);
+        logic wire2d [1][3];
+        assign wire2d[0][2] = d_in;
+        for (genvar c = 0; c < 2; c++) begin : g
+            child u_c (
+                .clk(clk),
+                .d(wire2d[0][c+1]),
+                .q(wire2d[0][c])
+            );
+        end
+        assign q_out = wire2d[0][0];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 2, f"expected 2 child flops; got {len(flops)}"
+    # Order flops by instance label (g[0] then g[1])
+    flops_by_inst = {}
+    for f in flops:
+        if "g[0]" in f.name:
+            flops_by_inst[0] = f
+        elif "g[1]" in f.name:
+            flops_by_inst[1] = f
+    assert 0 in flops_by_inst and 1 in flops_by_inst, (
+        f"expected one flop in each generate iteration; got {list(flops_by_inst.keys())}"
+    )
+    # The chain: g[1].q drives wire2d[0][1] which drives g[0].d.
+    # So g[0]'s D bit must equal g[1]'s Q bit.
+    g1_q = flops_by_inst[1].connections["Q"][0]
+    g0_d = flops_by_inst[0].connections["D"][0]
+    assert g0_d == g1_q, (
+        f"chain broken: g[0].D={g0_d} should alias to g[1].Q={g1_q} via "
+        "wire2d[0][1]. Bit allocations don't share — the 2-D unpacked-array "
+        "port-aliasing gap is still present."
+    )
+
+
+def test_child_port_aliases_packed_and_2d_unpacked(tmp_path: Path) -> None:
+    """Same chain but the inner element is a packed W-bit bus
+    (the production ``logic [CMD_W-1:0] mesh [R][C+1]`` shape from
+    tiny-NPU's MXP). Tests that the W-bit element alias propagates,
+    not just single-bit elements."""
+    src = """
+    module child #(parameter int W = 4) (
+        input  logic         clk,
+        input  logic [W-1:0] d,
+        output logic [W-1:0] q
+    );
+        always_ff @(posedge clk) q <= d;
+    endmodule
+
+    module m #(parameter int W = 4) (
+        input  logic         clk,
+        input  logic [W-1:0] d_in,
+        output logic [W-1:0] q_out
+    );
+        logic [W-1:0] mesh [1][3];
+        assign mesh[0][2] = d_in;
+        for (genvar c = 0; c < 2; c++) begin : g
+            child #(.W(W)) u_c (
+                .clk(clk),
+                .d(mesh[0][c+1]),
+                .q(mesh[0][c])
+            );
+        end
+        assign q_out = mesh[0][0];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 2, f"expected 2 child flops; got {len(flops)}"
+    flops_by_inst = {0: None, 1: None}
+    for f in flops:
+        for k in flops_by_inst:
+            if f"g[{k}]" in f.name:
+                flops_by_inst[k] = f
+    assert all(flops_by_inst.values()), (
+        f"missing one of the per-iteration flops: {flops_by_inst}"
+    )
+    g1_q = flops_by_inst[1].connections["Q"]
+    g0_d = flops_by_inst[0].connections["D"]
+    assert tuple(g0_d) == tuple(g1_q), (
+        f"W-bit chain broken: g[0].D={g0_d} should alias to g[1].Q={g1_q}"
+    )


### PR DESCRIPTION
## Summary

Fixes [#69](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/69). `_element_select_bits` expected the inner `.value` to be a bare `NamedValueExpression` and bailed on nested element selects (`arr[i][j]`). When such a select appears in a port connection inside a generate instantiation — the tiny-NPU MXP shape `.ml_cmd_data_in(ml_cmd_d[r][c+1])` per cor instantiation — the child instance's port-internal bits got fresh allocations instead of aliasing to the parent's bit pool. The bit chain through the tile array was severed, and every cor-to-cor ripple crossing in MXP (ml_cmd / ml_act / mu_acc / mu_cmd / mr_ret) was invisible to the analyzer — only intra-cor crossings made it into the report.

Companion to [#53](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/53), [#54](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/54), [#55](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/55), [#59](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/59), [#62](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/62), [#64](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/64) (the latter via [PR #70](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/70), which this PR stacks on — base targeting `bugfix/64-deferred-emit` since #70 isn't merged yet).

## Approach

New `_resolve_select_chain` walks an `ElementSelectExpression` chain inward through `.value` to a `NamedValueExpression`, returning `(base_sym, base_bits, offset_in_bits, stride_in_bits)`. The recursion accumulates the linearised bit offset and the per-level stride (from the inner type's `selectableWidth`).

`_element_select_bits` becomes a thin wrapper that calls `_resolve_select_chain` and slices the named variable's bit pool at the linearised offset. Single-dim cases (`data[i]`, `chain[i]`, `arr[i]`) reduce to the same arithmetic as [#62](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/63) — the new path is just the recursive form.

Port-connection bit aliasing routes through `_bits_of_expression` → `_element_select_bits`, so once the helper handles the nested case, the child-port alias falls out for free with no changes to `_emit_child_instance` / `_port_connection_bits`.

## Test plan

- [x] 3 new tests in `tests/test_slang_2d_port_alias.py`: nested `arr[i][j]` on a packed-and-unpacked 4-bit-element 2x2 array, generate-instantiated 2-instance chain through `wire2d[0][c+1]` (single-bit elements), and the same chain with W-bit packed elements (the production tiny-NPU MXP shape).
- [x] Full pytest suite: **228 passed, 2 skipped** (no regressions; #62's single-dim element-select tests, #64 walker tests, #59 for-loop tests all still pass).
- [x] Lint + format + mypy clean.
- [x] End-to-end on `ip_demo_tiny_npu`:
  - Crossings rise **118 → 154** as inter-cor ripple-chain crossings emerge.
  - MXP ml→mu crossings double (32 → 68): 32 intra-cor (already detected via #70) + **36 inter-cor** (newly visible).
  - Cor (0,0) reports 8 crossings (was 5): 3 md→mr + 5 ml→mu — the 3 new ml→mu are upstream cor → (0,0) ripples.
  - 0 violations, all 6 project CDC analyses PASS.

## Iteration arc (slang-frontend stack)

| Stage | Tiny-NPU flops | Crossings | Async | Violations |
|---|---:|---:|---:|---:|
| Baseline (no fixes) | 28 | 0 | 0 | 0 (false PASS) |
| After #53 / #54 / #59 / #62 / #64-no-else / #55 | 1073 | 95 | 27 | 0 |
| After [#70](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/70) (#64 deferred) | 684 | 118 | 22 | 0 |
| **After this PR** | **684** | **154** | **22** | **0** |

## Out of scope

- Range selects across nested chains (`arr[i][hi:lo]`) — the resolver covers the case but `_range_select_bits` doesn't dispatch through it yet. Filing a follow-up if a design needs it.
- Multi-pattern indexed parts (`arr[i+:N]`) — separate gap.
- Dynamic / associative arrays — synth doesn't model these.
- Yosys frontend, rule semantics, JSON schema — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
