### PR TITLE
fix(slang): fold compile-time-constant if/else conditions

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -685,14 +685,27 @@ class _ModuleBuilder:
         block_reset_sym = reset_sym
         block_reset_active_low = reset_active_low
         try:
-            if self._kind_name(inner) == "ConditionalStatement":
-                # The if-condition's variable IS the reset signal —
-                # confirm against the event-list-derived candidate,
-                # but trust the body shape when they disagree (event
-                # lists are sometimes ordered unconventionally).
-                cond_reset = self._extract_condition_symbol(inner.conditions[0].expr)
-                if cond_reset is not None:
-                    block_reset_sym = cond_reset
+            reset_check = self._classify_reset_check(inner, reset_sym)
+            if reset_check is not None:
+                # Canonical reset-check shape — either async-reset
+                # ``always_ff @(posedge clk or negedge rst_n) begin
+                #     if (!rst_n) <reset_assigns> else <data> end``
+                # or its sync-reset cousin
+                # ``always_ff @(posedge clk) begin
+                #     if (!rst_n) <reset_assigns> else <data> end``
+                # In both, the reset arm's writes are absorbed into
+                # the flop's reset value rather than emitted as
+                # separate writes (we only walk ``ifFalse``, the data
+                # branch). For async reset, the reset signal comes
+                # from the event list; for sync reset we identified
+                # the shape heuristically (constant-only ifTrue arm
+                # — matches every synthesizable reset block).
+                # Falling outside that envelope (a runtime ``if (cond)``
+                # at the top of a no-reset always_ff, where the ifTrue
+                # arm computes a real value) flows into the general
+                # walker below so both arms drain into one flop per
+                # LHS, not silently dropped.
+                block_reset_sym = reset_check
                 data_branch = inner.ifFalse
                 if data_branch is None:
                     return  # no else → no data assignment to model
@@ -783,6 +796,98 @@ class _ModuleBuilder:
             return expr.symbol
         return None
 
+    def _classify_reset_check(
+        self, inner: Any, reset_sym_from_event_list: Any | None
+    ) -> Any | None:
+        """Return the reset symbol for ``inner`` if it has the canonical
+        reset-check shape, else ``None`` so the caller walks the body
+        normally.
+
+        Two shapes match:
+
+        - **Async reset.** The event list announced an async reset
+          (``or negedge rst_n``), so ``reset_sym_from_event_list`` is
+          non-None, and the body's outer if-condition gates on that
+          same symbol.
+        - **Sync reset.** No async reset event, but the body's outer
+          ``ConditionalStatement`` writes only constants in its
+          ``ifTrue`` arm (the standard ``if (!rst_n) <constants>
+          else <data>`` shape that synthesizers fold into ``$sdff``).
+          The constant-only check is what distinguishes a real reset
+          check from a runtime ``if (cond)`` at the top of a no-reset
+          always_ff body — the latter has a real RHS expression in
+          ifTrue and must be walked as a normal mux-tree.
+        """
+        if self._kind_name(inner) != "ConditionalStatement":
+            return None
+        conds = getattr(inner, "conditions", None)
+        if not conds:
+            return None
+        cond_sym = self._extract_condition_symbol(conds[0].expr)
+        if cond_sym is None:
+            return None
+        if reset_sym_from_event_list is not None:
+            return cond_sym if cond_sym is reset_sym_from_event_list else None
+        # Sync-reset heuristic: the ifTrue arm assigns only constants.
+        if self._is_constant_only_assignment_tree(inner.ifTrue):
+            return cond_sym
+        return None
+
+    def _is_constant_only_assignment_tree(self, stmt: Any) -> bool:
+        """``True`` if every nonblocking assignment reachable from
+        ``stmt`` has a compile-time-constant RHS (IntegerLiteral,
+        ConversionExpression wrapping a literal, or another expression
+        ``_const_int`` can fold). Used to distinguish a reset-arm
+        body (all-constant assigns) from a runtime if/else arm.
+
+        Recurses through the same control-flow shapes the walker
+        handles — BlockStatement, StatementList, ConditionalStatement
+        (both arms), CaseStatement, ForLoopStatement. Bails on
+        anything it can't reason about; that returns ``False`` and
+        the caller falls through to the dynamic-condition path,
+        which is the conservative choice.
+        """
+        if stmt is None:
+            return True  # vacuously: no assignments → no non-constants
+        kind = self._kind_name(stmt)
+        if kind == "BlockStatement":
+            return self._is_constant_only_assignment_tree(stmt.body)
+        if kind in {"StatementList", "ListStatement"}:
+            return all(
+                self._is_constant_only_assignment_tree(s)
+                for s in (getattr(stmt, "list", []) or [])
+            )
+        if kind == "ConditionalStatement":
+            return all(
+                self._is_constant_only_assignment_tree(arm)
+                for arm in (stmt.ifTrue, stmt.ifFalse)
+                if arm is not None
+            )
+        if kind == "CaseStatement":
+            ok = all(
+                self._is_constant_only_assignment_tree(getattr(it, "stmt", None))
+                for it in (getattr(stmt, "items", []) or [])
+            )
+            default = getattr(stmt, "defaultCase", None)
+            if default is not None:
+                ok = ok and self._is_constant_only_assignment_tree(default)
+            return ok
+        if kind == "ForLoopStatement":
+            return self._is_constant_only_assignment_tree(getattr(stmt, "body", None))
+        if kind == "ExpressionStatement":
+            expr = getattr(stmt, "expr", None)
+            if expr is None or type(expr).__name__ != "AssignmentExpression":
+                # Non-assignment ExpressionStatement (e.g. function
+                # call) — not a reset assign; bail conservatively.
+                return False
+            if not getattr(expr, "isNonBlocking", False):
+                return False
+            return self._const_int(expr.right) is not None
+        if kind == "VariableDeclStatement":
+            return True  # loop-var declarations etc. contribute no flop
+        # Anything else (timing control, immediate assert, …) — bail.
+        return False
+
     def _emit_assignments_in(
         self,
         statement: Any,
@@ -827,11 +932,29 @@ class _ModuleBuilder:
                 )
             return
         if kind == "ConditionalStatement":
-            # Push the condition onto the enable stack while walking
-            # each arm so ``_emit_assignment_expression`` accumulates
-            # writes with the right enable. ``_drain_proc_writes``
-            # then collapses all writes to one flop per LHS with a
-            # mux tree:
+            # Compile-time-constant fold: if the condition is a
+            # parameter-driven (``IS_DIAGONAL``-style) or literal
+            # constant, walk only the live arm with no enable push.
+            # Matches Yosys-flatten + opt_clean's pruning of dead
+            # arms, so the resulting netlist doesn't leak fanin
+            # from a statically unreachable RHS into the mux tree
+            # (the cause of #72's 36 false-positive md→mr crossings
+            # on tiny-NPU's non-diagonal mxp_cors).
+            cond_expr = statement.conditions[0].expr if statement.conditions else None
+            cond_const = self._const_int(cond_expr)
+            if cond_const is not None:
+                live = statement.ifTrue if cond_const != 0 else statement.ifFalse
+                if live is not None:
+                    self._emit_assignments_in(
+                        live, clk_sym, reset_sym, reset_active_low, src_node
+                    )
+                return
+
+            # Dynamic condition: push the bit onto the enable stack
+            # while walking each arm so ``_emit_assignment_expression``
+            # accumulates writes with the right enable.
+            # ``_drain_proc_writes`` then collapses all writes to one
+            # flop per LHS with a mux tree:
             #
             # - ifTrue arm: push ``cond`` (positive polarity).
             # - ifFalse arm: push ``$not(cond)`` (negate via a $not

--- a/tests/test_slang_const_cond_fold.py
+++ b/tests/test_slang_const_cond_fold.py
@@ -1,0 +1,236 @@
+"""Coverage tests for slang-frontend compile-time-constant if/else
+folding.
+
+Issue: rtl-buddy-cdc#72 — after the deferred-emission walker (PR #70)
+landed, an ``if/else`` with a compile-time-constant condition emits
+**both** arms' fanin into the resulting flop's mux tree. The dead
+arm is structurally unreachable at runtime (Yosys-flatten + opt_clean
+prunes it) but the slang frontend doesn't fold, so the rule pack
+reports crossings through the dead path.
+
+Surfaced on tiny-NPU's MXP: 12 non-diagonal cors each report 3
+md→mr crossings (the `if (IS_DIAGONAL) ... else ...` mr_clk body
+where `IS_DIAGONAL` is statically false). 36 false-positive
+crossings on a 4×4 array.
+
+The tests below pin the contract: a constant-foldable condition
+collapses to walk only the live arm, and the dead arm's RHS does
+not appear in any cell connection of the resulting flop.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang const-cond-fold tests are gated on it",
+        allow_module_level=True,
+    )
+
+FLOP_TYPES = frozenset({"$dff", "$adff", "$dffe", "$adffe", "$sdff", "$sdffe"})
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _flops(module) -> list:
+    return [c for c in module.cells.values() if c.type in FLOP_TYPES]
+
+
+def _reachable_bits(module, start_bit) -> set:
+    """All bits reachable backwards from ``start_bit`` through comb
+    cells. Used to assert that a port's bits don't reach the flop's D
+    when the arm that referenced them is statically dead."""
+    drivers = {}
+    for name, cell in module.cells.items():
+        for port, bits in cell.connections.items():
+            if port in ("Q", "Y"):
+                for b in bits:
+                    if isinstance(b, int):
+                        drivers[b] = (name, port)
+    seen = set()
+    frontier = [start_bit]
+    walk_types = {"$mux", "$not", "$and", "$or", "$xor", "$add", "$sub"}
+    while frontier:
+        b = frontier.pop()
+        if b in seen or not isinstance(b, int):
+            continue
+        seen.add(b)
+        drv = drivers.get(b)
+        if drv is None:
+            continue
+        cell = module.cells[drv[0]]
+        if cell.type not in walk_types:
+            continue
+        for port, bits in cell.connections.items():
+            if port in ("Q", "Y"):
+                continue
+            for x in bits:
+                frontier.append(x)
+    return seen
+
+
+# --- literal constant condition -------------------------------------------
+
+
+def test_if_literal_true_takes_only_true_arm(tmp_path: Path) -> None:
+    """``if (1'b1) q <= a; else q <= b;`` — the b path is dead. The
+    resulting flop's D bits must not reach ``b_in``'s port bit."""
+    src = """
+    module m (input logic clk, a_in, b_in, output logic q);
+        always_ff @(posedge clk) begin
+            if (1'b1) q <= a_in;
+            else      q <= b_in;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1, f"expected one flop; got {len(flops)}"
+    d_bit = flops[0].connections["D"][0]
+    a_bit = mod.ports["a_in"].bits[0]
+    b_bit = mod.ports["b_in"].bits[0]
+    # Live arm: a_in must drive D directly (no mux needed for a folded condition).
+    assert d_bit == a_bit, f"expected D=a_in directly; got D={d_bit}, a_in={a_bit}"
+    # Dead arm: b_in must not appear anywhere in the reachable fanin.
+    reachable = _reachable_bits(mod, d_bit) | {d_bit}
+    assert b_bit not in reachable, (
+        f"b_in bit {b_bit} must not be reachable from D's fanin; "
+        "the dead arm should be pruned."
+    )
+
+
+def test_if_literal_false_takes_only_false_arm(tmp_path: Path) -> None:
+    """Mirror case: ``if (1'b0)`` — the a path is dead."""
+    src = """
+    module m (input logic clk, a_in, b_in, output logic q);
+        always_ff @(posedge clk) begin
+            if (1'b0) q <= a_in;
+            else      q <= b_in;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    d_bit = flops[0].connections["D"][0]
+    a_bit = mod.ports["a_in"].bits[0]
+    b_bit = mod.ports["b_in"].bits[0]
+    assert d_bit == b_bit, f"expected D=b_in directly; got D={d_bit}, b_in={b_bit}"
+    reachable = _reachable_bits(mod, d_bit) | {d_bit}
+    assert a_bit not in reachable, (
+        f"a_in bit {a_bit} must not be reachable; the false-true arm is dead."
+    )
+
+
+# --- parameter-folded condition ------------------------------------------
+
+
+def test_if_parameter_false_takes_only_false_arm(tmp_path: Path) -> None:
+    """The headline mxp_cor case: ``if (USE_A) q <= a; else q <= b;``
+    where ``USE_A`` is a per-instance parameter bound at elaboration.
+    The non-diagonal cor pattern (IS_DIAGONAL=0)."""
+    src = """
+    module child #(parameter bit USE_A = 0) (
+        input  logic clk,
+        input  logic d_a,
+        input  logic d_b,
+        output logic q
+    );
+        always_ff @(posedge clk) begin
+            if (USE_A) q <= d_a;
+            else       q <= d_b;
+        end
+    endmodule
+
+    module m (input logic clk, in_a, in_b, output logic q_out);
+        child #(.USE_A(1'b0)) u_b (.clk(clk), .d_a(in_a), .d_b(in_b), .q(q_out));
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    d_bit = flops[0].connections["D"][0]
+    in_a_bit = mod.ports["in_a"].bits[0]
+    in_b_bit = mod.ports["in_b"].bits[0]
+    # The instance has USE_A=0, so the live arm assigns d_b → drives D directly.
+    assert d_bit == in_b_bit, (
+        f"expected D=in_b (the live arm); got D={d_bit}, in_b={in_b_bit}"
+    )
+    reachable = _reachable_bits(mod, d_bit) | {d_bit}
+    assert in_a_bit not in reachable, (
+        f"in_a bit {in_a_bit} must not be reachable through D's mux; "
+        f"USE_A=0 means the a-arm is statically dead. Reachable={sorted(reachable)[:10]}"
+    )
+
+
+def test_if_parameter_true_takes_only_true_arm(tmp_path: Path) -> None:
+    """Mirror: ``USE_A = 1`` selects the a-arm."""
+    src = """
+    module child #(parameter bit USE_A = 0) (
+        input  logic clk,
+        input  logic d_a,
+        input  logic d_b,
+        output logic q
+    );
+        always_ff @(posedge clk) begin
+            if (USE_A) q <= d_a;
+            else       q <= d_b;
+        end
+    endmodule
+
+    module m (input logic clk, in_a, in_b, output logic q_out);
+        child #(.USE_A(1'b1)) u_a (.clk(clk), .d_a(in_a), .d_b(in_b), .q(q_out));
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    d_bit = flops[0].connections["D"][0]
+    in_a_bit = mod.ports["in_a"].bits[0]
+    in_b_bit = mod.ports["in_b"].bits[0]
+    assert d_bit == in_a_bit, (
+        f"expected D=in_a (the live arm); got D={d_bit}, in_a={in_a_bit}"
+    )
+    reachable = _reachable_bits(mod, d_bit) | {d_bit}
+    assert in_b_bit not in reachable, (
+        f"in_b bit {in_b_bit} must not be reachable; USE_A=1 → b-arm is dead."
+    )
+
+
+# --- runtime condition still emits the mux -------------------------------
+
+
+def test_runtime_condition_still_emits_mux(tmp_path: Path) -> None:
+    """Defensive: a runtime condition (not foldable) must still emit
+    the full mux tree. Without this, the const-fold path would
+    accidentally collapse legitimate runtime if/else."""
+    src = """
+    module m (input logic clk, cond, a_in, b_in, output logic q);
+        always_ff @(posedge clk) begin
+            if (cond) q <= a_in;
+            else      q <= b_in;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    d_bit = flops[0].connections["D"][0]
+    reachable = _reachable_bits(mod, d_bit) | {d_bit}
+    a_bit = mod.ports["a_in"].bits[0]
+    b_bit = mod.ports["b_in"].bits[0]
+    assert a_bit in reachable and b_bit in reachable, (
+        "runtime if/else must keep both arms' fanin in the mux tree; "
+        f"a_in={a_bit}, b_in={b_bit}, reachable={sorted(reachable)[:10]}"
+    )


### PR DESCRIPTION
## Summary

Fixes [#72](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/72). After [PR #70](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/70)'s deferred-emission walker landed, an `if/else` with a compile-time-constant condition emitted **both** arms' fanin into the flop's mux tree. The dead arm was structurally unreachable at runtime but the rule pack walked its fanin and reported crossings through the dead path.

Surfaced on tiny-NPU's MXP: 12 non-diagonal cors each reported 3 `md→mr` crossings (the `if (IS_DIAGONAL) ... else ...` mr_clk body, with `IS_DIAGONAL` statically 0 for off-diagonal cors). **36 false-positive crossings** on a 4×4 array.

Stacked on [PR #71](https://github.com/rtl-buddy/rtl-buddy-cdc/pull/71) (#69's 2-D port aliasing) since the end-to-end verification depends on both being in place.

## Approach

Two coordinated changes:

- **`_emit_assignments_in`'s ConditionalStatement dispatch** now folds via `_const_int`. If the condition is a compile-time constant (literal or parameter-driven), walk only the live arm with no enable push. The dead arm is skipped entirely so its writes never enter `_proc_writes` and the mux tree collapses naturally — matches Yosys-flatten + `opt_clean`'s dead-arm pruning.
- **Tightened `_emit_procedural_block`'s reset-check special-case** via the new `_classify_reset_check` helper. It fires only when the body's outer if is a *genuine* reset check, identified either by an event-list async-reset symbol matching the if-condition, or by the ifTrue arm containing only constant-RHS assignments (the sync-reset shape). Falling outside that envelope (a runtime `if (cond)` at the top of a no-reset always_ff) flows into the general walker so both arms drain into one flop per LHS instead of silently dropping the ifTrue arm — a latent bug surfaced by the new test suite.

The sync-reset detection via constant-only-ifTrue is the load-bearing heuristic. It correctly catches `ip_cdc_sync`'s `if (!rst_n) <for-loop-of-RST_VAL> else <data>` shape and distinguishes it from a runtime `if (cond) q <= a; else q <= b;` where ifTrue's RHS is a real expression.

## Test plan

- [x] 5 new tests in `tests/test_slang_const_cond_fold.py`: literal-true / literal-false / parameter-false / parameter-true folds (the dead arm's RHS must not be reachable through the resulting flop's D fanin) and a defensive runtime-condition case that must still emit the full mux tree.
- [x] Full pytest suite: **233 passed, 2 skipped** (no regressions; `good_2ff_sync`'s async-reset sync-chain still fires correctly, `ip_cdc_sync`-style sync-reset chains still detected, all prior fixtures pass).
- [x] Lint + format + mypy clean.
- [x] End-to-end on `ip_demo_tiny_npu`:
  - Crossings drop **154 → 118** (the 36 false-positive md→mr on 12 non-diagonal cors clear).
  - Per-cor breakdown now matches the design's `IS_DIAGONAL` parameter: 4 diagonal cors report 3 md→mr each, 12 non-diagonal cors report 0.
  - All 6 project CDC analyses PASS at 0 violations.

## Per-cor verification on MXP

| Cor | IS_DIAGONAL | md→mr (before) | md→mr (after) |
|---|---|---:|---:|
| (0,0) / (1,1) / (2,2) / (3,3) | true | 3 | **3** ✓ |
| Other 12 cors | false | 3 (false-pos) | **0** ✓ |

## Iteration arc (slang-frontend stack)

| Stage | Tiny-NPU flops | Crossings | Violations | Notes |
|---|---:|---:|---:|---|
| Baseline (no fixes) | 28 | 0 | 0 | false PASS |
| After #53 / #54 / #59 / #62 / #64-no-else / #55 | 1073 | 95 | 0 | |
| After #70 (#64 deferred) | 684 | 118 | 0 | intra-cor crossings exposed |
| After #71 (#69) | 684 | 154 | 0 | inter-cor crossings exposed |
| **After this PR (#72)** | **684** | **118** | **0** | dead-arm false-positives pruned |

The 118 ≠ 95 — same headline number but different content. Pre-stack: 95 crossings with the diagonal turn double-counted (intra-cor only). Post-stack: 118 crossings reflecting the correct intra-cor + inter-cor structure of the MXP fabric, with no false-positives from statically-dead branches.

## Out of scope

- Case-statement const-fold (`case (1'b1)`) — same shape, different dispatch path. File a follow-up if a real design hits it. Tiny-NPU's case statements are all runtime-dispatched.
- Generic dead-code elimination beyond if-condition folding — the deferred-emission walker already builds a minimal mux tree; this is a peephole on top.
- Yosys frontend, rule semantics, JSON schema — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
