### PR TITLE
feat(reporter): resolve Violation.instance_path at the CLI boundary

### DIFF
--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -16,7 +16,7 @@ from rtl_buddy_cdc.domain import Crossing, assign_domains, find_crossings
 from rtl_buddy_cdc.frontend import Frontend, elaborate, resolve_auto
 from rtl_buddy_cdc.frontends.slang import SlangFrontendUnavailable
 from rtl_buddy_cdc.frontends.yosys import YosysError
-from rtl_buddy_cdc.reporter import AnalysisResult
+from rtl_buddy_cdc.reporter import AnalysisResult, _instance_path
 from rtl_buddy_cdc.rules import Violation, run_all as run_all_rules
 from rtl_buddy_cdc.waivers import SuppressedViolation
 
@@ -389,6 +389,31 @@ def _analyze_module_and_report(
             dataclasses.replace(v, severity="error") if v.severity == "warning" else v
             for v in violations
         ]
+
+    # Resolve each violation's hierarchical instance path from its
+    # ``cell_name``. Done here, at the CLI boundary, so the rule pack
+    # stays frontend-agnostic (no ``reporter`` import in ``rules.py``).
+    # See ``wiki/raw/articles/hierarchical-reporting.md`` for the
+    # resolver contract and the parent issue #46 for the rendering
+    # phases that consume the field.
+    violations = [
+        dataclasses.replace(v, instance_path=_instance_path(module, v.cell_name))
+        for v in violations
+    ]
+    suppressed = [
+        dataclasses.replace(
+            s,
+            violation=dataclasses.replace(
+                s.violation,
+                instance_path=_instance_path(module, s.violation.cell_name),
+            ),
+        )
+        for s in suppressed
+    ]
+    baseline_carryover = [
+        dataclasses.replace(v, instance_path=_instance_path(module, v.cell_name))
+        for v in baseline_carryover
+    ]
 
     result = AnalysisResult(
         module=module,

--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -497,6 +497,71 @@ _SRC_RE = re.compile(
 )
 
 
+# Yosys ``flatten`` writes nested cells under a literal ``$flatten\``
+# prefix followed by the instance name and a ``.`` separator. The
+# constant captures one literal backslash — Python source needs the
+# double-backslash escape, the on-disk string is one byte.
+_FLATTEN_PREFIX = "$flatten\\"
+
+
+def _instance_path(module: Module, cell_name: str | None) -> tuple[str, ...]:
+    """Map a cell name to the hierarchical instance path it lives in.
+
+    Returns an empty tuple for cells at the top instance (the common
+    case on flat IP-block fixtures), the inferred path otherwise. The
+    ``module`` argument is currently unused but mirrors the
+    :func:`_source_location` signature and leaves room for a future
+    hierarchy-aware lookup (e.g. resolving an attribute-tagged netname
+    back through an alias chain).
+
+    Cell-name shapes the analyzer sees today:
+
+    - ``$flatten\\u_x.<leaf>`` — Yosys post-flatten, user instance.
+      Strip the prefix, split on the *first* ``.``; the prefix piece
+      is one path component. Iterate while the remainder still begins
+      with ``$flatten\\`` to cover the (rare) nested case.
+    - ``$procdff$42`` / ``$logic_and$<file>:<line>$N`` — top-level
+      Yosys auto-name. No instance prefix; the ``$<...>:<line>`` shape
+      embeds a source path so naïve ``split('.')`` would tokenize on
+      the dot inside the file path. Returns ``()``.
+    - ``u_b0.q`` — slang frontend. Plain dotted path; the last
+      component is the leaf symbol, everything before it is the
+      instance path. The top instance is *not* part of the name (the
+      slang frontend walks the top with ``hier_prefix=''``), so the
+      resolver does not need to strip a top component.
+    - Anything else (e.g. slang top-level ``$mux$23``) → ``()``.
+    """
+    if cell_name is None:
+        return ()
+    parts: list[str] = []
+    remaining = cell_name
+    while remaining.startswith(_FLATTEN_PREFIX):
+        body = remaining[len(_FLATTEN_PREFIX) :]
+        dot = body.find(".")
+        if dot < 0:
+            # Malformed ``$flatten\<name>`` with no separator — bail
+            # conservatively rather than guessing.
+            return tuple(parts)
+        parts.append(body[:dot])
+        remaining = body[dot + 1 :]
+    if parts:
+        return tuple(parts)
+    # No ``$flatten\`` prefix. Distinguish the slang dotted shape from
+    # top-level Yosys auto-names. Yosys auto-names always begin with
+    # ``$``; the ``$<...>:<line>`` shape may embed dots inside the
+    # source path, so a name with ``$`` before its first ``.`` is
+    # never a slang hierarchical path.
+    first_dot = cell_name.find(".")
+    if first_dot < 0:
+        return ()
+    if "$" in cell_name[:first_dot]:
+        return ()
+    components = cell_name.split(".")
+    if len(components) < 2:
+        return ()
+    return tuple(components[:-1])
+
+
 def _source_location(module: Module, cell_name: str | None) -> dict | None:
     """Translate a cell's ``attributes["src"]`` into a structured location.
 

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -32,6 +32,15 @@ class Violation:
     # cell's ``attributes["src"]`` field. Falls back to the crossing's
     # dst flop if not set.
     cell_name: str | None = None
+    # Hierarchical instance path the offending cell lives in, derived
+    # from ``cell_name`` by ``reporter._instance_path`` at the CLI
+    # boundary. ``()`` means the cell is at the top instance (the
+    # common case on flat IP-block fixtures) and is also the safe
+    # default for rules that construct ``Violation`` directly — the
+    # resolver only runs in ``cli._analyze_and_report``, not in the
+    # rule pack. Reporters consume this in phase 2/3/4 of #46 to
+    # group findings by instance.
+    instance_path: tuple[str, ...] = ()
 
 
 # ``ctx`` is keyword-only on every rule; using ``Callable[..., ...]`` because

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import importlib.metadata
 import io
 import json
@@ -17,6 +18,7 @@ from rtl_buddy_cdc.reporter import (
     JSON_CONTRACT,
     TOOL_VERSION,
     AnalysisResult,
+    _instance_path,
     render_json,
     render_sarif,
     render_text,
@@ -497,3 +499,100 @@ def test_baseline_carryover_chains(tmp_path: Path) -> None:
     # The current finding matches via the baseline's carryover bucket.
     assert payload["summary"]["violations"] == 0
     assert payload["summary"]["baseline_carryover"] == 1
+
+
+# --- hierarchical instance path (issue #75) ---------------------------------
+#
+# Phase 1 of #46: every Violation carries an ``instance_path: tuple[str, ...]``
+# resolved from its ``cell_name``. The resolver runs in the CLI boundary, not
+# in the rule pack. These tests pin the resolver's behaviour against the
+# three cell-name shapes the analyzer sees today (Yosys ``$flatten\`` prefix,
+# top-level Yosys auto-name, slang dotted) and verify the field actually
+# reaches ``AnalysisResult.violations`` on a real fixture.
+
+
+@pytest.mark.parametrize(
+    "cell_name, expected",
+    [
+        # Top instance / None → empty tuple.
+        (None, ()),
+        ("$procdff$42", ()),
+        ("$logic_and$tests/foo.sv:55$13", ()),
+        # Yosys flatten — single instance, then nested.
+        ("$flatten\\u_sync_ack.$procdff$84", ("u_sync_ack",)),
+        ("$flatten\\u_a.$flatten\\u_b.$dff$1", ("u_a", "u_b")),
+        # slang frontend dotted shape; the last component is the leaf
+        # symbol, not an instance.
+        ("u_b0.q", ("u_b0",)),
+        # Pathological — cell names containing dots are not produced by
+        # either shipping frontend, but the resolver still does
+        # something sensible (treats the last component as the leaf).
+        ("u_b0.cell_with.dots", ("u_b0", "cell_with")),
+    ],
+)
+def test_instance_path_resolver_table(
+    result: AnalysisResult, cell_name: str | None, expected: tuple[str, ...]
+) -> None:
+    # The ``module`` argument is currently unused but the contract takes
+    # it for parity with ``_source_location``; passing the existing
+    # result's module satisfies the type without changing behaviour.
+    assert _instance_path(result.module, cell_name) == expected
+
+
+def test_instance_path_default_on_violation_is_empty_tuple() -> None:
+    """A ``Violation`` constructed without ``instance_path`` defaults to
+    ``()``. This keeps existing test literals across the suite valid
+    without an audit, and matches the resolver's top-instance result."""
+    from rtl_buddy_cdc.rules import Violation
+
+    v = Violation(rule_id="CDC-001", severity="error", message="x")
+    assert v.instance_path == ()
+
+
+def test_instance_path_populated_on_handshake_strict_run(tmp_path: Path) -> None:
+    """End-to-end: a real fixture with nested instances (ip_cdc_handshake
+    instantiates two ``ip_cdc_sync`` children, ``u_sync_ack`` and
+    ``u_sync_req``) at ``--sync-depth 3`` produces two CDC-002 findings
+    whose ``cell_name`` carries the ``$flatten\\u_sync_*`` prefix. The
+    CLI boundary must populate ``instance_path`` accordingly."""
+    fix_dir = Path(__file__).parent / "fixtures" / "ip_cdc_handshake"
+    json_path = fix_dir / "ip_cdc_handshake.json"
+    sdc_path = fix_dir / "ip_cdc_handshake.sdc"
+    if not json_path.exists():
+        pytest.skip(f"fixture not built: {json_path}")
+    out = tmp_path / "report.json"
+    _analyze_and_report(
+        json_path,
+        sdc_path,
+        None,
+        OutputFormat.json,
+        out,
+        sync_depth=3,
+    )
+    payload = json.loads(out.read_text())
+    # Two CDC-002 findings (one per sync chain); each must come from
+    # inside one of the named child instances.
+    rule_ids = {v["rule_id"] for v in payload["violations"]}
+    assert rule_ids == {"CDC-002"}, rule_ids
+    # ``instance_path`` is not yet emitted in the JSON payload (phase 2),
+    # so rebuild the AnalysisResult to peek at the in-memory field.
+    module = netlist.load(json_path)
+    spec = sdc_mod.parse_file(sdc_path)
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    async_crossings = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    raw = run_all_rules(module, async_crossings, spec, required_depth=3)
+    # Run the same boundary post-pass the CLI runs.
+    resolved = [
+        dataclasses.replace(v, instance_path=_instance_path(module, v.cell_name))
+        for v in raw
+    ]
+    assert {v.instance_path for v in resolved} == {("u_sync_ack",), ("u_sync_req",)}


### PR DESCRIPTION
Closes #75. Phase 1 of #46.

## Summary

- New frozen field `Violation.instance_path: tuple[str, ...] = ()` (default keeps existing test literals valid).
- New `reporter._instance_path(module, cell_name) -> tuple[str, ...]` resolver handling the three cell-name shapes the analyzer sees in practice.
- Wired at `cli._analyze_module_and_report` (boundary between rule pack and reporter) so the rule pack stays frontend-agnostic — no `reporter` import in `rules.py`. Resolver also runs on `suppressed` and `baseline_carryover` so subsequent phases see populated paths on every code path.
- **No reporter output changes** in this phase. JSON / SARIF / text are byte-identical to main. `JSON_CONTRACT` keys, `--baseline` match key, SARIF schema all untouched.

## Resolver behaviour

| Input | `instance_path` |
|---|---|
| `None` | `()` |
| `$procdff$42` (top-level Yosys auto-name) | `()` |
| `$logic_and$tests/foo.sv:55$13` (embedded file path) | `()` |
| `$flatten\u_sync_ack.$procdff$84` | `('u_sync_ack',)` |
| `$flatten\u_a.$flatten\u_b.$dff$1` (nested) | `('u_a', 'u_b')` |
| `u_b0.q` (slang frontend) | `('u_b0',)` |
| `u_b0.cell_with.dots` (pathological, documented) | `('u_b0', 'cell_with')` |

The `$-before-first-dot` guard is the load-bearing piece — without it, the embedded source path in `$logic_and$tests/foo.sv:55$13` would tokenize on its own `.` and produce nonsense.

## Test plan

- [x] `tests/test_reporter.py::test_instance_path_resolver_table` — 7 parametrized cases pin the resolver behaviour
- [x] `tests/test_reporter.py::test_instance_path_default_on_violation_is_empty_tuple` — default field value
- [x] `tests/test_reporter.py::test_instance_path_populated_on_handshake_strict_run` — end-to-end against `ip_cdc_handshake` at `--sync-depth 3`, asserts the two CDC-002 findings carry `('u_sync_ack',)` and `('u_sync_req',)`
- [x] `uv run pytest -q` — 167 passed, 11 skipped
- [x] `uv run ruff check && uv run ruff format --check`
- [x] `uv run mypy` — Success: no issues found in 13 source files
- [x] JSON contract test (`test_json_contract_keys_present_and_typed`) and SARIF schema test (`tests/test_sarif_schema.py`, 6 cases) still green — phase 1 doesn't alter either output

🤖 Generated with [Claude Code](https://claude.com/claude-code)