### PR TITLE
docs: catch up README + CHANGELOG + wiki to post-#46 main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ src/rtl_buddy_cdc/
 ├── frontend.py        # Frontend enum + elaborate() factory (dispatches by name)
 ├── frontends/
 │   ├── yosys.py       # Yosys frontend: shell out + netlist.load
-│   └── slang.py       # slang frontend (in development, issue #5) — lazy pyslang import
+│   └── slang.py       # slang frontend (Yosys-parity in 0.2.0) — lazy pyslang import
 ├── netlist.py         # Yosys write_json loader (Module / Cell / Port / Netname)
 ├── flops.py           # FF cell zoo (FF_CELL_TYPES) + Flop dataclass
 ├── domain.py          # trace_clock_root + find_crossings (BFS) + Crossing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Hierarchical reporting** (#46). Every violation gains an
+  `instance_path: tuple[str, ...]` field resolved at the
+  `cli._analyze_and_report` boundary from the cell's name. The
+  resolver normalises both the Yosys-flatten shape
+  (`$flatten\u_a.\u_b.<leaf>` — one `$flatten\` prefix regardless of
+  depth) and the slang frontend's dotted shape (`u_b0.q`) into the
+  same `tuple[str, ...]`, with the top instance never appearing as
+  a component. The rule pack stays frontend-agnostic — no `reporter`
+  import in `rules.py`. Rendering changes are additive: text reporter
+  buckets findings under per-instance headers inside each rule group
+  (`[top]` / `u_block_a / u_sync`), collapsing back to the flat
+  layout when every finding lives at top; JSON output gains
+  `instance_path: list[str]` on every violation entry plus a
+  top-level `by_instance` aggregation of kept violations; SARIF
+  results gain a `logicalLocations` entry alongside the existing
+  `physicalLocation` when the path is non-empty. `JSON_CONTRACT` and
+  the `--baseline` match key are untouched — historical baselines
+  do not re-flag on first run after the bump. Phased landing in
+  #83 / #87 / #88 / #89; the resolver's nested-flatten handling
+  was corrected in #90 after a template-design demo surfaced that
+  Yosys emits exactly one `$flatten\` prefix per cell (not one per
+  level). Design captured in
+  `wiki/raw/articles/hierarchical-reporting.md` (#82).
+- **SARIF 2.1.0 schema validation in the test suite** (#80). The
+  OASIS errata01 SARIF schema is vendored at
+  `tests/schemas/sarif-2.1.0.json` (CI does not reach out to
+  schemastore.org or docs.oasis-open.org); `tests/test_sarif_schema.py`
+  validates `render_sarif` output across four render paths
+  (clean, with-violations, waiver-suppressed, baseline-carryover)
+  plus rule-shape variants. Caught schema drift the shape-assertion
+  tests miss — a typo'd field name, a wrong-type value, a missing
+  required sub-field on a code path no shape assertion happens to
+  read. `jsonschema` added to the `test` dep group; runtime deps
+  stay typer-only.
+- **slang frontend: `$dff` / `$adff` WIDTH and ARST_VALUE
+  parameters** (#40). Emitted flops carry the parameters Yosys
+  populates for the same shapes, so downstream consumers that key
+  off `cell.parameters["WIDTH"]` (or read the reset polarity from
+  `ARST_VALUE`) see consistent values across frontends.
 - **`--strict` flag** on `analyze` and `lint` (#29). Promotes every
   `warning`-severity violation (CDC-002, CDC-005 today) to `error`
   before reporters see it, so the text banner, JSON `severity`, and
@@ -83,6 +122,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   acceptance set — `bad_bus_crossing` (no gating at all) and
   `ip_cdc_handshake` (direct mux-on-D, no buffers) keep their
   pre-existing behaviour.
+
+### Fixed
+
+- **slang frontend: `always_comb if/else` both-arms emission** (#64).
+  An if/else where both arms wrote the same LHS dropped one arm
+  because the per-LHS `$mux` emission keyed on the canonical
+  variable and overwrote the alias before the second arm walked.
+  Fix defers the emission until both branches have been visited.
+- **slang frontend: nested element-select / 2-D port alias** (#69).
+  A 2-D port driven from an indexed select (`x[i][j]`) didn't
+  resolve through the alias chain because the resolver stopped at
+  the first element-select. Walk now recurses through nested
+  selects.
+- **resolver: Yosys multi-level flatten** (#90). The phase-1
+  resolver assumed Yosys emits `$flatten\u_a.$flatten\u_b.<leaf>`
+  for nested flatten. Real Yosys emits exactly *one* `$flatten\`
+  prefix per cell regardless of nesting depth, with deeper
+  hierarchy encoded as additional dot-separated `\`-escaped
+  instance identifiers. Symptom on the project-template
+  `demo_tiny_alu_subsys` design: findings inside
+  `u_hs_cmd/u_sync_ack` and `u_hs_result/u_sync_ack` bucketed under
+  just `u_hs_cmd` / `u_hs_result`, dropping the inner level. Fix
+  walks dot-separated tokens after the prefix until one starts with
+  `$` (that's the leaf), accumulating instance components (with the
+  Yosys identifier-escape `\` stripped) in between.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Each violation carries:
 
 `--format text|json|sarif` (default `text`), `--output PATH` to write to a file.
 
-- **Text** — human-readable summary suitable for terminals and CI logs.
-- **JSON** — structured, includes summary counts, full crossing/violation lists, and source locations. Stable schema for downstream consumers (rtl-buddy itself, custom dashboards).
-- **SARIF 2.1.0** — GitHub-Code-Scanning-compatible. `tool.driver.rules` populated for every rule that fired in the run; results carry `physicalLocation.region`. Suppressed (waived) findings are emitted with a SARIF `suppressions` field so the alert exists but doesn't fail the build.
+- **Text** — human-readable summary suitable for terminals and CI logs. Inside each rule group, violations are bucketed by hierarchical instance path (`[top]` / `u_block_a / u_sync`); the bucketing collapses to a flat layout when every finding in the rule group lives at the top instance.
+- **JSON** — structured, includes summary counts, full crossing/violation lists, and source locations. Stable schema for downstream consumers (rtl-buddy itself, custom dashboards). Every violation also carries an `instance_path: list[str]`; a top-level `by_instance` summary aggregates kept violations by path.
+- **SARIF 2.1.0** — GitHub-Code-Scanning-compatible. `tool.driver.rules` populated for every rule that fired in the run; results carry `physicalLocation.region` and, when the violation lives inside a child instance, a `logicalLocations` entry whose `fullyQualifiedName` is the dot-joined instance path. Suppressed (waived) findings are emitted with a SARIF `suppressions` field so the alert exists but doesn't fail the build.
 
 To inspect SARIF locally without uploading, the easiest paths are the [SARIF Viewer VS Code extension](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer) or the browser-based [Microsoft SARIF web viewer](https://microsoft.github.io/sarif-web-component/).
 
@@ -275,6 +275,7 @@ Implemented:
 - [x] First-class port→flop crossings: `find_crossings(module, port_clock=...)` emits port-sourced `Crossing` records for ports the SDC has typed via `set_input_delay`. CDC-001 and CDC-002 now fire on those (CDC-003 defers to CDC-006's existing port-comb walk; CDC-004 / CDC-005 skip them as flop-source-specific concepts).
 - [x] CDC-007 reset-tree grouping: violations are merged by `(src_flop, src_clk, dst_clk)` — a single async-reset source feeding many destinations produces one violation listing every destination, instead of N near-duplicates.
 - [x] **slang frontend** — elaborate SystemVerilog via [pyslang](https://pypi.org/project/pyslang/) as a peer to the Yosys frontend, swappable via `lint --frontend slang`. Covers flop inference (async-reset shape), combinational primitive lowering (binary / unary / conditional / element-select / range-select / concatenation / replication), `always_comb`, hierarchical instance flattening with port aliasing, SV attribute propagation, and Yosys-style `src` source-location attributes on every emitted cell (`file:line.col-line.col`, surfaced by the JSON / SARIF reporters). Reaches parity with the Yosys frontend on every SDC-equipped fixture in the regression suite. Opt-in via the `[slang]` install extra (`pip install 'rtl-buddy-cdc[slang]'`); the default install stays `typer`-only.
+- [x] **Hierarchical reporting** (#46) — every violation carries an `instance_path: tuple[str, ...]` derived from its Yosys-flatten or slang cell name, populated at the CLI boundary so the rule pack stays frontend-agnostic. Text reporter buckets findings under per-instance headers inside each rule group (`[top]` / `u_block_a / u_sync`), collapsing to the flat layout when every finding in the rule group lives at top. JSON output gains `instance_path: list[str]` on every violation / suppressed / baseline_carryover entry plus a top-level `by_instance` aggregation of kept violations. SARIF gains `logicalLocations` with `fullyQualifiedName` on each result whose instance path is non-empty, alongside the existing `physicalLocation`. All additive — `JSON_CONTRACT` keys and `--baseline` match key are untouched. See [`wiki/raw/articles/hierarchical-reporting.md`](wiki/raw/articles/hierarchical-reporting.md) for the design.
 
 Not yet:
 
@@ -282,7 +283,7 @@ Not yet:
 - [ ] CDC-007 refinements — recognise multi-source reset synchronizer trees and shared reset distribution networks
 - [ ] DFT / scan-mode awareness — exempt scan_en, scan_in, test-mode controls from CDC checks under a configurable scan-mode pragma
 - [ ] In-RTL pragma comments (`// rtl-buddy-cdc disable-rule …`, Spyglass-style block suppression) for inline waiving without an external file
-- [ ] Hierarchical reporting — group violations by module instance for large designs
+- [ ] Instance-scoped waivers (`waive CDC-001 inst:u_block_a/.*`) — natural follow-on to hierarchical reporting now that `instance_path` is on every violation
 - [ ] Pulse-width / fast-to-slow data-loss checks (CDC-009-class: data on src_clk shorter than one dst_clk period)
 - [ ] Glitch detection on data path through async muxes / clock-gate enables
 

--- a/wiki/concepts/cdc-data-model.md
+++ b/wiki/concepts/cdc-data-model.md
@@ -81,12 +81,22 @@ Key predicates:
 ```python
 @dataclass(frozen=True)
 class Violation:
-    rule_id: str           # "CDC-001" .. "CDC-008"
-    severity: str          # "error" | "warning" | "info"
-    message: str           # human-readable
-    crossing: Crossing | None    # None for non-data rules (CDC-007, CDC-008)
-    cell_name: str | None        # for source locations via cell.attributes["src"]
+    rule_id: str                   # "CDC-001" .. "CDC-008"
+    severity: str                  # "error" | "warning" | "info"
+    message: str                   # human-readable
+    crossing: Crossing | None      # None for non-data rules (CDC-007, CDC-008)
+    cell_name: str | None          # for source locations via cell.attributes["src"]
+    instance_path: tuple[str, ...] # hierarchy path the cell lives in; () = top
 ```
+
+`instance_path` is resolved from `cell_name` at the
+`cli._analyze_and_report` boundary by `reporter._instance_path` —
+the rule pack itself is frontend-agnostic and does not import the
+reporter. `()` is the safe default and is what `Violation`
+constructed directly (e.g. in tests) gets when the field is
+omitted. Reporters consume the field for per-instance grouping
+(text `[top]` / `u_a / u_b` headers, JSON `by_instance`, SARIF
+`logicalLocations`).
 
 ## AnalysisResult
 

--- a/wiki/concepts/waivers-and-reporting.md
+++ b/wiki/concepts/waivers-and-reporting.md
@@ -40,13 +40,15 @@ A hit on any of the three suppresses. First matching waiver wins (top-down).
 Three formatters share the same `AnalysisResult` input. Format selection is purely a CLI flag (`--format text|json|sarif`); the analyzer pipeline runs the same regardless.
 
 ### `render_text`
-Human-readable. Module summary, domain counts, crossing list, then violations grouped by severity. Designed for terminal and CI-log review.
+Human-readable. Module summary, domain counts, crossing list, then violations grouped by rule. Inside each rule group, findings are bucketed by `Violation.instance_path` under per-instance headers (`[top]` for top-level, `u_block_a / u_sync` for nested paths); the bucketing collapses to a flat layout when every finding in the group is at top, so output on flat IP-block fixtures is byte-identical to pre-hierarchical-reporting. Designed for terminal and CI-log review.
 
 ### `render_json`
 Full structured output with a stable schema. Used by `rb cdc` to extract violation counts and by custom dashboards. The downstream contract: `summary.violations` (int), `summary.suppressed` (int), `summary.crossings` (int). These three keys are pinned in code by `reporter.JSON_CONTRACT` and a paired test that fails on rename or retype — see `tests/test_reporter.py::test_json_contract_keys_present_and_typed`.
 
+Every violation / suppressed / baseline-carryover entry also carries `instance_path: list[str]` (always present, `[]` at top, never `null` or missing), and a top-level `by_instance` list aggregates *kept* violations by path with per-rule counts. The `--baseline` match key (`rule_id`, `cell_name`, `message`) is intentionally not extended with `instance_path` — historical baselines do not re-flag after the field was added.
+
 ### `render_sarif`
-SARIF 2.1.0, GitHub Code Scanning compatible. Populates `tool.driver.rules` for every rule that fired. Each result carries `physicalLocation.region` parsed from `cell.attributes["src"]`. Suppressed findings emit with a `suppressions` field so the alert exists but doesn't fail the build.
+SARIF 2.1.0, GitHub Code Scanning compatible. Populates `tool.driver.rules` for every rule that fired. Each result carries `physicalLocation.region` parsed from `cell.attributes["src"]`, and — when `instance_path` is non-empty — a `logicalLocations` entry with `fullyQualifiedName` (dot-joined path) and `kind: "module"`. Suppressed findings emit with a `suppressions` field so the alert exists but doesn't fail the build. Output is validated against the OASIS-published SARIF 2.1.0 schema by `tests/test_sarif_schema.py` across five render paths.
 
 ## The Reporter Contract
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -2,7 +2,7 @@
 
 > Content catalog. Every wiki page listed under its type with a one-line summary.
 > Read this first to find relevant pages for any query.
-> Last updated: 2026-05-14 | Total pages: 10
+> Last updated: 2026-05-16 | Total pages: 11
 
 ## Entities
 - [[rtl-buddy-cdc]] — Python-based CDC linter consuming a `Module` from a Yosys or slang frontend; goals, non-goals, module map, and rtl-buddy integration
@@ -17,6 +17,9 @@
 - [[elaboration-frontends]] — Yosys + slang frontends behind `--frontend`; shared `Module` contract; how to add a new frontend
 - [[sdc-parsing]] — `shlex`-based SDC parser design, supported commands, deliberate omissions, diagnostics policy
 - [[waivers-and-reporting]] — Waiver file format and matching, text/JSON/SARIF formatters, AnalysisResult contract
+
+## Articles (raw)
+- [hierarchical-reporting](raw/articles/hierarchical-reporting.md) — Design proposal for #46 (now shipped): `Violation.instance_path`, resolver, JSON `by_instance`, SARIF `logicalLocations`, text per-instance grouping
 
 ## Comparisons
 

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -328,17 +328,28 @@ declared async). See [§6](#6-sdc-parsing) for the parser scope.
 ```python
 @dataclass(frozen=True)
 class Violation:
-    rule_id: str           # "CDC-001" .. "CDC-008"
-    severity: str          # "error" | "warning" | "info"
-    message: str           # human-readable
-    crossing: Crossing | None    # the offending crossing (most rules)
-    cell_name: str | None        # most-responsible cell (for src locations)
+    rule_id: str                   # "CDC-001" .. "CDC-008"
+    severity: str                  # "error" | "warning" | "info"
+    message: str                   # human-readable
+    crossing: Crossing | None      # the offending crossing (most rules)
+    cell_name: str | None          # most-responsible cell (for src locations)
+    instance_path: tuple[str, ...] # hierarchy path the cell lives in; () = top
 ```
 
 `crossing` is `None` for rules that operate on a non-data shape
 (CDC-007 reset crossings, CDC-008 clock-as-data). `cell_name` lets
 structured reporters surface a `file:line:col` source location by
 looking at `cell.attributes["src"]`.
+
+`instance_path` is the dot-stripped, tuple-form hierarchy the
+offending cell lives in. Resolved from `cell_name` at the
+`cli._analyze_and_report` boundary (the rule pack stays
+frontend-agnostic — no `reporter` import in `rules.py`); see
+[`wiki/raw/articles/hierarchical-reporting.md`](hierarchical-reporting.md)
+for the resolver contract. `()` is the safe default (top instance)
+and is also what rules constructing a `Violation` directly get
+without specifying — the boundary post-pass overrides it for every
+finding that actually flows through `_analyze_and_report`.
 
 ### 4.7 The reporter contract
 
@@ -694,20 +705,53 @@ so re-baselining doesn't re-flag inherited findings.
 Three formatters share the same `AnalysisResult` input:
 
 - **`render_text`** — human-readable. Module summary, domain counts,
-  crossing list, then the violations grouped by severity. Designed
-  for terminal and CI-log review.
+  crossing list, then the violations grouped by rule. Inside each
+  rule group, findings are bucketed by `instance_path` (§4.6) under
+  per-instance headers (`[top]` for top-level findings,
+  `u_block_a / u_sync` for nested paths). The bucketing collapses
+  to a flat layout when every finding in the rule group lives at
+  top, so flat IP-block fixtures' output is byte-identical to
+  pre-hierarchical-reporting. Designed for terminal and CI-log
+  review.
 - **`render_json`** — full structured output. Stable schema. Used by
   `rb cdc` (rtl-buddy's wrapper) to extract violation counts, and by
-  any custom dashboard.
+  any custom dashboard. Every violation / suppressed /
+  baseline-carryover entry carries `instance_path: list[str]`
+  (always present, `[]` at top, never `null` or missing). A
+  top-level `by_instance` list aggregates kept violations by path,
+  sorted lexicographically (empty path first), with per-rule counts.
+  Suppressed and baseline-carried findings are excluded from
+  `by_instance` — the aggregation answers "what's actually failing
+  per block", not "what structural findings exist". The
+  `JSON_CONTRACT` keys (`summary.violations`, `summary.suppressed`,
+  `summary.crossings`) and the `--baseline` match key
+  (`rule_id`, `cell_name`, `message`) are unchanged by the
+  hierarchical additions, so historical baselines do not re-flag
+  after the bump.
 - **`render_sarif`** — SARIF 2.1.0, GitHub-Code-Scanning-compatible.
-  Populates `tool.driver.rules` for every rule that fired in the run.
-  Each result carries `physicalLocation.region` parsed from the
-  cell's `attributes["src"]`. Suppressed findings are emitted with a
+  Populates `tool.driver.rules` for every rule that fired in the
+  run. Each result carries `physicalLocation.region` parsed from the
+  cell's `attributes["src"]`, and — when the violation's
+  `instance_path` is non-empty — a `logicalLocations` entry with
+  `name` (leaf component), `fullyQualifiedName` (dot-joined path),
+  and `kind: "module"`. `logicalLocations` is omitted (not emitted
+  as an empty array) at top instance so the output diff stays
+  minimal on flat fixtures. Suppressed findings are emitted with a
   `suppressions` field so the alert exists but doesn't fail the
   build.
 
 Format selection is purely a CLI flag (`--format text|json|sarif`);
 the analyzer pipeline runs the same way regardless.
+
+The SARIF output is validated against the OASIS-published 2.1.0
+schema by `tests/test_sarif_schema.py`, vendored at
+`tests/schemas/sarif-2.1.0.json` so CI does not depend on
+schemastore reachability. Five render paths are covered (clean,
+with-violations, waiver-suppressed, baseline-carryover, plus a
+rule-shape variant pass). The schema test catches the structural
+mistakes the shape-assertion tests miss — typo'd field names,
+wrong-type values, required-sub-field omissions on code paths no
+shape assertion happens to read.
 
 ## 11. Extension points
 


### PR DESCRIPTION
Docs-only cleanup pass after the hierarchical-reporting work (#46) and the SARIF schema test (#80) landed without same-PR documentation updates. AGENTS.md's directive is to land contract / schema changes alongside the doc updates — this PR catches up the drift.

## Audit summary (from the Explore agent's pass)

| File | Drift fixed |
|---|---|
| `README.md` | "Hierarchical reporting" moved from Not yet → Implemented with the actual shipped behaviour; "Output formats" bullets now mention per-instance bucketing, `by_instance`, and `logicalLocations`; new Not-yet entry for instance-scoped waivers. |
| `CHANGELOG.md` | New `[Unreleased]` entries for #46 (4 phases + proposal doc), #80 (SARIF schema validation), #40 (slang `\$dff` / `\$adff` parameters), and Fixed entries for #64, #69, #90. |
| `AGENTS.md` | Dropped the stale "slang frontend (in development, issue #5)" — slang reached parity in 0.2.0. |
| `wiki/index.md` | Bumped Last updated / Total pages; added a cross-link to the new hierarchical-reporting proposal article under a new "Articles (raw)" section. |
| `wiki/raw/articles/rtl-buddy-cdc-architecture.md` | §4.6 Violation now includes `instance_path`; §10 Reporting now describes per-instance bucketing in text, `by_instance` in JSON, `logicalLocations` in SARIF, and the vendored SARIF schema validation. |
| `wiki/concepts/cdc-data-model.md` | `Violation` block + commentary updated to match. |
| `wiki/concepts/waivers-and-reporting.md` | render_text / render_json / render_sarif bullets rewritten; `--baseline` match-key non-extension pinned in prose. |

## What's NOT in this PR

- No version bump. The merged work in `[Unreleased]` is sized to be the next minor (0.3.0) when the maintainer cuts it; this PR doesn't claim that release.
- No code changes. `uv run pytest -q` (181 passed), `uv run ruff check`, `uv run mypy` all unchanged and green.
- The `elaboration-frontends` concept doc is unchanged — the audit confirmed it doesn't need adjustment for the #40 work, which is an internal slang detail rather than a user-visible contract change.

## Test plan

- [x] Audit performed by an Explore subagent against README / CHANGELOG / AGENTS.md / wiki/**.md
- [x] `uv run pytest -q` — 181 passed, 11 skipped
- [x] `uv run ruff check && uv run mypy` clean
- [ ] Reviewer pass on the `[Unreleased]` framing — particularly whether the hierarchical-reporting bullet reads at the right level of detail for downstream consumers reading the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)