### PR TITLE
fix(reporter): handle Yosys multi-level flatten in _instance_path

### DIFF
--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -570,14 +570,19 @@ def _instance_path(module: Module, cell_name: str | None) -> tuple[str, ...]:
 
     Cell-name shapes the analyzer sees today:
 
-    - ``$flatten\\u_x.<leaf>`` — Yosys post-flatten, user instance.
-      Strip the prefix, split on the *first* ``.``; the prefix piece
-      is one path component. Iterate while the remainder still begins
-      with ``$flatten\\`` to cover the (rare) nested case.
-    - ``$procdff$42`` / ``$logic_and$<file>:<line>$N`` — top-level
-      Yosys auto-name. No instance prefix; the ``$<...>:<line>`` shape
-      embeds a source path so naïve ``split('.')`` would tokenize on
-      the dot inside the file path. Returns ``()``.
+    - ``$flatten\\<inst>.<leaf>`` (single level) and
+      ``$flatten\\<inst>.\\<inner>.<leaf>`` (any depth) — Yosys post-
+      flatten. The flatten pass emits *exactly one* ``$flatten\\``
+      prefix per cell regardless of nesting; deeper hierarchy is
+      encoded as additional dot-separated, ``\\``-escaped instance
+      identifiers in the same name. After the prefix, walk
+      dot-separated tokens until one starts with ``$`` — that's the
+      leaf cell. Everything before it is the instance path (with the
+      Yosys identifier-escape ``\\`` stripped from each token).
+    - ``$procdff$42`` / ``$add$<file>:<line>$N`` — top-level Yosys
+      auto-name. No instance prefix; the ``$<kind>$<file>:<line>``
+      shape embeds a source path so naïve ``split('.')`` would
+      tokenize on the dot inside ``.sv``. Returns ``()``.
     - ``u_b0.q`` — slang frontend. Plain dotted path; the last
       component is the leaf symbol, everything before it is the
       instance path. The top instance is *not* part of the name (the
@@ -587,18 +592,19 @@ def _instance_path(module: Module, cell_name: str | None) -> tuple[str, ...]:
     """
     if cell_name is None:
         return ()
-    parts: list[str] = []
-    remaining = cell_name
-    while remaining.startswith(_FLATTEN_PREFIX):
-        body = remaining[len(_FLATTEN_PREFIX) :]
-        dot = body.find(".")
-        if dot < 0:
-            # Malformed ``$flatten\<name>`` with no separator — bail
-            # conservatively rather than guessing.
-            return tuple(parts)
-        parts.append(body[:dot])
-        remaining = body[dot + 1 :]
-    if parts:
+    if cell_name.startswith(_FLATTEN_PREFIX):
+        body = cell_name[len(_FLATTEN_PREFIX) :]
+        # Leaf detection: the first ``$``-prefixed dot-separated token
+        # is the leaf cell (``$procdff$N``, ``$add$<file>:<line>$N``,
+        # ``$auto$proc_dff.cc:242:proc_dff$N``, etc.). Stop accumulating
+        # instance components when we hit it; the leaf may itself
+        # contain ``.`` inside an embedded source path which we
+        # deliberately don't try to tokenize further.
+        parts: list[str] = []
+        for tok in body.split("."):
+            if tok.startswith("$"):
+                break
+            parts.append(tok.lstrip("\\"))
         return tuple(parts)
     # No ``$flatten\`` prefix. Distinguish the slang dotted shape from
     # top-level Yosys auto-names. Yosys auto-names always begin with

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -518,9 +518,21 @@ def test_baseline_carryover_chains(tmp_path: Path) -> None:
         (None, ()),
         ("$procdff$42", ()),
         ("$logic_and$tests/foo.sv:55$13", ()),
-        # Yosys flatten — single instance, then nested.
+        # Yosys flatten — single-level instance.
         ("$flatten\\u_sync_ack.$procdff$84", ("u_sync_ack",)),
-        ("$flatten\\u_a.$flatten\\u_b.$dff$1", ("u_a", "u_b")),
+        # Yosys flatten — nested (multi-level). Yosys emits *one*
+        # ``$flatten\`` prefix per cell regardless of nesting depth;
+        # inner instances are encoded as dot-separated ``\``-escaped
+        # identifiers inside the same name.
+        ("$flatten\\u_hs_cmd.\\u_sync_ack.$procdff$893", ("u_hs_cmd", "u_sync_ack")),
+        # Yosys flatten — leaf cell with embedded source path inside
+        # its auto-name (``$add$<file>:<line>$N``). The path contains
+        # ``.sv`` which must NOT be tokenized as more hierarchy; the
+        # leaf-detection guard on ``$`` prefix protects this.
+        (
+            "$flatten\\u_afifo.$add$/abs/path/ip_async_fifo.sv:39$314",
+            ("u_afifo",),
+        ),
         # slang frontend dotted shape; the last component is the leaf
         # symbol, not an instance.
         ("u_b0.q", ("u_b0",)),

--- a/wiki/raw/articles/hierarchical-reporting.md
+++ b/wiki/raw/articles/hierarchical-reporting.md
@@ -144,12 +144,15 @@ def _instance_path(module: Module, cell_name: str | None) -> tuple[str, ...]:
 Resolution rules, in order:
 
 1. `cell_name is None` → `()`.
-2. The name begins with `$flatten\` (Yosys post-flatten user
-   instance) — strip the prefix, split on the **first** `.`
-   (everything after the first dot is the leaf cell name, not
-   further hierarchy under flatten); the part before is one
-   instance component. Repeat as long as the leaf still starts
-   with `$flatten\`.
+2. The name begins with `$flatten\` (Yosys post-flatten). Yosys
+   emits **exactly one** `$flatten\` prefix per cell regardless of
+   nesting depth — deeper hierarchy is encoded as additional
+   dot-separated, `\`-escaped instance identifiers inside the same
+   name (e.g. `$flatten\u_hs_cmd.\u_sync_ack.$procdff$893` for a
+   cell two levels deep). Strip the prefix, then walk dot-separated
+   tokens until one starts with `$` — that's the leaf cell name;
+   everything before it is the instance path. Strip the Yosys
+   identifier-escape `\` from each instance token.
 3. The name contains no `$flatten\` and no `$` before the first
    `.` — this is the slang shape. Split on `.`, return all
    components *except the last* (the last is the leaf symbol
@@ -159,13 +162,10 @@ Resolution rules, in order:
 
 The "no `$` before the first `.`" guard in rule 3 is what protects
 the `$logic_and$<file>:<line>$13` shape from being mistakenly split
-on the `.` inside the source path.
-
-Rule 2 covers nested-flatten cases (a child of a child) by
-iterating. In practice Yosys emits a single `$flatten\` regardless
-of nesting depth, but the loop is cheap and the explicit handling
-matches what `flatten -separator .` actually produces under unusual
-options.
+on the `.` inside the source path. The "stop at first `$`-prefixed
+token" guard in rule 2 does the same job for leaf cells inside
+flatten whose auto-name embeds a source path
+(`$add$/abs/path/file.sv:39$314`).
 
 ### 5.3 Where the resolver runs
 
@@ -216,8 +216,9 @@ resolver gains a frontend-aware branch — preference is the former
 | `cell_name=None` | `()` |
 | `"$procdff$42"` | `()` |
 | `"$logic_and$tests/foo.sv:55$13"` | `()` |
-| `"$flatten\u_sync_ack.$procdff$84"` | `("u_sync_ack",)` |
-| `"$flatten\u_a.$flatten\u_b.$dff$1"` (nested) | `("u_a", "u_b")` |
+| `"$flatten\u_sync_ack.$procdff$84"` (single level) | `("u_sync_ack",)` |
+| `"$flatten\u_hs_cmd.\u_sync_ack.$procdff$893"` (nested) | `("u_hs_cmd", "u_sync_ack")` |
+| `"$flatten\u_afifo.$add$/abs/path/ip_async_fifo.sv:39$314"` (leaf has embedded source path) | `("u_afifo",)` |
 | `"u_b0.q"` (slang) | `("u_b0",)` |
 | `"u_top.u_b0.q"` (hypothetical frontend that includes top) | `("u_top", "u_b0")` — accepted; documenting top-stripping is the frontend's responsibility |
 | `"u_b0.cell_name_with.dots_in_it"` (pathological) | `("u_b0", "cell_name_with")` — accepted as a known limitation; cell names with dots are not produced by either shipping frontend |


### PR DESCRIPTION
## Problem

The phase-1 resolver assumed Yosys emits nested-flatten cell names as `\$flatten\u_a.\$flatten\u_b.<leaf>`. Real Yosys output is different: `flatten` emits *exactly one* `\$flatten\\` prefix per cell regardless of nesting depth — deeper hierarchy is encoded as additional dot-separated, `\\`-escaped instance identifiers inside the same name.

Concrete example from `demo_tiny_alu_subsys` in the project template:

```
\$flatten\u_hs_cmd.\u_sync_ack.\$procdff\$893
```

This cell lives two levels deep (`u_hs_cmd/u_sync_ack`), but the previous resolver split on the first `.` and stopped, yielding just `("u_hs_cmd",)` and dropping the inner level. Result: the phase 4 text report bucketed all findings inside two different children of `u_hs_cmd` under the same `u_hs_cmd` header, hiding which `u_sync_*` child each finding came from.

## Fix

After stripping the single `\$flatten\\` prefix, walk dot-separated tokens until one starts with `\$`. That marks the leaf cell (`\$procdff\$N`, `\$add\$<file>:<line>\$N`, `\$auto\$proc_dff.cc:242:proc_dff\$N`, etc.). Everything before it is the instance path; the Yosys identifier-escape `\\` is stripped from each component.

The `\$`-prefixed-leaf guard also handles cells whose leaf auto-name embeds a source path with `.sv` inside — which a naïve full split-on-dot would otherwise tokenize as more hierarchy.

## Test plan

- [x] Updated `test_instance_path_resolver_table` to match real Yosys output (the previous nested case used a synthetic shape that never occurs). New cases cover:
  - `"\$flatten\u_hs_cmd.\u_sync_ack.\$procdff\$893"` → `("u_hs_cmd", "u_sync_ack")`
  - `"\$flatten\u_afifo.\$add\$/abs/path/ip_async_fifo.sv:39\$314"` → `("u_afifo",)` (embedded path in leaf)
- [x] Updated `wiki/raw/articles/hierarchical-reporting.md` §5.5 to document the actual Yosys encoding.
- [x] `uv run pytest -q` — 177 passed, 11 skipped
- [x] `uv run ruff check && uv run mypy` clean
- [x] Re-ran `rtl-buddy-cdc lint` on `demo_tiny_alu_subsys` at `--sync-depth 3`: findings now bucket correctly under `u_hs_cmd / u_sync_ack`, `u_hs_cmd / u_sync_req`, `u_hs_result / u_sync_ack`, `u_hs_result / u_sync_req`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)