### PR TITLE
test(fixtures): lock in untyped-input multi-domain gap (#97)

### DIFF
--- a/tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.json
+++ b/tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.json
@@ -1,0 +1,130 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_unconstrained_input_two_domains": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:16.1-27.10"
+      },
+      "ports": {
+        "clk_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "clk_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "in": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "q_a": {
+          "direction": "output",
+          "bits": [ 5 ]
+        },
+        "q_b": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$procdff$3": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:25.5-25.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 4 ],
+            "Q": [ 6 ]
+          }
+        },
+        "$procdff$4": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:24.5-24.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 4 ],
+            "Q": [ 5 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\q_a[0:0]": {
+          "hide_name": 1,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:24.5-24.42"
+          }
+        },
+        "$0\\q_b[0:0]": {
+          "hide_name": 1,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:25.5-25.42"
+          }
+        },
+        "clk_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:17.18-17.23"
+          }
+        },
+        "clk_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:18.18-18.23"
+          }
+        },
+        "in": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:19.18-19.20"
+          }
+        },
+        "q_a": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:20.18-20.21"
+          }
+        },
+        "q_b": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv:21.18-21.21"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sdc
+++ b/tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sdc
@@ -1,0 +1,6 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period 7.5  [get_ports clk_b]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
+# Intentionally NO `set_input_delay` on `in` — that's the SDC gap that
+# CDC-011 (issue #97) is meant to surface. Adding typing here would
+# invalidate the fixture for its purpose.

--- a/tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv
+++ b/tests/fixtures/bad_unconstrained_input_two_domains/bad_unconstrained_input_two_domains.sv
@@ -1,0 +1,27 @@
+// Regression-baseline fixture for issue #97 (CDC-011, pending).
+//
+// Scalar input `in` has no `set_input_delay -clock` typing in the SDC
+// and is captured by flops in two distinct clock domains (`clk_a`,
+// `clk_b`) declared asynchronous. With CDC-011 absent today,
+// find_crossings never walks the untyped port and the rule pack
+// reports clean — locking that current behaviour in so any later
+// change (CDC-011 landing, or a data-model change that retroactively
+// walks untyped ports) is forced to update the paired test.
+//
+// When CDC-011 lands, flip the test assertion to expect one
+// error-severity violation: `in` captured in {clk_a, clk_b}, which is
+// intrinsically wrong regardless of SDC opinion (a single port cannot
+// be synchronous to two distinct clocks).
+
+module bad_unconstrained_input_two_domains (
+    input  logic clk_a,
+    input  logic clk_b,
+    input  logic in,
+    output logic q_a,
+    output logic q_b
+);
+
+    always_ff @(posedge clk_a) q_a <= in;
+    always_ff @(posedge clk_b) q_b <= in;
+
+endmodule

--- a/tests/test_bad_unconstrained_input_two_domains.py
+++ b/tests/test_bad_unconstrained_input_two_domains.py
@@ -1,0 +1,82 @@
+"""Regression-baseline test for the untyped-input multi-domain gap.
+
+Issue: rtl-buddy-cdc#97 — when a top-level input port has no
+``set_input_delay -clock`` typing, ``find_crossings`` never iterates
+it (the port-walk at ``domain.py:413-481`` is keyed off
+``ClockSpec.port_clock``), so a crossing that physically lands the
+port in two distinct clock domains reports clean. This test pins that
+current behaviour so any later change (CDC-011 landing, or a
+data-model change that retroactively walks untyped ports) is forced
+to update the assertions here.
+
+When CDC-011 lands, flip the assertions to expect one error-severity
+violation naming ``in`` and both ``{clk_a, clk_b}`` destinations — a
+single port cannot be synchronous to two distinct clocks, so it is
+intrinsically wrong regardless of SDC opinion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_unconstrained_input_two_domains"
+JSON = FIX_DIR / "bad_unconstrained_input_two_domains.json"
+SDC = FIX_DIR / "bad_unconstrained_input_two_domains.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    return module, crossings, spec
+
+
+def test_sdc_has_no_input_delay(context) -> None:
+    """Sanity: confirm the SDC really omits ``set_input_delay`` for
+    ``in``. If a future SDC edit adds typing, this fixture stops
+    documenting the gap and should be re-thought."""
+    _module, _crossings, spec = context
+    assert "in" not in spec.port_clock, (
+        "Fixture invariant violated: `in` got a port_clock entry. "
+        "The SDC must leave `in` untyped to exercise the #97 gap."
+    )
+
+
+def test_untyped_port_emits_no_crossings(context) -> None:
+    """Today: ``in`` has no ``port_clock`` entry → no port-sourced
+    Crossing is emitted, even though it physically lands on flops in
+    two different clock domains. When CDC-011 lands, flip this to
+    assert >=1 port-sourced crossing whose ``src_port == 'in'``."""
+    _module, crossings, _spec = context
+    port_crossings = [c for c in crossings if c.src_port == "in"]
+    assert port_crossings == [], (
+        f"Untyped port `in` was walked unexpectedly: got "
+        f"{[(c.src_port, c.dst_clock) for c in port_crossings]}. "
+        "CDC-011 (#97) may now be implemented — flip this assertion "
+        "to expect crossings landing in both clk_a and clk_b."
+    )
+
+
+def test_rule_pack_reports_clean(context) -> None:
+    """Today: with no port-sourced crossings, the rule pack stays
+    silent on the untyped-port-to-two-domains shape. When CDC-011
+    lands, flip to expect one error-severity violation naming ``in``
+    and both destination clocks ``{clk_a, clk_b}``."""
+    module, crossings, spec = context
+    violations = run_all_rules(module, crossings, spec)
+    assert violations == [], (
+        f"Expected zero violations today; got "
+        f"{[(v.rule_id, v.severity, v.message) for v in violations]}. "
+        "CDC-011 (#97) may now fire — update the assertion to expect "
+        "one error-severity violation naming `in` and both clk_a/clk_b."
+    )


### PR DESCRIPTION
## Summary

Adds a regression-baseline fixture + test for the #97 coverage gap:
a scalar input port with no `set_input_delay -clock` typing is captured
by flops in two distinct clock domains, but `find_crossings` never
walks untyped ports (the port-walk at `domain.py:413-481` is gated on
`ClockSpec.port_clock`), so the rule pack reports clean.

The fixture **does not** implement CDC-011 — it pins the current
behaviour so any later change has to update the test rather than
silently flipping behaviour. The test docstring spells out which
assertions to flip and what severity to expect when CDC-011 lands
(error: a single port cannot be synchronous to two distinct clocks —
intrinsically wrong regardless of SDC opinion).

Tracks #97. Does not close it (that's the proposal + rule).

## What's in here

- `tests/fixtures/bad_unconstrained_input_two_domains/{.sv,.sdc,.json}` —
  two-flop, two-clock capture of an untyped scalar input; SDC has
  `create_clock` + async-group but no `set_input_delay`.
- `tests/test_bad_unconstrained_input_two_domains.py` — three
  assertions:
  - SDC invariant: `in` has no `port_clock` entry (catches accidental
    SDC edits that would invalidate the fixture).
  - `find_crossings` emits zero port-sourced crossings for `in` today.
  - Rule pack returns `violations == []`.

## Test plan

- [x] `uv run pytest -q tests/test_bad_unconstrained_input_two_domains.py`
  — 3 passed.
- [x] `uv run pytest -q` full suite — 288 passed, 2 skipped (unchanged
  from main).
- [x] `uv run ruff check` — all checks passed.
- [x] `uv run ruff format --check` — already formatted.
- [x] `uv run mypy` — no issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)