### PR TITLE
feat(reporter): per-instance grouping in the text report

### DIFF
--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -243,12 +243,44 @@ def _render_violations(result: AnalysisResult, out: IO[str], s: _Style) -> None:
         vs = by_rule[rule_id]
         desc = _RULE_DESCRIPTIONS.get(rule_id, "")
         out.write(f"\n  {s.bold}{rule_id}{s.reset} — {desc}\n")
-        for v in vs:
-            _render_one_violation(v, result.module, out, s)
+        _render_rule_group(vs, result.module, out, s)
+
+
+def _render_rule_group(
+    violations: list[Violation], module: Module, out: IO[str], s: _Style
+) -> None:
+    """Render the violations within a single rule group.
+
+    Per-instance bucketing is engaged iff *any* violation in the group
+    carries a non-empty ``instance_path``. When every violation is at
+    the top instance — the common case on flat IP-block fixtures — the
+    headers collapse and the output is byte-identical to the pre-#46
+    layout. Phase 4 of #46.
+    """
+    if not any(v.instance_path for v in violations):
+        for v in violations:
+            _render_one_violation(v, module, out, s, indent=4)
+        return
+    # Bucket by instance_path. Tuple comparison sorts ``()`` before any
+    # populated path, then lexicographically — which is exactly the
+    # display order we want: top first, then nested in path order.
+    by_inst: dict[tuple[str, ...], list[Violation]] = defaultdict(list)
+    for v in violations:
+        by_inst[v.instance_path].append(v)
+    for path in sorted(by_inst):
+        header = "[top]" if not path else " / ".join(path)
+        out.write(f"    {s.dim}{header}{s.reset}\n")
+        for v in by_inst[path]:
+            _render_one_violation(v, module, out, s, indent=6)
 
 
 def _render_one_violation(
-    v: Violation, module: Module, out: IO[str], s: _Style
+    v: Violation,
+    module: Module,
+    out: IO[str],
+    s: _Style,
+    *,
+    indent: int = 4,
 ) -> None:
     severity_color = {
         "error": s.red,
@@ -260,9 +292,11 @@ def _render_one_violation(
     if loc is not None:
         line_part = f":{loc['start_line']}" if "start_line" in loc else ""
         loc_str = f"  {s.dim}{loc['file']}{line_part}{s.reset}"
-    out.write(f"    {severity_color}{v.severity}{s.reset}{loc_str}\n")
+    pad = " " * indent
+    msg_pad = " " * (indent + 2)
+    out.write(f"{pad}{severity_color}{v.severity}{s.reset}{loc_str}\n")
     for line in _wrap_message(v.message):
-        out.write(f"      {line}\n")
+        out.write(f"{msg_pad}{line}\n")
 
 
 def _wrap_message(text: str) -> list[str]:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -875,3 +875,131 @@ def test_sarif_logical_locations_on_suppressed_entries(
     assert ll[0]["fullyQualifiedName"] == "u_block_a.u_sync"
     assert ll[0]["name"] == "u_sync"
     assert ll[0]["kind"] == "module"
+
+
+# --- text reporter per-instance grouping (phase 4 of #46) -------------------
+#
+# Inside each rule group, violations are bucketed by ``instance_path`` and
+# rendered with a per-instance header (``[top]`` for the top bucket,
+# ``a / b / c`` for nested paths). Headers collapse when every violation in
+# the group is at the top instance — flat IP-block fixtures' output stays
+# byte-identical to today.
+
+
+def test_text_no_instance_headers_on_flat_fixture(result: AnalysisResult) -> None:
+    """``bad_single_ff_sync`` is a flat fixture (no child instances).
+    The grouped layout collapses and the rendered text contains no
+    instance-header markers — same output as before phase 4."""
+    buf = io.StringIO()
+    render_text(result, buf, color=False)
+    text = buf.getvalue()
+    assert "[top]" not in text
+    # No 'a / b' style instance headers either. The ' / ' substring is
+    # specific enough — rule descriptions use ' — ' (em-dash) not ' / '.
+    assert " / " not in text
+
+
+def test_text_groups_by_instance_on_handshake_strict(tmp_path: Path) -> None:
+    """``ip_cdc_handshake`` at ``--sync-depth 3`` fires two CDC-002
+    findings, one inside ``u_sync_ack`` and one inside ``u_sync_req``.
+    The text report buckets them under per-instance headers in
+    sorted order (no ``[top]`` here since neither finding is
+    top-instance)."""
+    fix_dir = Path(__file__).parent / "fixtures" / "ip_cdc_handshake"
+    json_path = fix_dir / "ip_cdc_handshake.json"
+    sdc_path = fix_dir / "ip_cdc_handshake.sdc"
+    if not json_path.exists():
+        pytest.skip(f"fixture not built: {json_path}")
+    out = tmp_path / "report.txt"
+    _analyze_and_report(
+        json_path,
+        sdc_path,
+        None,
+        OutputFormat.text,
+        out,
+        sync_depth=3,
+        color=False,
+    )
+    text = out.read_text()
+    # Both instance headers are present; top header is omitted because
+    # neither finding sits at top.
+    assert "    u_sync_ack\n" in text
+    assert "    u_sync_req\n" in text
+    assert "[top]" not in text
+    # Headers appear in sorted order: u_sync_ack before u_sync_req.
+    ack_pos = text.index("u_sync_ack")
+    req_pos = text.index("u_sync_req")
+    assert ack_pos < req_pos
+    # Each instance header is followed (within the rule group) by an
+    # indented severity line. Two CDC-002s total, both `warning`.
+    assert text.count("      warning") == 2
+
+
+def test_text_mixed_top_and_nested_renders_both_headers(
+    result: AnalysisResult,
+) -> None:
+    """When a single rule group has BOTH a top-instance violation and
+    a nested-instance one, the layout emits ``[top]`` first then the
+    nested-path header. Built from synthetic violations because no
+    shipping fixture exercises this mix yet."""
+    from rtl_buddy_cdc.rules import Violation as RuleViolation
+
+    v_top = RuleViolation(
+        rule_id="CDC-001",
+        severity="error",
+        message="top-level finding",
+    )
+    v_nested = RuleViolation(
+        rule_id="CDC-001",
+        severity="error",
+        message="nested finding",
+        instance_path=("u_block_a", "u_sync"),
+    )
+    mixed = AnalysisResult(
+        module=result.module,
+        domains=result.domains,
+        crossings=result.crossings,
+        async_crossings=result.async_crossings,
+        spec=result.spec,
+        violations=[v_top, v_nested],
+    )
+    buf = io.StringIO()
+    render_text(mixed, buf, color=False)
+    text = buf.getvalue()
+    assert "    [top]\n" in text
+    assert "    u_block_a / u_sync\n" in text
+    # Top bucket comes first.
+    assert text.index("[top]") < text.index("u_block_a / u_sync")
+    # Severity lines under each bucket use the deeper indent (6 spaces)
+    # so the header→body relationship is visually unambiguous.
+    assert "      error" in text
+
+
+def test_text_grouped_layout_indent_one_deeper_than_flat(
+    result: AnalysisResult,
+) -> None:
+    """When grouping engages, severity lines sit one indent level
+    deeper than they do in the flat layout (6 spaces vs 4). The
+    rule-group line itself ('  CDC-NNN — ...') is unchanged."""
+    from rtl_buddy_cdc.rules import Violation as RuleViolation
+
+    nested = RuleViolation(
+        rule_id="CDC-001",
+        severity="error",
+        message="x",
+        instance_path=("u_a",),
+    )
+    grouped = AnalysisResult(
+        module=result.module,
+        domains=result.domains,
+        crossings=result.crossings,
+        async_crossings=result.async_crossings,
+        spec=result.spec,
+        violations=[nested],
+    )
+    buf = io.StringIO()
+    render_text(grouped, buf, color=False)
+    text = buf.getvalue()
+    assert "  CDC-001" in text  # rule header at 2 spaces (unchanged)
+    assert "    u_a\n" in text  # instance header at 4 spaces
+    assert "      error" in text  # severity at 6 spaces (deeper than flat)


### PR DESCRIPTION
Closes #78. Phase 4 (final) of #46.

## Summary

Inside each rule group, violations are bucketed by `instance_path`. Top instance is rendered first (`[top]`), then nested paths sorted lexicographically with ` / ` separators (`u_block_a / u_sync`). Severity lines under each bucket sit one indent level deeper than today's flat layout.

```
  CDC-001 — Unsynchronized control crossing (no second-stage flop)
    [top]
      error  alu_accel.sv:42
        flop dst_q crosses ...
    u_block_a / u_sync
      error  block_a/sync.sv:18
        flop u_sync.dst_q crosses ...
```

## The collapse rule

Grouping only engages when *some* violation in the rule group has a non-empty `instance_path`. On every shipping `bad_*` fixture (all flat IP-block designs), the bucketing collapses and the text output is **byte-identical** to today. This is what keeps the existing text-reporter tests green without per-fixture snapshot updates.

The implementation guard:

```python
if not any(v.instance_path for v in violations):
    for v in violations:
        _render_one_violation(v, module, out, s, indent=4)
    return
```

## Refactor

`_render_one_violation` gained an `indent=` kwarg (default 4 = today's flat layout indent; grouped path uses 6 so the per-instance header → body relationship is visually unambiguous). The previous hard-coded 4-space severity / 6-space message indent now scales off this kwarg.

A new `_render_rule_group` helper carries the bucketing logic, keeping `_render_violations` focused on the per-rule grouping it already does.

## Test plan

- [x] `test_text_no_instance_headers_on_flat_fixture` — `bad_single_ff_sync` produces zero `[top]` or ` / ` markers; collapsed path verified.
- [x] `test_text_groups_by_instance_on_handshake_strict` — `ip_cdc_handshake` at `--sync-depth 3` produces two CDC-002 findings under `u_sync_ack` and `u_sync_req` headers in sorted order, no `[top]` (neither at top), severity lines at indent 6.
- [x] `test_text_mixed_top_and_nested_renders_both_headers` — synthetic AnalysisResult with one top + one nested violation; `[top]` appears before the nested header.
- [x] `test_text_grouped_layout_indent_one_deeper_than_flat` — pins the indent levels (rule header at 2, instance header at 4, severity at 6).
- [x] `uv run pytest -q` — 180 passed, 11 skipped
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy` clean

## What lands after this

#46's four implementation phases are now complete. Phase 5 (instance-scoped waivers) is the optional stretch — explicit non-goal of #46 and not blocked by anything that's landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)