### PR TITLE
fix(slang): emit $dlatch cells for always_latch blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **slang frontend: emit `$dlatch` for `always_latch` blocks** (#39).
+  The frontend used to silently drop every ``always_latch`` block —
+  no cell emitted, so legitimate latches (the ICG enable-latch in
+  the ``clock_gating`` fixture and any other glitch-free integrated
+  clock gate) had no driver in the resulting netlist. The
+  procedural-block dispatch now recognises ``AlwaysLatch`` and lowers
+  the canonical single-arm ``if (en) lhs = rhs;`` shape to a
+  ``$dlatch`` with ``EN`` / ``D`` / ``Q`` connections and the
+  ``WIDTH`` / ``EN_POLARITY`` parameters Yosys writes for the same
+  shape. Inverted-enable conditions (``if (~clk)``) lower the
+  inversion through a ``$not`` cell driving ``EN`` rather than
+  folding into ``EN_POLARITY=0``, matching the slang frontend's
+  existing convention for conditional polarity. The latch type
+  intentionally stays outside ``flops.FF_CELL_TYPES`` — latches
+  don't bound clock domains and stay transparent to
+  ``find_crossings`` by design (out-of-scope per #39). Multi-arm /
+  case / explicit-else latch bodies and ``$adlatch`` (async-reset
+  latch) remain unmodelled and fall through silently, matching
+  Yosys's ``proc_dlatch`` envelope.
 - **slang frontend: `case` statement completeness** (#84, #85).
   Two paired holes in the `CaseStatement` lowering, both visible only
   on parameter-driven or FSM-style RTL the procedural walker reaches

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -702,8 +702,11 @@ class _ModuleBuilder:
         if kind_name == "AlwaysComb":
             self._emit_always_comb(block)
             return
+        if kind_name == "AlwaysLatch":
+            self._emit_always_latch(block)
+            return
         if kind_name != "AlwaysFF":
-            return  # initial / always_latch / final — not modelled
+            return  # initial / final — not modelled
         body = block.body
         # Expected shape: TimedStatement(timing=EventListControl, stmt=...)
         if self._kind_name(body) != "TimedStatement":
@@ -2293,6 +2296,115 @@ class _ModuleBuilder:
             attributes={},
         )
         return bits
+
+    # -- always_latch ---------------------------------------------------
+
+    def _emit_always_latch(self, block: Any) -> None:
+        """Walk an ``always_latch`` body and emit a ``$dlatch`` cell
+        for each ``if (en) lhs = rhs;`` single-arm shape.
+
+        Issue #39: pre-fix the slang frontend silently dropped every
+        ``always_latch`` block, so the ICG enable-latch in the
+        ``clock_gating`` fixture (and any other legitimate latch) had
+        no driver in the resulting netlist. The latch is intentionally
+        outside ``flops.FF_CELL_TYPES`` — latches don't bound clock
+        domains and stay transparent to ``find_crossings``; making
+        them visible is purely about netlist completeness so the rule
+        pack and any future latch-aware rule see them.
+
+        Only the single-arm ``if (cond) lhs = rhs;`` shape is
+        modelled (the canonical pattern Yosys's ``proc_dlatch``
+        infers). Multi-arm if/else, case, and explicit-`else` shapes
+        fall through silently — they don't synthesise to a clean
+        ``$dlatch`` either, so leaving them unmodelled mirrors the
+        Yosys frontend's behaviour. ``$adlatch`` (latch with async
+        reset) is explicitly out of scope per #39.
+        """
+        self._walk_latch_statement(block.body)
+
+    def _walk_latch_statement(self, stmt: Any) -> None:
+        if stmt is None:
+            return
+        kind = self._kind_name(stmt)
+        if kind == "BlockStatement":
+            self._walk_latch_statement(stmt.body)
+            return
+        if kind in {"StatementList", "ListStatement"}:
+            for s in getattr(stmt, "list", []) or []:
+                self._walk_latch_statement(s)
+            return
+        if kind != "ConditionalStatement":
+            return
+        en_bit = self._lower_condition_to_bit(getattr(stmt, "conditions", None))
+        if en_bit is None:
+            return
+        # Drill through the optional BlockStatement on the ifTrue arm.
+        arm = stmt.ifTrue
+        while arm is not None and self._kind_name(arm) == "BlockStatement":
+            arm = arm.body
+        if arm is None or self._kind_name(arm) != "ExpressionStatement":
+            return
+        expr = arm.expr
+        if type(expr).__name__ != "AssignmentExpression":
+            return
+        # Latch bodies should use blocking assigns (``=``); a
+        # nonblocking write here would be a SV style violation that
+        # we'd rather surface as "latch dropped" than silently model.
+        if getattr(expr, "isNonBlocking", False):
+            return
+        q_bits = self._lvalue_bits(expr.left)
+        if q_bits is None:
+            return
+        d_bits = self._bits_of_expression(expr.right)
+        if d_bits is None:
+            d_bits = self._unknown_driver(width=len(q_bits))
+        self._emit_dlatch_cell(en_bit, q_bits, d_bits, src_node=stmt)
+        # An explicit ``else`` would write a second value and break
+        # the single-arm-implicit-hold semantics — uncommon, and Yosys
+        # ``proc_dlatch`` doesn't infer a clean ``$dlatch`` for it
+        # either. Conservative skip; the analyzer surfaces the
+        # missing driver if it bites.
+
+    def _emit_dlatch_cell(
+        self,
+        en: Bit,
+        q_bits: tuple[Bit, ...],
+        d_bits: tuple[Bit, ...],
+        src_node: Any,
+    ) -> None:
+        """Allocate a ``$dlatch`` with the given enable / data / Q.
+
+        ``EN_POLARITY`` is hard-coded to active-high. Inverted-
+        enable shapes (``if (~en) lhs = rhs``) come through here with
+        ``en`` already routed through a ``$not`` cell by
+        ``_lower_condition_to_bit`` → ``_bits_of_expression``, which
+        mirrors how the slang frontend models conditional polarity
+        elsewhere. Folding the inversion into ``EN_POLARITY=0`` would
+        diverge from that convention; the rule pack doesn't read the
+        polarity parameter today, so the netlist shape is what
+        matters.
+        """
+        width = len(q_bits)
+        parameters: dict[str, str] = {
+            "EN_POLARITY": "1",
+            "WIDTH": _param_int32(width),
+        }
+        attrs: dict[str, str] = {}
+        src = self._src_attr(src_node) if src_node is not None else None
+        if src is not None:
+            attrs["src"] = src
+        name = self._fresh_cell_name("$dlatch")
+        self._cells[name] = Cell(
+            name=name,
+            type="$dlatch",
+            connections={
+                "EN": (en,),
+                "D": d_bits,
+                "Q": q_bits,
+            },
+            parameters=parameters,
+            attributes=attrs,
+        )
 
     # -- always_comb ----------------------------------------------------
 

--- a/tests/test_slang_always_latch.py
+++ b/tests/test_slang_always_latch.py
@@ -1,0 +1,220 @@
+"""Coverage tests for slang-frontend ``always_latch`` lowering.
+
+Issue: rtl-buddy-cdc#39 — the slang frontend silently dropped every
+``always_latch`` block (no cell emitted). Latches are sometimes
+legitimate (ICG enable-latch in the ``clock_gating`` fixture) and
+sometimes a CDC vector — either way the analyzer needs to see them.
+
+The tests pin the expected ``$dlatch`` shape: ``EN``/``D``/``Q``
+connections matching the body's ``if (en) lhs = rhs;`` single-branch
+implicit-hold pattern, plus the ``WIDTH`` / ``EN_POLARITY``
+parameters Yosys writes for the same shape. End-to-end coverage on
+the clock-gating fixture's ``en_latched`` shape confirms the slang
+frontend now produces a netlist with the ICG latch represented.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang always_latch tests are gated on it",
+        allow_module_level=True,
+    )
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _dlatches(module) -> list:
+    return [c for c in module.cells.values() if c.type == "$dlatch"]
+
+
+def _build_drivers(mod) -> dict:
+    drv = {}
+    for name, cell in mod.cells.items():
+        for port, bits in cell.connections.items():
+            if port in ("Q", "Y"):
+                for b in bits:
+                    if isinstance(b, int):
+                        drv[b] = (name, port)
+    return drv
+
+
+# --- synthetic single-arm latch ------------------------------------------
+
+
+def test_simple_always_latch_emits_dlatch(tmp_path: Path) -> None:
+    """``always_latch if (en) q = d;`` must emit a ``$dlatch`` with
+    ``EN=en``, ``D=d``, ``Q=q`` and ``EN_POLARITY`` active-high
+    (the condition is bare ``en``, no inversion to fold)."""
+    src = """
+    module m (input logic en, d, output logic q);
+        always_latch begin
+            if (en) q = d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    latches = _dlatches(mod)
+    assert len(latches) == 1, (
+        f"expected one $dlatch for q; got {len(latches)}. "
+        "Pre-fix the slang frontend silently dropped always_latch blocks."
+    )
+    latch = latches[0]
+    en_bit = mod.ports["en"].bits[0]
+    d_bit = mod.ports["d"].bits[0]
+    q_bit = mod.ports["q"].bits[0]
+    assert latch.connections["EN"] == (en_bit,), (
+        f"EN should wire to the ``en`` port; got {latch.connections['EN']}"
+    )
+    assert latch.connections["D"] == (d_bit,)
+    assert latch.connections["Q"] == (q_bit,)
+    assert latch.parameters.get("EN_POLARITY", "").endswith("1"), (
+        f"EN_POLARITY should be active-high for bare ``if (en)``; got "
+        f"{latch.parameters.get('EN_POLARITY')!r}"
+    )
+    width_param = latch.parameters.get("WIDTH")
+    assert width_param is not None, "WIDTH parameter missing"
+    assert len(width_param) == 32, "WIDTH should use the 32-bit binary encoding"
+    assert int(width_param, 2) == 1, f"WIDTH should be 1; got {int(width_param, 2)}"
+
+
+def test_always_latch_multibit_width(tmp_path: Path) -> None:
+    """Multi-bit LHS — ``WIDTH`` parameter must match the latch's
+    actual bit width (4) and D/Q tuples must each have 4 bits."""
+    src = """
+    module m (input logic en, input logic [3:0] d, output logic [3:0] q);
+        always_latch begin
+            if (en) q = d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    latches = _dlatches(mod)
+    assert len(latches) == 1
+    latch = latches[0]
+    assert len(latch.connections["D"]) == 4
+    assert len(latch.connections["Q"]) == 4
+    width_param = latch.parameters.get("WIDTH", "")
+    assert int(width_param, 2) == 4, f"WIDTH should be 4; got {int(width_param, 2)}"
+
+
+# --- clock_gating ICG shape ----------------------------------------------
+
+
+def test_clock_gating_icg_latch_shape(tmp_path: Path) -> None:
+    """The exact ``clock_gating`` ICG body: ``always_latch if (~clk)
+    en_latched = en;``. Must emit a ``$dlatch`` for ``en_latched``
+    whose D resolves to ``en`` and whose EN traces back to ``clk``
+    (through a ``$not`` for the inversion — the slang frontend models
+    the polarity in the upstream cell rather than as ``EN_POLARITY=0``,
+    matching how it already lowers conditional expressions
+    elsewhere)."""
+    src = """
+    module m (input logic clk, en, output logic en_latched);
+        always_latch begin
+            if (~clk) en_latched = en;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    latches = _dlatches(mod)
+    assert len(latches) == 1, f"expected one $dlatch for en_latched; got {len(latches)}"
+    latch = latches[0]
+    en_bit = mod.ports["en"].bits[0]
+    en_latched_bit = mod.ports["en_latched"].bits[0]
+    assert latch.connections["D"] == (en_bit,)
+    assert latch.connections["Q"] == (en_latched_bit,)
+    # EN should resolve back to clk through the $not cell.
+    drivers = _build_drivers(mod)
+    en_pin = latch.connections["EN"][0]
+    en_drv = drivers.get(en_pin)
+    assert en_drv is not None, "latch EN must have a driver (the $not on ~clk)"
+    not_cell = mod.cells[en_drv[0]]
+    assert not_cell.type == "$not", (
+        f"~clk should lower to a $not cell driving EN; got {not_cell.type}"
+    )
+    clk_bit = mod.ports["clk"].bits[0]
+    assert clk_bit in not_cell.connections.get("A", ()), (
+        "the $not driving EN should consume the clk port bit"
+    )
+
+
+# --- regression: latch is not a flop --------------------------------------
+
+
+def test_latch_not_classified_as_flop(tmp_path: Path) -> None:
+    """``$dlatch`` is intentionally outside ``flops.FF_CELL_TYPES`` —
+    latches don't bound clock domains and are transparent to
+    ``find_crossings``. Confirm the new cell type doesn't sneak into
+    the flop set (which would change rule-pack semantics)."""
+    from rtl_buddy_cdc import flops
+
+    assert "$dlatch" not in flops.FF_CELL_TYPES, (
+        "$dlatch must stay out of FF_CELL_TYPES — latches are transparent "
+        "to the domain-assignment BFS by design (issue #39 out-of-scope)."
+    )
+
+    src = """
+    module m (input logic en, d, output logic q);
+        always_latch begin
+            if (en) q = d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flop_list = flops.find_flops(mod)
+    assert flop_list == [], (
+        f"latch should not be discoverable as a flop; got {flop_list}"
+    )
+
+
+# --- end-to-end: clock_gating fixture under slang frontend ---------------
+
+
+def test_clock_gating_fixture_under_slang() -> None:
+    """End-to-end: elaborate the clock_gating fixture via slang (not
+    the pre-built Yosys JSON) and confirm assign_domains resolves the
+    flop's clock back to ``clk`` and the rule pack stays silent —
+    same acceptance the Yosys frontend already meets in
+    :mod:`tests.test_clock_gating`. Pre-fix the always_latch was
+    dropped so ``en_latched`` had no driver and the clock-network
+    resolution could diverge from the Yosys path."""
+    fixture = Path(__file__).parent / "fixtures" / "clock_gating" / "clock_gating.sv"
+    sdc = Path(__file__).parent / "fixtures" / "clock_gating" / "clock_gating.sdc"
+    if not fixture.exists() or not sdc.exists():
+        pytest.skip("clock_gating fixture missing")
+
+    from rtl_buddy_cdc import sdc as sdc_mod
+    from rtl_buddy_cdc.domain import assign_domains, find_crossings
+    from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+    mod = elaborate([fixture], "clock_gating", frontend=Frontend.slang)
+    # The ICG latch should now be present.
+    assert len(_dlatches(mod)) == 1, (
+        f"expected one $dlatch for the ICG enable; got "
+        f"{[c.type for c in mod.cells.values()]}"
+    )
+    spec = sdc_mod.parse_file(sdc)
+    domains = assign_domains(mod)
+    assert len(domains) == 1
+    assert domains[0].clock == "clk", (
+        f"flop's domain should resolve to clk through the ICG; got {domains[0].clock!r}"
+    )
+    crossings = find_crossings(mod)
+    violations = run_all_rules(mod, crossings, spec)
+    assert violations == [], (
+        f"clock_gating must stay silent under the slang frontend; got "
+        f"{[(v.rule_id, v.message) for v in violations]}"
+    )


### PR DESCRIPTION
## Summary

The slang frontend used to silently drop every ``always_latch`` block
— the procedural-block dispatch only recognised ``AlwaysComb`` and
``AlwaysFF``, with ``AlwaysLatch`` falling through under a "not
modelled" comment. Legitimate latches (the ICG enable-latch in the
``clock_gating`` fixture is the canonical case) had no driver in the
resulting netlist, so the clock-network walk saw fanin gaps and the
slang frontend's output diverged from Yosys-flatten on any design
using a latch.

Adds ``AlwaysLatch`` to the procedural-block dispatch and lowers the
canonical single-arm ``if (en) lhs = rhs;`` shape (the pattern
Yosys's ``proc_dlatch`` infers) to a ``\$dlatch`` with
``EN`` / ``D`` / ``Q`` connections and ``EN_POLARITY`` / ``WIDTH``
parameters. Inverted-enable shapes (``if (~clk)``) route the
inversion through a ``\$not`` cell on ``EN`` rather than folding
into ``EN_POLARITY=0``, matching how the slang frontend already
lowers conditional polarity elsewhere — the rule pack doesn't read
``EN_POLARITY``, so the netlist shape is what matters.

``\$dlatch`` stays outside ``flops.FF_CELL_TYPES`` — latches don't
bound clock domains and remain transparent to ``find_crossings`` by
design (out-of-scope per the issue). Multi-arm / case-arm /
explicit-else latch bodies and ``\$adlatch`` (async-reset latch) are
unmodelled and fall through silently, mirroring ``proc_dlatch``'s
envelope.

Closes #39

## Test plan

- [x] `uv run pytest -q` (285 passed, 2 skipped — 5 new tests in
  `tests/test_slang_always_latch.py` covering: synthetic
  single-arm latch (EN/D/Q/EN_POLARITY/WIDTH), multi-bit width,
  clock-gating ICG ``if (~clk) en_latched = en`` shape (\$not on
  EN), \$dlatch not in FF_CELL_TYPES regression guard, end-to-end
  clock_gating fixture under slang frontend stays silent).
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] Existing `tests/test_clock_gating.py` (Yosys-frontend path) —
  unchanged, still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)