### PR TITLE
fix(slang): sync-reset shape emits $sdff with SRST_VALUE / SRST_POLARITY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     that previously hit the walker still does).
   Casez / casex / `inside`-set match remain out of scope and bail via
   `_bits_of_expression` returning None, same as today.
+- **slang frontend: sync-reset shape emits `$sdff`** (#86). After
+  PR #74's sync-reset shape detection landed, sync-reset bodies —
+  ``always_ff @(posedge clk) if (!rst_n) <constants> else <data>`` —
+  walked only the data arm but still produced ``$adff`` cells wired
+  to the reset signal, with ``ARST_POLARITY`` defaulted to active-
+  high (the event list never carried an async-reset event to read
+  the polarity off). Two bugs in one cell: wrong cell type relative
+  to Yosys-flatten (which materialises ``$sdff`` here), and wrong
+  polarity even within the ``$adff`` shape. ``_classify_reset_check``
+  now returns ``(symbol, kind, active_low)`` and threads ``kind``
+  through ``_drain_proc_writes`` → ``_emit_flop_cell``, which
+  branches on it to emit ``$sdff`` with ``SRST`` / ``SRST_POLARITY``
+  / ``SRST_VALUE`` for the sync case. Sync polarity is derived from
+  the condition shape itself (``!rst_n`` / ``~rst_n`` → active-low,
+  bare ``rst`` → active-high) since the event list has nothing to
+  read there. Async and no-reset paths are unchanged; the rule pack
+  is cell-type-tolerant via ``flops.FF_CELL_TYPES`` so existing
+  detection isn't affected.
 - **slang frontend: `always_comb if/else` both-arms emission** (#64).
   An if/else where both arms wrote the same LHS dropped one arm
   because the per-LHS `$mux` emission keyed on the canonical

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -730,8 +730,9 @@ class _ModuleBuilder:
         self._proc_resets = {}
         block_reset_sym = reset_sym
         block_reset_active_low = reset_active_low
+        block_reset_kind: str | None = None
         try:
-            reset_check = self._classify_reset_check(inner, reset_sym)
+            reset_check = self._classify_reset_check(inner, reset_sym, reset_active_low)
             if reset_check is not None:
                 # Canonical reset-check shape — either async-reset
                 # ``always_ff @(posedge clk or negedge rst_n) begin
@@ -742,22 +743,24 @@ class _ModuleBuilder:
                 # In both, the reset arm's writes are absorbed into
                 # the flop's reset value rather than emitted as
                 # separate writes (we only walk ``ifFalse``, the data
-                # branch). For async reset, the reset signal comes
-                # from the event list; for sync reset we identified
-                # the shape heuristically (constant-only ifTrue arm
-                # — matches every synthesizable reset block).
+                # branch). For async reset, the reset signal and
+                # polarity come from the event list; for sync reset
+                # the shape is identified heuristically (constant-only
+                # ifTrue arm) and the polarity is read off the
+                # condition itself (``!rst_n`` vs bare ``rst``).
                 # Falling outside that envelope (a runtime ``if (cond)``
                 # at the top of a no-reset always_ff, where the ifTrue
                 # arm computes a real value) flows into the general
                 # walker below so both arms drain into one flop per
                 # LHS, not silently dropped.
-                block_reset_sym = reset_check
+                block_reset_sym, block_reset_kind, block_reset_active_low = reset_check
                 data_branch = inner.ifFalse
                 if data_branch is None:
                     return  # no else → no data assignment to model
                 # Capture reset-arm literal RHS values before walking
                 # the data arm — drain time looks these up to populate
-                # ``$adff``'s ``ARST_VALUE`` parameter (issue #40).
+                # ``$adff``'s ``ARST_VALUE`` / ``$sdff``'s ``SRST_VALUE``
+                # parameter (issues #40 / #86).
                 self._collect_reset_assignments(inner.ifTrue)
                 self._emit_assignments_in(
                     data_branch,
@@ -787,7 +790,11 @@ class _ModuleBuilder:
                     src_node=src_node,
                 )
             self._drain_proc_writes(
-                clk_sym, block_reset_sym, block_reset_active_low, src_node
+                clk_sym,
+                block_reset_sym,
+                block_reset_active_low,
+                src_node,
+                reset_kind=block_reset_kind,
             )
         finally:
             self._proc_writes = {}
@@ -885,41 +892,59 @@ class _ModuleBuilder:
         return None
 
     def _classify_reset_check(
-        self, inner: Any, reset_sym_from_event_list: Any | None
-    ) -> Any | None:
-        """Return the reset symbol for ``inner`` if it has the canonical
-        reset-check shape, else ``None`` so the caller walks the body
-        normally.
+        self,
+        inner: Any,
+        reset_sym_from_event_list: Any | None,
+        reset_active_low_from_event_list: bool,
+    ) -> tuple[Any, str, bool] | None:
+        """Classify ``inner`` against the canonical reset-check shape.
 
-        Two shapes match:
+        Returns ``(reset_sym, kind, active_low)`` when matched, else
+        ``None`` so the caller walks the body as a normal procedural
+        statement (no reset semantics).
 
-        - **Async reset.** The event list announced an async reset
-          (``or negedge rst_n``), so ``reset_sym_from_event_list`` is
-          non-None, and the body's outer if-condition gates on that
-          same symbol.
-        - **Sync reset.** No async reset event, but the body's outer
-          ``ConditionalStatement`` writes only constants in its
-          ``ifTrue`` arm (the standard ``if (!rst_n) <constants>
-          else <data>`` shape that synthesizers fold into ``$sdff``).
-          The constant-only check is what distinguishes a real reset
-          check from a runtime ``if (cond)`` at the top of a no-reset
-          always_ff body — the latter has a real RHS expression in
-          ifTrue and must be walked as a normal mux-tree.
+        ``kind`` is ``"async"`` when the event list carried a
+        dedicated reset event (``or negedge rst_n``); the body's
+        outer ``if`` then gates on that same symbol, and
+        ``active_low`` comes from the event-list edge.
+
+        ``kind`` is ``"sync"`` for the synthesizable-into-``$sdff``
+        shape — no reset in the event list, but the body's outer
+        ``ConditionalStatement`` writes only constants in its
+        ``ifTrue`` arm (matches ``if (!rst_n) <constants> else
+        <data>``). ``active_low`` is derived from the condition
+        shape: a ``UnaryExpression`` wrapping the symbol (``!rst_n``
+        / ``~rst_n``) marks active-low, a bare reference marks
+        active-high. The event list has no reset event to read in
+        this case, so the condition shape is the only source.
+
+        The constant-only check is what distinguishes a real reset
+        check from a runtime ``if (cond)`` at the top of a no-reset
+        always_ff body — the latter has a real RHS expression in
+        ifTrue and must be walked as a normal mux-tree.
         """
         if self._kind_name(inner) != "ConditionalStatement":
             return None
         conds = getattr(inner, "conditions", None)
         if not conds:
             return None
-        cond_sym = self._extract_condition_symbol(conds[0].expr)
+        cond_expr = conds[0].expr
+        cond_sym = self._extract_condition_symbol(cond_expr)
         if cond_sym is None:
             return None
         if reset_sym_from_event_list is not None:
-            return cond_sym if cond_sym is reset_sym_from_event_list else None
+            if cond_sym is not reset_sym_from_event_list:
+                return None
+            return cond_sym, "async", reset_active_low_from_event_list
         # Sync-reset heuristic: the ifTrue arm assigns only constants.
-        if self._is_constant_only_assignment_tree(inner.ifTrue):
-            return cond_sym
-        return None
+        if not self._is_constant_only_assignment_tree(inner.ifTrue):
+            return None
+        # Polarity from the condition shape — same convention as the
+        # async edge: ``!rst_n`` / ``~rst_n`` is active-low, bare
+        # ``rst`` is active-high. ``_extract_condition_symbol`` already
+        # accepts both shapes; mirror its branch here.
+        active_low = type(cond_expr).__name__ == "UnaryExpression"
+        return cond_sym, "sync", active_low
 
     def _is_constant_only_assignment_tree(self, stmt: Any) -> bool:
         """``True`` if every nonblocking assignment reachable from
@@ -1512,6 +1537,7 @@ class _ModuleBuilder:
         reset_sym: Any | None,
         reset_active_low: bool,
         src_node: Any,
+        reset_kind: str | None = None,
     ) -> None:
         """Emit one flop per accumulated LHS.
 
@@ -1531,6 +1557,11 @@ class _ModuleBuilder:
         ``D = mux(not_cond, mux(cond, Q, a), b)`` — equivalent to a
         Yosys ``$mux(cond, b, a)`` after ``opt_clean`` but with the
         explicit hold-feedback shape the detector recognises.
+
+        ``reset_kind`` (``"async"`` / ``"sync"`` / ``None``) controls
+        whether ``_emit_flop_cell`` materialises ``$adff``, ``$sdff``,
+        or plain ``$dff``. ``None`` is also accepted alongside
+        ``reset_sym=None`` for blocks with no reset.
         """
         for q_bits, writes in self._proc_writes.items():
             d_bits: tuple[Bit, ...] = q_bits  # initial Q-feedback
@@ -1548,6 +1579,7 @@ class _ModuleBuilder:
                 d_bits,
                 src_node,
                 reset_value=reset_value,
+                reset_kind=reset_kind,
             )
 
     def _build_hold_mux(
@@ -1581,8 +1613,19 @@ class _ModuleBuilder:
         d_bits: tuple[Bit, ...],
         src_node: Any,
         reset_value: int = 0,
+        reset_kind: str | None = None,
     ) -> None:
-        """Allocate a ``$dff`` / ``$adff`` cell with the given D and Q."""
+        """Allocate a ``$dff`` / ``$adff`` / ``$sdff`` cell with the
+        given D and Q.
+
+        ``reset_kind`` picks the reset shape when ``reset_sym`` is
+        non-None: ``"async"`` → ``$adff`` (ARST/ARST_POLARITY/
+        ARST_VALUE), ``"sync"`` → ``$sdff`` (SRST/SRST_POLARITY/
+        SRST_VALUE). ``None`` is treated as async to preserve the
+        pre-#86 behaviour for any caller that hasn't been updated;
+        ``_emit_procedural_block`` always passes an explicit kind
+        when there is a reset.
+        """
         connections: dict[str, tuple[Bit, ...]] = {
             "CLK": self._alloc_bits(clk_sym),
             "D": d_bits,
@@ -1590,13 +1633,18 @@ class _ModuleBuilder:
         }
         cell_type = "$dff"
         if reset_sym is not None:
-            connections["ARST"] = self._alloc_bits(reset_sym)
-            cell_type = "$adff"
+            if reset_kind == "sync":
+                connections["SRST"] = self._alloc_bits(reset_sym)
+                cell_type = "$sdff"
+            else:
+                # ``"async"`` (or unspecified — pre-#86 default).
+                connections["ARST"] = self._alloc_bits(reset_sym)
+                cell_type = "$adff"
         # CLK_POLARITY: slang lowering only emits posedge-clocked flops
         # today, so this is hard-coded to "1". Negedge support (issue
         # out-of-scope for #40) will need a polarity arg threaded down.
-        # WIDTH / ARST_POLARITY match Yosys' 32-bit binary-string param
-        # encoding; ARST_VALUE matches the flop's bit width so the
+        # WIDTH / *RST_POLARITY match Yosys' 32-bit binary-string param
+        # encoding; *RST_VALUE matches the flop's bit width so the
         # string length lines up with the D / Q nets.
         width = len(q_bits)
         parameters: dict[str, str] = {
@@ -1604,8 +1652,14 @@ class _ModuleBuilder:
             "WIDTH": _param_int32(width),
         }
         if reset_sym is not None:
-            parameters["ARST_POLARITY"] = _param_int32(0 if reset_active_low else 1)
-            parameters["ARST_VALUE"] = _param_bits(reset_value, width)
+            polarity = _param_int32(0 if reset_active_low else 1)
+            value_param = _param_bits(reset_value, width)
+            if cell_type == "$sdff":
+                parameters["SRST_POLARITY"] = polarity
+                parameters["SRST_VALUE"] = value_param
+            else:
+                parameters["ARST_POLARITY"] = polarity
+                parameters["ARST_VALUE"] = value_param
         attrs: dict[str, str] = {}
         src = self._src_attr(src_node) if src_node is not None else None
         if src is not None:

--- a/tests/test_slang_sync_reset_sdff.py
+++ b/tests/test_slang_sync_reset_sdff.py
@@ -1,0 +1,203 @@
+"""Coverage tests for slang-frontend sync-reset cell emission.
+
+Issue: rtl-buddy-cdc#86 — after PR #74 added sync-reset shape
+detection (``_classify_reset_check`` with the constant-only-ifTrue
+heuristic), sync-reset bodies — ``always_ff @(posedge clk) begin if
+(!rst_n) <constants> else <data> end`` — walk only the ifFalse arm
+but still emit ``$adff`` cells wired to the reset signal, with
+``ARST_POLARITY`` taken from the event list (which never saw the
+reset). That's two bugs:
+
+1. The cell type lies — synthesizers materialise ``$sdff`` for this
+   shape; emitting ``$adff`` makes the slang output diverge from
+   Yosys-flatten in cell-type-sensitive consumers (SARIF and JSON
+   round-trip cell types verbatim).
+2. The polarity comes from the event list which never carried an
+   async-reset event, so it defaults to "1" (active high) — wrong
+   for the canonical ``if (!rst_n)`` body.
+
+The tests pin the expected ``$sdff`` shape: ``SRST`` wired to the
+reset signal, ``SRST_POLARITY`` derived from the if-condition's
+shape (``!rst_n`` → "0", bare ``rst`` → "1"), and ``SRST_VALUE``
+matching the constant the reset arm assigned. Async and no-reset
+paths are guarded as regressions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang sync-reset tests are gated on it",
+        allow_module_level=True,
+    )
+
+FLOP_TYPES = frozenset({"$dff", "$adff", "$dffe", "$adffe", "$sdff", "$sdffe"})
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _flops(module) -> list:
+    return [c for c in module.cells.values() if c.type in FLOP_TYPES]
+
+
+# --- sync reset, active low ------------------------------------------------
+
+
+def test_sync_reset_active_low_zero_emits_sdff(tmp_path: Path) -> None:
+    """``always_ff @(posedge clk) if (!rst_n) q <= 1'b0; else q <= d;``
+    must emit a ``$sdff`` with the reset signal on ``SRST``,
+    ``SRST_POLARITY=0`` (active low), ``SRST_VALUE`` matching the
+    flop's width and all-zero, no ``ARST`` connection."""
+    src = """
+    module m (input logic clk, rst_n, d, output logic q);
+        always_ff @(posedge clk) begin
+            if (!rst_n) q <= 1'b0;
+            else        q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1, f"expected one flop; got {[c.type for c in flops]}"
+    flop = flops[0]
+    assert flop.type == "$sdff", (
+        f"expected $sdff for sync-reset shape; got {flop.type}. "
+        "$adff would be wrong (no event-list async-reset event); "
+        "$dff would drop the reset value entirely."
+    )
+    assert "SRST" in flop.connections, (
+        f"$sdff must wire the sync-reset signal onto SRST; got "
+        f"connections={list(flop.connections.keys())}"
+    )
+    rst_bit = mod.ports["rst_n"].bits[0]
+    assert flop.connections["SRST"][0] == rst_bit
+    assert "ARST" not in flop.connections, (
+        "sync-reset $sdff must not carry ARST; that would imply async semantics"
+    )
+    # SRST_POLARITY uses Yosys' 32-bit binary-string convention; "0"
+    # means active-low. SRST_VALUE width matches the flop's data width.
+    assert flop.parameters.get("SRST_POLARITY", "").endswith("0"), (
+        f"SRST_POLARITY should be active-low ('...0'); got "
+        f"{flop.parameters.get('SRST_POLARITY')!r}"
+    )
+    width = len(flop.connections["Q"])
+    srst_value = flop.parameters.get("SRST_VALUE")
+    assert srst_value is not None, "SRST_VALUE missing"
+    assert len(srst_value) == width, (
+        f"SRST_VALUE width ({len(srst_value)}) must match flop width ({width})"
+    )
+    assert set(srst_value) == {"0"}, (
+        f"reset value 0 → all-zero bits; got {srst_value!r}"
+    )
+
+
+def test_sync_reset_with_nonzero_value(tmp_path: Path) -> None:
+    """``if (!rst_n) q <= 4'hA;`` — ``SRST_VALUE`` should encode the
+    constant via :func:`_param_bits` (MSB-first binary, length matches
+    the flop width). 4'hA = decimal 10 = ``"1010"``. Mirrors the
+    convention ``$adff``'s ``ARST_VALUE`` uses on the async path."""
+    src = """
+    module m (input logic clk, rst_n, input logic [3:0] d, output logic [3:0] q);
+        always_ff @(posedge clk) begin
+            if (!rst_n) q <= 4'hA;
+            else        q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    flop = flops[0]
+    assert flop.type == "$sdff"
+    srst_value = flop.parameters.get("SRST_VALUE", "")
+    assert len(srst_value) == 4
+    assert srst_value == "1010", (
+        f"4'hA MSB-first → '1010'; got {srst_value!r}. If this fails, the "
+        "encoder convention may have shifted — cross-check $adff ARST_VALUE "
+        "on the async-reset path."
+    )
+
+
+def test_sync_reset_active_high(tmp_path: Path) -> None:
+    """Bare ``if (rst)`` condition → active-high reset. ``SRST_POLARITY``
+    should end in "1"."""
+    src = """
+    module m (input logic clk, rst, d, output logic q);
+        always_ff @(posedge clk) begin
+            if (rst) q <= 1'b0;
+            else     q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    flop = flops[0]
+    assert flop.type == "$sdff"
+    assert flop.parameters.get("SRST_POLARITY", "").endswith("1"), (
+        f"bare ``if (rst)`` → active-high; got SRST_POLARITY="
+        f"{flop.parameters.get('SRST_POLARITY')!r}"
+    )
+
+
+# --- regression: async reset still emits $adff ----------------------------
+
+
+def test_async_reset_still_adff(tmp_path: Path) -> None:
+    """The ``or negedge rst_n`` async-reset shape must still emit
+    ``$adff`` with the ARST family of parameters — adding sync-reset
+    support must not regress the canonical async path."""
+    src = """
+    module m (input logic clk, rst_n, d, output logic q);
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 1'b0;
+            else        q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    flop = flops[0]
+    assert flop.type == "$adff", (
+        f"async reset (event-list) should keep emitting $adff; got {flop.type}"
+    )
+    assert "ARST" in flop.connections
+    assert "SRST" not in flop.connections
+    assert "ARST_VALUE" in flop.parameters
+    assert "SRST_VALUE" not in flop.parameters
+
+
+# --- regression: no-reset $dff path unchanged -----------------------------
+
+
+def test_no_reset_still_dff(tmp_path: Path) -> None:
+    """``always_ff @(posedge clk) q <= d;`` (no reset at all) must
+    keep emitting a plain ``$dff`` — no SRST/ARST wiring, no reset
+    parameters."""
+    src = """
+    module m (input logic clk, d, output logic q);
+        always_ff @(posedge clk) q <= d;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1
+    flop = flops[0]
+    assert flop.type == "$dff"
+    assert "ARST" not in flop.connections
+    assert "SRST" not in flop.connections
+    assert "ARST_VALUE" not in flop.parameters
+    assert "SRST_VALUE" not in flop.parameters


### PR DESCRIPTION
## Summary

After PR #74's sync-reset shape detection landed, sync-reset bodies
— ``always_ff @(posedge clk) if (!rst_n) <constants> else <data>`` —
walked only the data arm but still produced ``\$adff`` cells wired
to the reset signal, with ``ARST_POLARITY`` defaulted to active-high
(the event list never carried an async-reset event to read the
polarity off). Two bugs in one cell: wrong cell type relative to
Yosys-flatten (which materialises ``\$sdff`` here), and wrong
polarity even within the ``\$adff`` shape.

``_classify_reset_check`` now returns ``(symbol, kind, active_low)``
and threads ``kind`` through ``_drain_proc_writes`` →
``_emit_flop_cell``, which branches on it to emit ``\$sdff`` with
``SRST`` / ``SRST_POLARITY`` / ``SRST_VALUE`` for the sync case.
Sync polarity is derived from the condition shape itself
(``!rst_n`` / ``~rst_n`` → active-low, bare ``rst`` → active-high)
since the event list has nothing to read there.

Async and no-reset paths are unchanged; the rule pack is cell-type-
tolerant via ``flops.FF_CELL_TYPES`` so existing detection isn't
affected. The win is alignment with Yosys-flatten on cell-type-
sensitive consumers — SARIF and JSON outputs round-trip cell types
verbatim, so emitting ``\$dff`` / ``\$adff`` for a sync-reset
register would be a real frontend-vs-yosys discrepancy visible
downstream.

Closes #86

## Test plan

- [x] `uv run pytest -q` (274 passed, 2 skipped)
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] New `tests/test_slang_sync_reset_sdff.py` — five tests
  covering: sync-reset active-low with zero value, sync-reset with
  nonzero (4'hA) ``SRST_VALUE``, sync-reset active-high (bare
  ``if (rst)``), async-reset still emits ``\$adff`` (regression),
  no-reset still emits plain ``\$dff`` (regression).
- [x] Existing slang suite (`test_slang_stmt_walker.py`,
  `test_slang_const_cond_fold.py`, `test_slang_enable_inference.py`,
  `test_slang_if_else_both_arms.py`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)