### PR TITLE
feat(slang): populate $dff / $adff WIDTH and ARST_VALUE parameters (#40)

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -114,9 +114,12 @@ What is NOT yet implemented (next slices)
   :meth:`_walk_case_statement` lowering treats every label as a
   full ``$eq`` match, so wildcard bits in the label aren't honored.
   Uncommon in CDC-sensitive code and not yet wired up.
-- **Width-N $dff / $adff parameters** (``WIDTH``, ``ARST_VALUE``)
-  — partially populated today; not yet read by any rule but should
-  reach full Yosys parity for future rule extensions.
+- **``CLK_POLARITY = "0"`` for negedge-clocked flops** — the
+  procedural-block lowering assumes posedge today, so
+  ``CLK_POLARITY`` is hard-coded to ``"1"`` in :meth:`_emit_flop_cell`.
+  ``WIDTH`` / ``ARST_VALUE`` / ``ARST_POLARITY`` are populated in
+  Yosys-binary form per issue #40, and width comes straight from the
+  Q bit-tuple, so multi-bit flops have correct parameter shape.
 - **Yosys-only constructs** (``$_BUF_`` / ``$_NOT_`` primitives in SV
   source) are correctly rejected by slang — they're post-synthesis
   cells, not legal SV. Fixtures that rely on them
@@ -207,6 +210,22 @@ def elaborate(sources: list[Path], top: str) -> Module:
 # --- internal: build a Yosys-shape Module from a pyslang InstanceSymbol -----
 
 
+def _param_int32(val: int) -> str:
+    """Encode ``val`` as a 32-bit MSB-first binary string. Matches the
+    serialisation Yosys writes for integer-typed cell parameters
+    (``WIDTH``, ``ARST_POLARITY``) into ``write_json`` output."""
+    return format(val & 0xFFFFFFFF, "032b")
+
+
+def _param_bits(val: int, width: int) -> str:
+    """Encode ``val`` as an ``N``-bit MSB-first binary string of length
+    ``max(width, 1)``. Matches how Yosys serialises constant-bit-vector
+    parameters whose width tracks the flop's data width (``ARST_VALUE``,
+    where the string length equals the ``$adff``'s ``WIDTH``)."""
+    w = max(int(width), 1)
+    return format(val & ((1 << w) - 1), f"0{w}b")
+
+
 class _ModuleBuilder:
     """Translate a pyslang elaborated :class:`InstanceSymbol` into a
     :class:`netlist.Module`.
@@ -273,6 +292,15 @@ class _ModuleBuilder:
             tuple[Bit, ...],
             list[tuple[Bit | None, tuple[Bit, ...]]],
         ] = {}
+        # Per-procedural-block async-reset value accumulator: maps each
+        # LHS bit tuple to the integer constant written in the reset
+        # arm (``if (!rst_n) q <= 4'd5;`` → 5). Populated by
+        # ``_collect_reset_assignments`` from the ifTrue arm and read
+        # at drain time to fill the ``$adff`` ``ARST_VALUE`` parameter.
+        # Missing entries default to 0 — that's the conservative match
+        # for the typical ``q <= '0`` reset and keeps the netlist
+        # valid when the reset RHS isn't a recognised literal.
+        self._proc_resets: dict[tuple[Bit, ...], int] = {}
 
     # -- public ----------------------------------------------------------
 
@@ -699,6 +727,7 @@ class _ModuleBuilder:
         # end so one flop emits per LHS even when multiple arms write
         # the same target (the if/else both-arms case).
         self._proc_writes = {}
+        self._proc_resets = {}
         block_reset_sym = reset_sym
         block_reset_active_low = reset_active_low
         try:
@@ -713,6 +742,10 @@ class _ModuleBuilder:
                 data_branch = inner.ifFalse
                 if data_branch is None:
                     return  # no else → no data assignment to model
+                # Capture reset-arm literal RHS values before walking
+                # the data arm — drain time looks these up to populate
+                # ``$adff``'s ``ARST_VALUE`` parameter (issue #40).
+                self._collect_reset_assignments(inner.ifTrue)
                 self._emit_assignments_in(
                     data_branch,
                     clk_sym,
@@ -745,6 +778,44 @@ class _ModuleBuilder:
             )
         finally:
             self._proc_writes = {}
+            self._proc_resets = {}
+
+    def _collect_reset_assignments(self, stmt: Any) -> None:
+        """Walk an ``always_ff`` reset arm (``if (!rst_n) <stmt>``) and
+        record per-LHS reset values into ``self._proc_resets``.
+
+        Captures nonblocking assignments whose RHS is a compile-time
+        constant. Anything else — non-literal RHS, struct/hierref LHS,
+        nested conditionals — is silently skipped, and the drain-time
+        lookup falls back to 0. The reset values feed ``$adff``'s
+        ``ARST_VALUE`` parameter (issue #40); the rule pack doesn't
+        read it today, so a default of 0 keeps the netlist valid even
+        when this walker doesn't recognise the shape.
+        """
+        if stmt is None:
+            return
+        kind = self._kind_name(stmt)
+        if kind == "BlockStatement":
+            self._collect_reset_assignments(stmt.body)
+            return
+        if kind in {"StatementList", "ListStatement"}:
+            for s in getattr(stmt, "list", []) or []:
+                self._collect_reset_assignments(s)
+            return
+        if kind != "ExpressionStatement":
+            return
+        expr = stmt.expr
+        if type(expr).__name__ != "AssignmentExpression":
+            return
+        if not getattr(expr, "isNonBlocking", False):
+            return
+        q_bits = self._lvalue_bits(expr.left)
+        if q_bits is None:
+            return
+        val = self._const_int(expr.right)
+        if val is None:
+            return
+        self._proc_resets[q_bits] = val
 
     def _analyse_event_list(self, timing: Any) -> tuple[Any | None, Any | None, bool]:
         """Pick clock + (optional) async-reset symbols out of the
@@ -1189,8 +1260,15 @@ class _ModuleBuilder:
                     d_bits = rhs
                 else:
                     d_bits = self._build_hold_mux(enable, hold=d_bits, fire=rhs)
+            reset_value = self._proc_resets.get(q_bits, 0)
             self._emit_flop_cell(
-                clk_sym, reset_sym, reset_active_low, q_bits, d_bits, src_node
+                clk_sym,
+                reset_sym,
+                reset_active_low,
+                q_bits,
+                d_bits,
+                src_node,
+                reset_value=reset_value,
             )
 
     def _build_hold_mux(
@@ -1223,6 +1301,7 @@ class _ModuleBuilder:
         q_bits: tuple[Bit, ...],
         d_bits: tuple[Bit, ...],
         src_node: Any,
+        reset_value: int = 0,
     ) -> None:
         """Allocate a ``$dff`` / ``$adff`` cell with the given D and Q."""
         connections: dict[str, tuple[Bit, ...]] = {
@@ -1234,9 +1313,20 @@ class _ModuleBuilder:
         if reset_sym is not None:
             connections["ARST"] = self._alloc_bits(reset_sym)
             cell_type = "$adff"
-        parameters: dict[str, str] = {"CLK_POLARITY": "1"}
+        # CLK_POLARITY: slang lowering only emits posedge-clocked flops
+        # today, so this is hard-coded to "1". Negedge support (issue
+        # out-of-scope for #40) will need a polarity arg threaded down.
+        # WIDTH / ARST_POLARITY match Yosys' 32-bit binary-string param
+        # encoding; ARST_VALUE matches the flop's bit width so the
+        # string length lines up with the D / Q nets.
+        width = len(q_bits)
+        parameters: dict[str, str] = {
+            "CLK_POLARITY": "1",
+            "WIDTH": _param_int32(width),
+        }
         if reset_sym is not None:
-            parameters["ARST_POLARITY"] = "0" if reset_active_low else "1"
+            parameters["ARST_POLARITY"] = _param_int32(0 if reset_active_low else 1)
+            parameters["ARST_VALUE"] = _param_bits(reset_value, width)
         attrs: dict[str, str] = {}
         src = self._src_attr(src_node) if src_node is not None else None
         if src is not None:

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -289,6 +289,71 @@ def test_elaborated_module_has_expected_yosys_shape() -> None:
                 # Constant bits would be the string "0" / "1" / "x"
                 # / "z"; the canonical case here is all-integer.
                 assert isinstance(bit, (int, str))
+    # Issue #40: every $adff carries the Yosys-shape parameter dict
+    # — WIDTH / ARST_VALUE / ARST_POLARITY / CLK_POLARITY — populated
+    # in the same binary-string encoding Yosys writes for write_json.
+    # The fixture's flops are both 1-bit with active-low resets and a
+    # ``q <= 1'b0`` reset value, so the expected dict is deterministic.
+    for cell in ff_cells:
+        assert cell.type == "$adff"
+        assert cell.parameters == {
+            "CLK_POLARITY": "1",
+            "WIDTH": "0" * 31 + "1",
+            "ARST_POLARITY": "0" * 32,
+            "ARST_VALUE": "0",
+        }, cell.parameters
+
+
+def test_adff_parameters_track_multi_bit_width_and_reset_value(
+    tmp_path: Path,
+) -> None:
+    """Pin the parameter shape for a multi-bit flop with a non-zero
+    async reset value — exercises the ``WIDTH`` decoding (matches the
+    D bit-tuple length) and the ``ARST_VALUE`` width tracking with
+    ``WIDTH`` (issue #40). Yosys writes ``ARST_VALUE`` as an N-bit
+    binary string whose length equals ``WIDTH``; reset value 5 in a
+    4-bit flop is ``"0101"``."""
+    src = """module m (
+    input  logic clk, rst_n, d0, d1, d2, d3,
+    output logic [3:0] q
+);
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) q <= 4'd5;
+        else        q <= {d3, d2, d1, d0};
+    end
+endmodule
+"""
+    sv = tmp_path / "m.sv"
+    sv.write_text(src)
+    module = elaborate([sv], "m", frontend=Frontend.slang)
+    adff = next(c for c in module.cells.values() if c.type == "$adff")
+    assert adff.parameters == {
+        "CLK_POLARITY": "1",
+        "WIDTH": "0" * 28 + "0100",  # 4 in 32-bit binary
+        "ARST_POLARITY": "0" * 32,  # active-low (negedge rst_n)
+        "ARST_VALUE": "0101",  # 5 in 4-bit binary, length tracks WIDTH
+    }, adff.parameters
+
+
+def test_dff_parameters_have_width_but_no_arst(tmp_path: Path) -> None:
+    """The plain ``$dff`` case (no async reset) should still get
+    ``WIDTH`` + ``CLK_POLARITY``, but no ``ARST_*`` keys — Yosys omits
+    them when the cell type is ``$dff``."""
+    src = """module m (
+    input  logic clk, d,
+    output logic q
+);
+    always_ff @(posedge clk) q <= d;
+endmodule
+"""
+    sv = tmp_path / "m.sv"
+    sv.write_text(src)
+    module = elaborate([sv], "m", frontend=Frontend.slang)
+    dff = next(c for c in module.cells.values() if c.type == "$dff")
+    assert dff.parameters == {
+        "CLK_POLARITY": "1",
+        "WIDTH": "0" * 31 + "1",
+    }, dff.parameters
 
 
 # --- Issue #15 regression: child-port netnames preserved as aliases --------


### PR DESCRIPTION
## Summary
- Closes #40. The slang frontend's `$dff` / `$adff` cells now ship `WIDTH`, `ARST_VALUE`, `ARST_POLARITY`, and `CLK_POLARITY` in the same 32-bit / N-bit binary-string encoding Yosys writes for `write_json`. Width comes from the Q bit-tuple length so multi-bit flops have correct shape; `ARST_VALUE`'s string length tracks `WIDTH` per Yosys convention.
- Reset values are recovered by walking the `if (!rst_n)` arm: a new `_proc_resets` per-block accumulator + `_collect_reset_assignments` helper records the constant RHS of each nonblocking write, and `_drain_proc_writes` looks it up per LHS. Non-literal RHS, struct/hierref LHS, and nested conditionals fall back to 0 — keeps the netlist valid without inventing values.
- `CLK_POLARITY` stays hard-coded to `"1"` (slang lowering only emits posedge today). Replaced the old "partially populated $dff/$adff parameters" docstring caveat with a negedge-`CLK_POLARITY` caveat that remains.

## Test plan
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] `uv run pytest -q` — 235 passed, 2 skipped
- [x] `test_elaborated_module_has_expected_yosys_shape` extended to pin the full parameter dict on the existing `bad_single_ff_sync` fixture (1-bit, active-low, reset=0).
- [x] New `test_adff_parameters_track_multi_bit_width_and_reset_value` — 4-bit `$adff` with `4'd5` reset asserts `WIDTH = "...0100"`, `ARST_VALUE = "0101"`.
- [x] New `test_dff_parameters_have_width_but_no_arst` — plain `$dff` gets `WIDTH` + `CLK_POLARITY`, no `ARST_*` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)