### PR TITLE
fix(slang): case-statement completeness (const-fold + per-arm enable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **slang frontend: `case` statement completeness** (#84, #85).
+  Two paired holes in the `CaseStatement` lowering, both visible only
+  on parameter-driven or FSM-style RTL the procedural walker reaches
+  but previously mishandled:
+  - **Compile-time-constant case-expr folding** (#84). `case (MODE)`
+    with a parameter-bound `MODE` used to walk every arm, so dead
+    arms' RHS bits leaked into the deferred-emission mux tree and the
+    rule pack reported false-positive crossings through statically-
+    unreachable case items. Folds via `_const_int` (mirroring #72's
+    if/else fold) and walks only the live arm — or `defaultCase` when
+    no explicit match — so the resulting netlist matches what Yosys-
+    flatten + `opt_clean` would prune.
+  - **Per-arm enable inference for dynamic case-expr** (#85). Each
+    arm's body used to walk with no enable pushed, so writes
+    collapsed to a last-write-wins (or unconditional) value at drain
+    time and the gated-bus detector couldn't see arm-gated loads —
+    the standard FSM "load bus inside a case arm" shape. Each item's
+    enable is now the `$eq` of the case-expr with its match (chained
+    `$or` for multi-match items such as `2'd0, 2'd1:`); the default
+    arm's enable is `$not` of the OR of explicit-match equalities.
+    Pushed onto `_enable_stack` so the deferred-emission drain builds
+    a `$mux` tree gated by the arm-selection bits. Bails to walking
+    every arm unconditionally when the case-expr can't be lowered
+    (same conservative shape as the pre-PR behaviour, so any design
+    that previously hit the walker still does).
+  Casez / casex / `inside`-set match remain out of scope and bail via
+  `_bits_of_expression` returning None, same as today.
 - **slang frontend: `always_comb if/else` both-arms emission** (#64).
   An if/else where both arms wrote the same LHS dropped one arm
   because the per-LHS `$mux` emission keyed on the canonical

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -1091,22 +1091,9 @@ class _ModuleBuilder:
                     self._enable_stack.pop()
             return
         if kind == "CaseStatement":
-            # Each item is an ``ItemGroup`` with the match expressions
-            # on ``.expressions`` and the body on ``.stmt``. The
-            # default arm lives on ``.defaultCase`` (None if absent).
-            for item in getattr(statement, "items", []) or []:
-                self._emit_assignments_in(
-                    getattr(item, "stmt", None),
-                    clk_sym,
-                    reset_sym,
-                    reset_active_low,
-                    src_node,
-                )
-            default_arm = getattr(statement, "defaultCase", None)
-            if default_arm is not None:
-                self._emit_assignments_in(
-                    default_arm, clk_sym, reset_sym, reset_active_low, src_node
-                )
+            self._emit_case_statement(
+                statement, clk_sym, reset_sym, reset_active_low, src_node
+            )
             return
         if kind == "ForLoopStatement":
             self._emit_for_loop(
@@ -1123,6 +1110,146 @@ class _ModuleBuilder:
         # event, timing control inside always_ff — atypical) fall
         # through silently; the missing flops surface in analyze
         # output and we file the next gap when it bites a real design.
+
+    def _emit_case_statement(
+        self,
+        statement: Any,
+        clk_sym: Any,
+        reset_sym: Any | None,
+        reset_active_low: bool,
+        src_node: Any,
+    ) -> None:
+        """Walk a ``case`` body, emitting per-arm enables onto the
+        enable stack so the deferred-emission drain can build a mux
+        tree gated by each arm's ``case_expr == match`` equality.
+
+        Three paths, in order of decreasing precision:
+
+        - **Compile-time-constant case-expr (#84).** ``_const_int``
+          folds the case expression and (best-effort) each match
+          expression; walk only the matching arm — or the default
+          when none match — and return. Dead arms contribute no
+          fanin. Mirrors Yosys-flatten + opt_clean's pruning and the
+          if/else fold landed in #72.
+        - **Dynamic case-expr we can lower (#85).** Emit a ``$eq``
+          per match expression with the case-expr bits on ``A`` and
+          the match constant on ``B``. Items with multiple matches
+          OR the per-match equalities together. The default arm's
+          enable is ``$not($or(all explicit-match equalities))``.
+          Each arm walks with its enable pushed onto
+          ``_enable_stack``; the drain builds the corresponding
+          ``$mux`` tree.
+        - **Bail.** If the case-expr can't be lowered (kind we don't
+          model on the RHS yet), walk every arm with no enable —
+          same conservative policy as the pre-PR behaviour, so flops
+          still emit; we just lose the gating-mux shape on this
+          particular case.
+        """
+        case_expr = getattr(statement, "expr", None)
+        items = list(getattr(statement, "items", []) or [])
+        default_arm = getattr(statement, "defaultCase", None)
+
+        # #84: compile-time-constant case-expr — short-circuit to the
+        # matching arm. ``_const_int`` already folds parameter refs
+        # and arithmetic, so ``case (MODE)`` with a parameter-bound
+        # MODE resolves cleanly.
+        case_const = self._const_int(case_expr)
+        if case_const is not None:
+            live_arm: Any = None
+            for item in items:
+                for match_expr in getattr(item, "expressions", []) or []:
+                    match_const = self._const_int(match_expr)
+                    if match_const is not None and match_const == case_const:
+                        live_arm = getattr(item, "stmt", None)
+                        break
+                if live_arm is not None:
+                    break
+            if live_arm is None:
+                live_arm = default_arm
+            if live_arm is not None:
+                self._emit_assignments_in(
+                    live_arm, clk_sym, reset_sym, reset_active_low, src_node
+                )
+            return
+
+        # #85: dynamic case-expr — build per-item enables.
+        case_expr_bits = (
+            self._bits_of_expression(case_expr) if case_expr is not None else None
+        )
+        if case_expr_bits is None:
+            # Couldn't lower the case-expr. Conservative bail: walk
+            # every item with no enable so writes still surface as
+            # unconditional flops. Matches the pre-PR shape, so any
+            # design that hit the old path still does.
+            for item in items:
+                self._emit_assignments_in(
+                    getattr(item, "stmt", None),
+                    clk_sym,
+                    reset_sym,
+                    reset_active_low,
+                    src_node,
+                )
+            if default_arm is not None:
+                self._emit_assignments_in(
+                    default_arm, clk_sym, reset_sym, reset_active_low, src_node
+                )
+            return
+
+        explicit_match_bits: list[Bit] = []
+        for item in items:
+            item_match_bits: list[Bit] = []
+            for match_expr in getattr(item, "expressions", []) or []:
+                match_bits = self._bits_of_expression(match_expr)
+                if match_bits is None:
+                    continue
+                eq_y = self._alloc_anon_bits(1)
+                eq_name = self._fresh_cell_name("$eq")
+                self._cells[eq_name] = Cell(
+                    name=eq_name,
+                    type="$eq",
+                    connections={
+                        "A": case_expr_bits,
+                        "B": match_bits,
+                        "Y": eq_y,
+                    },
+                    parameters={},
+                    attributes={},
+                )
+                item_match_bits.append(eq_y[0])
+                explicit_match_bits.append(eq_y[0])
+            item_enable = self._or_bits(item_match_bits)
+            item_stmt = getattr(item, "stmt", None)
+            if item_enable is None:
+                # No lowerable match in this item (unmodelled pattern
+                # shape). Walk without enable so the body's flops still
+                # emit — same shape as the case-expr bail above.
+                self._emit_assignments_in(
+                    item_stmt, clk_sym, reset_sym, reset_active_low, src_node
+                )
+                continue
+            self._enable_stack.append(item_enable)
+            try:
+                self._emit_assignments_in(
+                    item_stmt, clk_sym, reset_sym, reset_active_low, src_node
+                )
+            finally:
+                self._enable_stack.pop()
+
+        if default_arm is not None:
+            no_match = self._or_bits(explicit_match_bits)
+            default_enable = self._lower_not(no_match) if no_match is not None else None
+            if default_enable is None:
+                self._emit_assignments_in(
+                    default_arm, clk_sym, reset_sym, reset_active_low, src_node
+                )
+            else:
+                self._enable_stack.append(default_enable)
+                try:
+                    self._emit_assignments_in(
+                        default_arm, clk_sym, reset_sym, reset_active_low, src_node
+                    )
+                finally:
+                    self._enable_stack.pop()
 
     def _emit_for_loop(
         self,
@@ -1322,6 +1449,35 @@ class _ModuleBuilder:
             attributes={},
         )
         return y[0]
+
+    def _or_bits(self, bits: list[Bit]) -> Bit | None:
+        """OR a list of single-bit ``Bit`` values into one bit via a
+        left-folded chain of ``$or`` cells. Returns ``None`` for an
+        empty list and the bit itself for a single-element list (no
+        cell emission). Used by the dynamic ``case`` lowering to OR
+        multi-match equalities within an item, and to OR explicit
+        matches for the default arm's negation."""
+        if not bits:
+            return None
+        if len(bits) == 1:
+            return bits[0]
+        result: Bit = bits[0]
+        for next_bit in bits[1:]:
+            or_y = self._alloc_anon_bits(1)
+            cell_name = self._fresh_cell_name("$or")
+            self._cells[cell_name] = Cell(
+                name=cell_name,
+                type="$or",
+                connections={
+                    "A": (result,),
+                    "B": (next_bit,),
+                    "Y": or_y,
+                },
+                parameters={},
+                attributes={},
+            )
+            result = or_y[0]
+        return result
 
     def _combine_enable_stack(self) -> Bit | None:
         """AND every entry on ``_enable_stack`` into a single bit, or

--- a/tests/test_slang_case_completeness.py
+++ b/tests/test_slang_case_completeness.py
@@ -1,0 +1,389 @@
+"""Coverage tests for slang-frontend ``case`` statement completeness.
+
+Issues:
+
+- rtl-buddy-cdc#84 — compile-time-constant case-expr must fold to walk
+  only the live arm. Today every item walks unconditionally, so dead
+  arms' fanin leaks into the deferred-emission mux tree and the rule
+  pack reports false-positive crossings through statically-unreachable
+  case items. Companion to #72's if/else fold.
+
+- rtl-buddy-cdc#85 — runtime case-arm bodies must walk with a
+  per-item enable (``case_expr == match``) pushed onto the enable
+  stack so writes accumulate with the right select bit. Today each
+  arm walks unconditionally, the drain collapses them to a
+  last-write-wins value, and the rule pack's ``_is_gated_bus_crossing``
+  can't fire on the standard FSM "load bus inside a case arm" shape.
+
+The tests below pin both contracts:
+
+- A constant case-expr produces flops whose D fanin contains only the
+  live arm's RHS bits — dead arms' ports do not appear anywhere
+  reachable from D.
+- A dynamic case-expr produces flops whose D is a ``$mux`` tree whose
+  ``S`` traces back through an ``$eq`` cell wired to the case
+  expression and the matching constant.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang case-completeness tests are gated on it",
+        allow_module_level=True,
+    )
+
+FLOP_TYPES = frozenset({"$dff", "$adff", "$dffe", "$adffe", "$sdff", "$sdffe"})
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _flops(module) -> list:
+    return [c for c in module.cells.values() if c.type in FLOP_TYPES]
+
+
+def _build_drivers(mod) -> dict:
+    drv = {}
+    for name, cell in mod.cells.items():
+        for port, bits in cell.connections.items():
+            if port in ("Q", "Y"):
+                for b in bits:
+                    if isinstance(b, int):
+                        drv[b] = (name, port)
+    return drv
+
+
+def _reachable_bits(mod, start_bit) -> set:
+    """All bits reachable backwards from ``start_bit`` through comb cells.
+
+    Used to assert that a port's bits appear in (or are absent from)
+    the fanin of a flop's D — the underlying question whenever we
+    want to know whether a particular RHS made it into the netlist.
+    """
+    drivers = _build_drivers(mod)
+    seen: set = set()
+    frontier = [start_bit]
+    walk_types = {
+        "$mux",
+        "$not",
+        "$and",
+        "$or",
+        "$xor",
+        "$eq",
+        "$ne",
+        "$add",
+        "$sub",
+    }
+    while frontier:
+        b = frontier.pop()
+        if b in seen or not isinstance(b, int):
+            continue
+        seen.add(b)
+        drv = drivers.get(b)
+        if drv is None:
+            continue
+        cell = mod.cells[drv[0]]
+        if cell.type not in walk_types:
+            continue
+        for port, bits in cell.connections.items():
+            if port in ("Q", "Y"):
+                continue
+            for x in bits:
+                frontier.append(x)
+    return seen
+
+
+# --- #84: compile-time-constant case-expr folds ---------------------------
+
+
+def test_const_case_walks_only_live_arm(tmp_path: Path) -> None:
+    """Parameter-driven ``case (MODE)`` with three arms — only the
+    matching arm's RHS should appear in the flop's D fanin. The dead
+    arms' input ports must not be reachable from D.
+
+    Mirrors the #84 repro: ``child #(.MODE(0))`` instantiations should
+    produce a netlist with no fanin from the ``MODE=1`` arm."""
+    src = """
+    module m #(parameter int MODE = 0) (
+        input  logic clk, rst_n,
+        input  logic d_a, d_b,
+        output logic q
+    );
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 1'b0;
+            else case (MODE)
+                0:       q <= d_a;
+                1:       q <= d_b;
+                default: q <= 1'b0;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1, f"expected one flop for q; got {len(flops)}"
+    d_bit = flops[0].connections["D"][0]
+    seen = _reachable_bits(mod, d_bit)
+
+    d_a_bit = mod.ports["d_a"].bits[0]
+    d_b_bit = mod.ports["d_b"].bits[0]
+    assert d_a_bit in seen, (
+        f"d_a (MODE=0 arm RHS) should reach the flop's D; reachable={sorted(seen)[:20]}"
+    )
+    assert d_b_bit not in seen, (
+        f"d_b (MODE=1 arm — dead) must not reach the flop's D; "
+        f"reachable={sorted(seen)[:20]}. Const-fold dropped — dead arms leak fanin."
+    )
+
+
+def test_const_case_default_when_no_match(tmp_path: Path) -> None:
+    """``case (3)`` with arms 0/1 and a default — the default must be
+    the only arm walked (no explicit match), and arms 0/1's RHSs must
+    not appear in the flop's D fanin."""
+    src = """
+    module m (
+        input  logic clk, rst_n,
+        input  logic d_a, d_b, d_def,
+        output logic q
+    );
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 1'b0;
+            else case (3)
+                0:       q <= d_a;
+                1:       q <= d_b;
+                default: q <= d_def;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    d_bit = flops[0].connections["D"][0]
+    seen = _reachable_bits(mod, d_bit)
+
+    d_def_bit = mod.ports["d_def"].bits[0]
+    d_a_bit = mod.ports["d_a"].bits[0]
+    d_b_bit = mod.ports["d_b"].bits[0]
+    assert d_def_bit in seen, "default arm's RHS should reach flop D"
+    assert d_a_bit not in seen, "arm 0 is dead (case-expr=3); RHS must not reach D"
+    assert d_b_bit not in seen, "arm 1 is dead (case-expr=3); RHS must not reach D"
+
+
+# --- #85: dynamic case-expr emits per-arm enable --------------------------
+
+
+def test_dynamic_case_emits_mux_with_eq_select(tmp_path: Path) -> None:
+    """The FSM-style "load bus inside a case arm" shape — the flop's D
+    must be a ``$mux`` whose ``S`` traces back through an ``$eq`` cell
+    wired to the case expression and the matching constant.
+
+    Without per-arm enable inference, the arm's write accumulates
+    unconditionally, the drain collapses to D = bus_in, and the rule
+    pack's gated-bus detector can't recognise that ``state`` gates
+    the load."""
+    src = """
+    module m (
+        input  logic       clk, rst_n,
+        input  logic [1:0] state,
+        input  logic [3:0] bus_in,
+        output logic [3:0] addr_q
+    );
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) addr_q <= 4'd0;
+            else case (state)
+                2'd0: addr_q <= bus_in;
+                default: ;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1, f"expected one flop for addr_q; got {len(flops)}"
+    flop = flops[0]
+    d_bits = flop.connections["D"]
+    drivers = _build_drivers(mod)
+    drv = drivers.get(d_bits[0])
+    assert drv is not None, "flop D has no driver"
+    drv_cell = mod.cells[drv[0]]
+    assert drv_cell.type == "$mux", (
+        f"expected $mux driving D for case-arm gated load; got {drv_cell.type}. "
+        "Without per-arm enable, the rule pack's gated-bus detector can't see "
+        "the state-gating on this FSM-style load."
+    )
+    # The mux's S must be driven (transitively) by an $eq cell —
+    # that's the ``state == 2'd0`` equality. Walk one or two levels
+    # back through $or (multi-match items chain ORs) to find it.
+    s_bit = drv_cell.connections["S"][0]
+    seen = _reachable_bits(mod, s_bit)
+    cell_types = set()
+    for b in seen:
+        d = drivers.get(b)
+        if d is not None:
+            cell_types.add(mod.cells[d[0]].type)
+    assert "$eq" in cell_types, (
+        f"mux S should resolve to an $eq cell (state == 2'd0); reachable cell "
+        f"types: {cell_types}"
+    )
+
+    # And the mux must wire the case expression's source (state) into
+    # the eq cell — bus_in must reach the data side (B) of the mux.
+    bus_bit = mod.ports["bus_in"].bits[0]
+    state_bit = mod.ports["state"].bits[0]
+    b_bits = drv_cell.connections["B"]
+    assert d_bits[0] != bus_bit, (
+        "without enable inference, D is wired straight to bus_in"
+    )
+    assert bus_bit in b_bits, f"$mux B should be bus_in; got {b_bits}"
+    assert state_bit in seen, (
+        "state should reach the mux S through the $eq cell — confirms the "
+        "case-expr is wired into the gating bit"
+    )
+
+
+def test_dynamic_case_default_negates_explicit_matches(tmp_path: Path) -> None:
+    """``default`` arm's enable must be the negation of the OR of the
+    explicit-match equalities. Two arms + default, with the default
+    writing a distinct LHS — the default's write should sit under a
+    ``$not`` cell wrapping the OR of the two ``$eq``s."""
+    src = """
+    module m (
+        input  logic       clk, rst_n,
+        input  logic [1:0] sel,
+        input  logic       d_def,
+        output logic       q_def
+    );
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q_def <= 1'b0;
+            else case (sel)
+                2'd0: ;
+                2'd1: ;
+                default: q_def <= d_def;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    flop = flops[0]
+    drivers = _build_drivers(mod)
+    drv = drivers.get(flop.connections["D"][0])
+    assert drv is not None, "no driver for q_def flop D"
+    drv_cell = mod.cells[drv[0]]
+    assert drv_cell.type == "$mux", (
+        f"expected $mux driving D for default-only conditional write; "
+        f"got {drv_cell.type}"
+    )
+    # Reachable cells from the mux S should include a $not cell —
+    # that's the negation of the OR of explicit-match equalities.
+    s_bit = drv_cell.connections["S"][0]
+    seen = _reachable_bits(mod, s_bit)
+    cell_types = set()
+    for b in seen:
+        d = drivers.get(b)
+        if d is not None:
+            cell_types.add(mod.cells[d[0]].type)
+    assert "$not" in cell_types, (
+        f"default-arm enable must include a $not (negate the OR of explicit "
+        f"matches); reachable types: {cell_types}"
+    )
+    assert "$eq" in cell_types, (
+        f"explicit-match equalities must be present beneath the $not; "
+        f"reachable types: {cell_types}"
+    )
+
+
+def test_dynamic_case_multi_match_item_ors_equalities(tmp_path: Path) -> None:
+    """``2'd0, 2'd1: addr_q <= bus_in;`` — the item's enable is the
+    OR of two equalities. The mux S should resolve to a ``$or`` of
+    two ``$eq`` cells."""
+    src = """
+    module m (
+        input  logic       clk, rst_n,
+        input  logic [1:0] sel,
+        input  logic [3:0] bus_in,
+        output logic [3:0] addr_q
+    );
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) addr_q <= 4'd0;
+            else case (sel)
+                2'd0, 2'd1: addr_q <= bus_in;
+                default: ;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    drivers = _build_drivers(mod)
+    drv = drivers.get(flops[0].connections["D"][0])
+    assert drv is not None
+    mux = mod.cells[drv[0]]
+    assert mux.type == "$mux"
+    s_drv = drivers.get(mux.connections["S"][0])
+    assert s_drv is not None, "mux S has no driver"
+    s_cell = mod.cells[s_drv[0]]
+    assert s_cell.type == "$or", (
+        f"multi-match item's enable should be an $or of equalities; "
+        f"got driver type {s_cell.type}"
+    )
+    # Each input of the $or should land on an $eq.
+    for port in ("A", "B"):
+        eq_drv = drivers.get(s_cell.connections[port][0])
+        assert eq_drv is not None
+        assert mod.cells[eq_drv[0]].type == "$eq", (
+            f"$or input {port} should be driven by $eq (per-match equality)"
+        )
+
+
+# --- regression: existing stmt-walker contract -----------------------------
+
+
+def test_existing_state_machine_still_emits_distinct_lvalues(tmp_path: Path) -> None:
+    """Regression guard for ``test_slang_stmt_walker.test_case_statement_emits_all_lvalues``:
+    distinct LHSs across arms must still each emit a flop. With per-arm
+    enable + deferred emission they now collapse to one flop per LHS
+    (state / a / b / c = 4 flops), where the previous walker emitted
+    one per *site*. ``≥ 4`` is the stable contract either way."""
+    src = """
+    module m (
+        input  logic clk, rst_n,
+        input  logic [1:0] sel,
+        output logic [1:0] state,
+        output logic a, b, c
+    );
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) begin
+                state <= 2'd0;
+                a <= 1'b0; b <= 1'b0; c <= 1'b0;
+            end else begin
+                case (sel)
+                    2'd0: begin state <= 2'd1; a <= 1'b1; end
+                    2'd1: begin state <= 2'd2; b <= 1'b1; end
+                    2'd2: begin state <= 2'd3; c <= 1'b1; end
+                    default: state <= 2'd0;
+                endcase
+            end
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) >= 4, (
+        f"expected ≥ 4 flops (one per distinct lvalue state/a/b/c); got {len(flops)}"
+    )


### PR DESCRIPTION
## Summary

Companion patches that close two paired holes in the slang frontend's
`CaseStatement` lowering, both visible only on parameter-driven or
FSM-style RTL the procedural walker reaches but previously
mishandled. Closes #84 and #85.

- **#84 — compile-time-constant case-expr folding.** `case (MODE)`
  with a parameter-bound `MODE` used to walk every arm, so dead arms'
  RHS bits leaked into the deferred-emission mux tree and the rule
  pack reported false-positive crossings through statically-
  unreachable case items. Folds via `_const_int` (mirroring #72's
  if/else fold) and walks only the live arm — or `defaultCase` when
  no explicit match — matching what Yosys-flatten + `opt_clean` would
  prune.

- **#85 — per-arm enable inference for dynamic case-expr.** Each
  arm's body used to walk with no enable pushed, so writes collapsed
  to a last-write-wins (or unconditional) value at drain time and
  the gated-bus detector couldn't see arm-gated loads — the standard
  FSM "load bus inside a case arm" shape. Each item's enable is now
  the `\$eq` of the case-expr with its match (chained `\$or` for
  multi-match items such as `2'd0, 2'd1:`); the default arm's enable
  is `\$not` of the OR of explicit-match equalities. Pushed onto
  `_enable_stack` so the deferred-emission drain builds the
  corresponding `\$mux` tree.

Both paths share a new `_emit_case_statement` entry point so the
existing `CaseStatement` branch in `_emit_assignments_in` stays a
one-line dispatch. A small `_or_bits` helper chains `\$or` cells the
same way `_combine_enable_stack` chains `\$and`.

Bails on unlowerable case-exprs to the pre-PR walk-every-arm-without-
enable shape, so designs that previously emitted any flops still do.
Casez / casex / `inside`-set patterns remain out of scope — they
bail via `_bits_of_expression` returning None on the unmodelled
match shape.

Closes #84
Closes #85

## Test plan

- [x] `uv run pytest -q` (275 passed, 2 skipped)
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] New `tests/test_slang_case_completeness.py` — six tests
  covering: const-case live-arm-only, const-case default
  fallthrough, dynamic-case `\$mux`-with-`\$eq`-select shape,
  default-arm `\$not`-of-OR enable, multi-match item `\$or`-of-`\$eq`
  enable, and a regression guard on `test_slang_stmt_walker`'s
  distinct-LHS contract.
- [x] Existing slang suite (`test_slang_stmt_walker.py`,
  `test_slang_const_cond_fold.py`, `test_slang_enable_inference.py`,
  `test_slang_if_else_both_arms.py`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)