### PR TITLE
rules: add CDC-011 — unconstrained primary input captured by clocked logic (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CDC-011 — Unconstrained primary input captured by clocked logic**
+  (#97). Surfaces the SDC-discipline gap where a top-level input port
+  has no `set_input_delay -clock <name>` typing but physically reaches
+  a flop's `D` pin. Implementation seam: `sdc.UNCONSTRAINED_SENTINEL`
+  + `sdc.synthesize_unconstrained_inputs(spec, module)` assigns the
+  sentinel to every untyped input port after parse; the existing
+  port-walk in `find_crossings` then emits port-sourced crossings the
+  rule can consume. `check_cdc_011` consolidates by source port:
+  single destination domain → `warning` (typical fix is SDC typing);
+  two or more distinct destination domains → `error` (a single port
+  cannot be synchronous to multiple clocks). CDC-001 / CDC-002 /
+  CDC-006 each gain a sentinel skip so they don't double-fire with
+  fix-advice mismatch. Parser now also surfaces a `partial_warnings`
+  entry when `set_*_delay` names ports but omits `-clock` (previously
+  silent). Four paired fixtures land: `bad_unconstrained_input_two_domains`
+  (multi-domain scalar — error), `bad_unconstrained_input_derived_clock`
+  (AND-of-clocks — warning), `bad_unconstrained_input_bus_two_domains`
+  (multi-domain bus — error), `bad_unconstrained_input_muxed_clock`
+  (test-mode mux — warning), each with a `good_*_typed` counterpart.
+  Ten existing `bad_*` fixtures retro-typed (`set_input_delay -clock
+  src_clk` on their data inputs) so each fires only the rule it was
+  authored to test; `ip_cdc_handshake` and `good_2ff_sync` updated
+  the same way.
 - **Design proposal: CDC-010, glitches on the clock network from a
   wrong-domain control signal** (#48). New
   `docs/proposals/clock-network-glitch.md` covers the failure mode

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python-based open-source CDC (Clock Domain Crossing) linting tool for RTL design
 
 ## Status
 
-Usable on IP-block-sized designs. Eight rules implemented (CDC-001 through CDC-008), three output formats (text / JSON / SARIF), waiver-file suppression, `(* cdc_sync *)` / `(* cdc_gray *)` SV attributes for user-vetted synchronizers and gray-coded buses, structural gray-code recognition for CDC-004, and `rb cdc` / `rb cdc-regression` integration in rtl-buddy. Two elaboration frontends at parity on the regression fixture suite — Yosys (default) and slang (opt-in via the `[slang]` extra). Tested against paired *bad / good* RTL fixtures for each rule.
+Usable on IP-block-sized designs. Nine rules implemented (CDC-001 through CDC-008 plus CDC-011), three output formats (text / JSON / SARIF), waiver-file suppression, `(* cdc_sync *)` / `(* cdc_gray *)` SV attributes for user-vetted synchronizers and gray-coded buses, structural gray-code recognition for CDC-004, and `rb cdc` / `rb cdc-regression` integration in rtl-buddy. Two elaboration frontends at parity on the regression fixture suite — Yosys (default) and slang (opt-in via the `[slang]` extra). Tested against paired *bad / good* RTL fixtures for each rule.
 
 Known gaps and roadmap items are tracked at the end of this README.
 
@@ -136,6 +136,7 @@ If no SDC is supplied, the tool prints a structural summary and skips all rule c
 | **CDC-006** | error | Glitchy combinational source — synchronizer is fed by combinational logic with no registering flop, reaching unregistered top-level ports. Suppressed when `set_input_delay -clock <my_clk>` types the port into the destination flop's own clock domain (port is asserted same-domain). |
 | **CDC-007** | error | Async reset crossing — flop's `ARST` is driven by a flop in a different async clock domain, no reset synchronizer. Violations are grouped by the shared async source: one report per source listing every destination flop it feeds (the typical reset-distribution-tree shape). |
 | **CDC-008** | error | Clock signal used as data — clock-network bit reaches a non-CLK input (flop `D`/`ARST`, comb input, etc.); cells that themselves drive a flop CLK are exempted (legitimate ICG / clock muxes / dividers) |
+| **CDC-011** | warning / error | Unconstrained primary input captured by clocked logic — top-level input port has no `set_input_delay -clock <name>` typing yet physically reaches a flop's `D` pin. Fires as `warning` when the port lands in a single destination clock domain (the fix is usually adding SDC typing); escalates to `error` when the same port lands in **two or more** distinct domains (a single port cannot be synchronous to multiple clocks — intrinsically wrong regardless of SDC opinion). One violation per source port, listing every destination clock. |
 
 Each violation carries:
 - rule ID and severity
@@ -261,7 +262,7 @@ Implemented:
 - [x] SDC parser (`create_clock`, `set_clock_groups -asynchronous`)
 - [x] Clock-domain tracing through buffers / ICGs / clock muxes / dividers
 - [x] Flop→flop crossing detection (single-bit + bus, deduped per pair)
-- [x] CDC-001 through CDC-008
+- [x] CDC-001 through CDC-008, plus CDC-011 (unconstrained primary inputs)
 - [x] `lint` standalone wrapper (yosys → analyzer)
 - [x] Text / JSON / SARIF reporters with source locations
 - [x] Waiver file suppression

--- a/docs/proposals/unconstrained-input-domain.md
+++ b/docs/proposals/unconstrained-input-domain.md
@@ -1,0 +1,184 @@
+# CDC-011: unconstrained primary input captured by clocked logic
+
+**Tracking issue:** rtl-buddy-cdc#97
+**Status:** implemented (this proposal landed alongside the rule).
+**Severity:** `warning` (single destination domain) /
+`error` (multi-domain capture).
+
+## 1. Failure mode
+
+A top-level input port has no `set_input_delay -clock <name>` typing
+in the SDC, but physically reaches a flop's `D` pin somewhere in the
+design. Two distinct shapes share the same root cause:
+
+```systemverilog
+// SDC: create_clock clk_a/clk_b/async-group; NO set_input_delay on `in`
+module top (input clk_a, clk_b, in, output q_a, q_b);
+    always_ff @(posedge clk_a) q_a <= in;   // captures in clk_a
+    always_ff @(posedge clk_b) q_b <= in;   // captures in clk_b
+endmodule
+```
+
+Pre-implementation the rule pack was silent on every port that
+`ClockSpec.port_clock` didn't carry — the destination flops looked
+"unsourced" to `find_crossings` and never produced port-sourced
+crossings, so CDC-001 / CDC-004 / CDC-006 saw nothing to compare.
+
+The same gap covers `set_input_delay` invocations that name ports but
+omit `-clock` (the constraint has no STA semantics; real timers reject
+it). The parser previously dropped the constraint silently; CDC-011's
+sentinel synthesis sweeps these ports up the same way as truly-
+missing constraints, and `_handle_set_delay` now surfaces a
+`partial_warnings` entry naming the affected ports.
+
+## 2. Why not extend CDC-001?
+
+`find_crossings` already walks input ports forward and emits port-
+sourced `Crossing` records (`domain.py:413-481`). The rules already
+discriminate on `src_port` vs `src_flop`; the reporter already
+serialises `src_port` to JSON (`reporter.py:431`). Letting the
+sentinel synthesis feed those existing paths means CDC-001 / CDC-004
+would fire on every untyped input port that lands on any flop. Two
+problems with that:
+
+1. **Wrong primary fix advice.** CDC-001's remediation is "add a 2FF
+   synchronizer" — but for an unconstrained port the fix is almost
+   always "add `set_input_delay -clock <name>` to the SDC". A
+   user-facing message that pushes the wrong fix is worse than
+   silence.
+2. **Coupled severity / opt-out.** Tying the new shape to CDC-001
+   (`error`) means every project lacking full SDC discipline
+   immediately gets a flood of `error`-level findings on the same
+   rule that catches genuine missing synchronizers. Disabling
+   CDC-001 to silence the noise also disables the real-bug coverage.
+
+A dedicated rule with its own severity and message gives the user a
+clean opt-out and lets us escalate severity by shape.
+
+## 3. Implementation
+
+Five seams, all small:
+
+1. **`sdc.UNCONSTRAINED_SENTINEL = "<unconstrained>"`.** Angle
+   brackets are illegal in Verilog/SDC names, so the sentinel never
+   collides with a real clock identifier.
+2. **`sdc.synthesize_unconstrained_inputs(spec, module)`.** Iterates
+   every input port; assigns the sentinel to ``spec.port_clock``
+   whenever `clock_for_port` returns `None`. Returns the list of
+   ports it touched (verbose-mode reporting hook). Called from the
+   CLI right after `parse_file`.
+3. **`ClockSpec.are_async` sentinel short-circuit.** The sentinel is
+   treated as async to every real clock — we don't know what domain
+   the port lives in, so any flop capture is a potential cross.
+   Keeps sentinel-sourced crossings in the post-filter list so
+   CDC-011 sees them.
+4. **`check_cdc_011` with grouping post-pass.** Buckets crossings by
+   `src_port` (only sentinel-sourced ones). For each port:
+   - `len({c.dst_clock}) >= 2` → one `error` listing every
+     destination clock.
+   - Otherwise → one `warning` naming the single destination clock
+     and pointing the user at `set_input_delay`.
+5. **Sentinel guards in CDC-001 / CDC-002 / CDC-006.** Each rule
+   gains `if c.src_clock == UNCONSTRAINED_SENTINEL: continue` (or,
+   for CDC-006's port-fanin loop, a per-port skip). Prevents
+   double-fire with wrong fix advice.
+
+No changes to `find_crossings`, the reporter contract, or the
+existing `Crossing` schema — the sentinel rides through the existing
+`src_clock` field. JSON consumers that key on `src_port` keep
+working.
+
+## 4. Severity escalation
+
+The port-walk emits one `Crossing` per (port, destination flop), so a
+port landing on flops in two clock domains produces two crossings
+sharing `src_port` with different `dst_clock`s. Without consolidation
+the rule would fire N independent warnings and lose the stronger
+signal that the multi-domain case is intrinsically broken.
+
+Single-port grouping recovers it:
+
+| Shape | Severity | Reasoning |
+|---|---|---|
+| port → flop(s) in 1 dst domain | `warning` | "you forgot SDC typing" — methodology gap, easy fix at the constraint level |
+| port → flops in ≥ 2 dst domains | `error` | a single port cannot be synchronous to two clocks; no amount of SDC typing alone fixes this, the RTL also needs a synchronizer somewhere |
+
+## 5. Fixtures
+
+Four paired (`bad_` + `good_`):
+
+| Fixture | Destination clock | Severity |
+|---|---|---|
+| `unconstrained_input_two_domains` | `clk_a` + `clk_b` (two ff banks) | `error` |
+| `unconstrained_input_derived_clock` | `clk_a & clk_b & clk_c` (AND tree) | `warning` |
+| `unconstrained_input_bus_two_domains` | `clk_a` + `clk_b`, bus width 8 | `error` |
+| `unconstrained_input_muxed_clock` | `tm ? tclk : sclk` | `warning` |
+
+Each `good_*_typed` counterpart adds the appropriate `set_input_delay
+-clock <name>` line (and a 2FF synchronizer on the foreign-domain
+capture in the two-domains shapes) and is registered in
+`tests/test_good_fixtures.py::GOOD_FIXTURES`.
+
+The first fixture (`bad_unconstrained_input_two_domains`) was
+originally landed in PR #98 as a regression baseline pinning the
+*pre*-CDC-011 behaviour. Its test was flipped here to assert the new
+positive shape — the SV / SDC / JSON files were unchanged so the same
+disk-level artifact exercises both eras of behaviour.
+
+## 6. Existing-fixture audit
+
+Ten `bad_*` fixtures had untyped data inputs whose tests passed
+because the relevant crossing was internal-flop → internal-flop, not
+port → flop. With sentinel synthesis live, every one of them would
+now also fire CDC-011 on its data input and pollute tests scoped to a
+single rule. Each fixture's SDC gained a `set_input_delay -clock
+src_clk [get_ports <data_input>]` line so it fires only the rule the
+fixture was authored to test:
+
+- `bad_bus_crossing`, `bad_comb_before_sync`,
+  `bad_comb_before_sync_with_if`, `bad_comb_case_before_sync`,
+  `bad_comb_source` (virtual `vclk_ext` rather than `src_clk` — the
+  fixture has no source-clock flop, so a virtual clock + async group
+  is the right idiom),
+- `bad_reconvergent_sync`, `bad_reconvergent_with_recombine`,
+  `bad_reset_crossing` (`d_in` typed to `dst_clk` because it's
+  sampled by a dst-clock flop directly; `kill_req` typed to
+  `src_clk`),
+- `bad_reset_tree`, `bad_single_ff_sync`.
+
+Two additional fixtures got the same treatment: `good_2ff_sync`
+(`d_in` typed `src_clk`) and `ip_cdc_handshake` (`src_valid`,
+`src_data` typed `src_clk`).
+
+`good_input_delay_domain`, `good_port_typed_sync`,
+`bad_port_no_sync`, and `bad_input_delay_cross_domain` already
+exercised the SDC-discipline shape and didn't need changes.
+
+## 7. Out of scope
+
+- **Inferring source domain from heuristics** (port-name patterns,
+  toplevel-clock-port co-occurrence). The whole point of the
+  warning is that the analyzer can't guess — the SDC author has to
+  assert.
+- **`set_input_delay` without `-clock` and without ports** (delay-
+  only constraint files). The parser stays silent on this shape;
+  the warning is reserved for the more clearly-erroneous
+  ports-named-but-no-clock case.
+- **Custom sentinel name via CLI flag.** The sentinel is an internal
+  identifier; users only see the rendered violation message, which
+  doesn't reference it.
+
+## 8. Open questions
+
+- Should there be a way to *silence* CDC-011 on a per-port basis
+  short of adding `set_input_delay`? E.g. an SV attribute
+  `(* cdc_async_input *)` on the port declaration to mean "yes I
+  know, this is genuinely an async logic-level signal and I've
+  documented it elsewhere." Right now the only escape is the waiver
+  file. Deferred until a real user asks.
+- Whether `set_input_delay -clock <virtual_clock>` is the most
+  ergonomic answer to the warning, or whether
+  `set_false_path -from [get_ports <p>]` should also be accepted.
+  Currently only the former silences CDC-011; the latter is
+  STA-correct but loses the async-domain information the analyzer
+  needs.

--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -346,6 +346,11 @@ def _analyze_module_and_report(
     violations: list[Violation] = []
     if sdc_path is not None:
         spec = sdc_mod.parse_file(sdc_path)
+        # Synthesize sentinel entries for input ports the SDC didn't
+        # type via ``set_input_delay -clock``. Lets find_crossings's
+        # existing port-walk emit port-sourced crossings for them so
+        # CDC-011 can fire — see ``sdc.synthesize_unconstrained_inputs``.
+        sdc_mod.synthesize_unconstrained_inputs(spec, module)
         if spec.partial_warnings and fmt is OutputFormat.text:
             for w in spec.partial_warnings:
                 typer.echo(f"warning: {sdc_path}: {w}", err=True)

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -16,7 +16,7 @@ from typing import Callable
 from rtl_buddy_cdc.domain import Crossing, assign_domains
 from rtl_buddy_cdc.flops import FF_CELL_TYPES, Flop, find_flops
 from rtl_buddy_cdc.netlist import Bit, Module
-from rtl_buddy_cdc.sdc import ClockSpec
+from rtl_buddy_cdc.sdc import UNCONSTRAINED_SENTINEL, ClockSpec
 
 
 @dataclass(frozen=True)
@@ -553,6 +553,8 @@ def check_cdc_001(
     for c in crossings:
         if c.width != 1:
             continue
+        if c.src_clock == UNCONSTRAINED_SENTINEL:
+            continue  # CDC-011 owns crossings from unconstrained ports
         if c.dst_flop.cell.name in ctx.user_syncs:
             continue  # user vouches for the synchronizer shape
         depth = _sync_chain_depth(
@@ -610,6 +612,8 @@ def check_cdc_002(
     for c in crossings:
         if c.width != 1:
             continue
+        if c.src_clock == UNCONSTRAINED_SENTINEL:
+            continue  # CDC-011 owns crossings from unconstrained ports
         if c.dst_flop.cell.name in ctx.user_syncs:
             continue
         depth = _sync_chain_depth(
@@ -1194,6 +1198,12 @@ def check_cdc_006(
             port_clk: str | None = None
             if clock_spec is not None:
                 port_clk = clock_spec.port_clock.get(p)
+            # Unconstrained ports belong to CDC-011, not CDC-006. The
+            # right fix for them is SDC typing, not "register the
+            # source"; firing CDC-006 here would push the wrong
+            # remediation.
+            if port_clk == UNCONSTRAINED_SENTINEL:
+                continue
             if (
                 port_clk is not None
                 and my_clock_name is not None
@@ -1446,6 +1456,93 @@ def check_cdc_007(
     return violations
 
 
+def check_cdc_011(
+    module: Module,  # noqa: ARG001
+    crossings: list[Crossing],
+    clock_spec: ClockSpec | None = None,  # noqa: ARG001
+    *,
+    ctx: _RuleContext | None = None,  # noqa: ARG001
+) -> list[Violation]:
+    """CDC-011 — Unconstrained primary input captured by clocked logic.
+
+    Fires on top-level input ports that the SDC didn't type via
+    ``set_input_delay -clock <name>`` but that physically reach a
+    flop's ``D`` pin. ``sdc.synthesize_unconstrained_inputs`` assigns
+    :data:`UNCONSTRAINED_SENTINEL` as ``port_clock`` for any such
+    port; :func:`find_crossings` then walks them and emits
+    port-sourced crossings whose ``src_clock`` carries the sentinel.
+
+    Severity escalation by shape:
+
+    * **error** when one port lands on flops in ``>=2`` distinct
+      destination clock domains. A single port cannot be synchronous
+      to two clocks at once, so this is intrinsically wrong
+      regardless of SDC opinion — typing it on either side won't
+      silence the rule, only fixing the RTL (or adding a synchronizer
+      on the foreign side) will.
+    * **warning** when the port lands in a single destination domain.
+      The usual fix is adding ``set_input_delay -clock <name>`` to
+      assert which domain the port belongs to (and adding a 2FF
+      synchronizer if it's a different domain than declared). This is
+      a methodology gap, not a hard bug.
+
+    One :class:`Violation` per source port — the message lists every
+    distinct destination clock, so a port fanning out across many
+    flops in two domains collapses to a single error rather than a
+    fixture-per-flop flood.
+    """
+    by_port: dict[str, list[Crossing]] = defaultdict(list)
+    for c in crossings:
+        if c.src_port is None:
+            continue
+        if c.src_clock != UNCONSTRAINED_SENTINEL:
+            continue
+        by_port[c.src_port].append(c)
+
+    violations: list[Violation] = []
+    for port in sorted(by_port):
+        cs = by_port[port]
+        dst_clocks = sorted({c.dst_clock for c in cs})
+        # Representative cell for source-location reporting: pick the
+        # alphabetically-first destination flop so the reporter has
+        # something concrete to anchor on.
+        repr_cell = sorted(c.dst_flop.cell.name for c in cs)[0]
+        if len(dst_clocks) > 1:
+            violations.append(
+                Violation(
+                    rule_id="CDC-011",
+                    severity="error",
+                    message=(
+                        f"unconstrained primary input {port!r} is "
+                        f"captured in multiple clock domains "
+                        f"({dst_clocks}); a single port cannot be "
+                        f"synchronous to more than one clock — add "
+                        f"set_input_delay -clock <name> and a "
+                        f"synchronizer on at least one destination"
+                    ),
+                    cell_name=repr_cell,
+                )
+            )
+        else:
+            (dst_clk,) = dst_clocks
+            violations.append(
+                Violation(
+                    rule_id="CDC-011",
+                    severity="warning",
+                    message=(
+                        f"unconstrained primary input {port!r} has no "
+                        f"set_input_delay -clock typing in the SDC "
+                        f"but is captured in domain {dst_clk!r}; add "
+                        f"set_input_delay -clock {dst_clk} "
+                        f"[get_ports {port}] (or declare the port's "
+                        f"true source clock and add a synchronizer)"
+                    ),
+                    cell_name=repr_cell,
+                )
+            )
+    return violations
+
+
 RULES: dict[str, RuleFn] = {
     "CDC-001": check_cdc_001,
     "CDC-002": check_cdc_002,
@@ -1455,6 +1552,7 @@ RULES: dict[str, RuleFn] = {
     "CDC-006": check_cdc_006,
     "CDC-007": check_cdc_007,
     "CDC-008": check_cdc_008,
+    "CDC-011": check_cdc_011,
 }
 
 

--- a/src/rtl_buddy_cdc/sdc.py
+++ b/src/rtl_buddy_cdc/sdc.py
@@ -642,11 +642,23 @@ def _handle_set_delay(spec: ClockSpec, args: list[str]) -> None:
 
     if saw_filter:
         spec.partial_warnings.append("set_*_delay: ignored unsupported -filter clause")
-    if clock is None or not ports:
-        # Delay without a -clock or without a port target — nothing
-        # actionable for CDC. Don't warn: this often comes from
-        # delay-only constraint files where users genuinely don't
-        # care about port→clock mapping.
+    if not ports:
+        # No port target — delay-only constraint or defaults-applies-
+        # to-all-ports usage. Nothing actionable for CDC; stay silent.
+        return
+    if clock is None:
+        # Port target named but no -clock anchor. set_input_delay /
+        # set_output_delay are intrinsically clock-relative (the delay
+        # is a fraction of a clock period), so without -clock the
+        # constraint has no STA semantics and most real timers reject
+        # it. Common misuse: users reach for set_input_delay when they
+        # meant set_input_transition (slew) or set_load. Warn so the
+        # mistake doesn't silently produce an untyped port.
+        spec.partial_warnings.append(
+            f"set_*_delay on {sorted(ports)} has no -clock anchor; "
+            "the constraint is ignored. Add -clock <name>, or use "
+            "set_input_transition / set_load for slew or load defaults."
+        )
         return
     for p in ports:
         spec.port_clock[p] = clock

--- a/src/rtl_buddy_cdc/sdc.py
+++ b/src/rtl_buddy_cdc/sdc.py
@@ -33,8 +33,23 @@ import logging
 import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rtl_buddy_cdc.netlist import Module
 
 logger = logging.getLogger(__name__)
+
+# Synthetic clock name assigned to input ports that have no
+# ``set_input_delay -clock`` typing. Picked to be obviously not a real
+# clock identifier (angle brackets are illegal in Verilog/SDC names) so
+# it never collides with anything the user could have written. CDC-011
+# owns crossings carrying this as ``src_clock``; CDC-001 / CDC-002 /
+# CDC-006 skip them to avoid double-firing. ``ClockSpec.are_async``
+# treats the sentinel as async to every real clock — the whole point
+# is that we *don't know* what domain the port lives in, so any flop
+# capture is a potential cross.
+UNCONSTRAINED_SENTINEL = "<unconstrained>"
 
 
 @dataclass(frozen=True)
@@ -144,6 +159,14 @@ class ClockSpec:
         """
         if a == b:
             return False
+        # Sentinel port-clock (synthesised for input ports without
+        # ``set_input_delay -clock`` typing) is treated as async to
+        # every real clock — we don't know the port's domain, so any
+        # flop capture is a potential cross. CDC-011 owns the rule
+        # that fires; the async flag here just keeps the crossing in
+        # the filtered list so CDC-011 sees it.
+        if a == UNCONSTRAINED_SENTINEL or b == UNCONSTRAINED_SENTINEL:
+            return True
         # Step 1: explicit override on unresolved names.
         for groups in self.async_groups:
             ga = next((g for g in groups if a in g), None)
@@ -224,6 +247,37 @@ def parse(text: str) -> ClockSpec:
 
 def parse_file(path: str | Path) -> ClockSpec:
     return parse(Path(path).read_text())
+
+
+def synthesize_unconstrained_inputs(spec: ClockSpec, module: "Module") -> list[str]:
+    """Assign :data:`UNCONSTRAINED_SENTINEL` to input ports not already
+    typed by the SDC.
+
+    Mutates ``spec.port_clock`` in place and returns the list of port
+    names that received the sentinel (caller may want to surface this
+    in verbose output). A port is considered untyped if
+    :meth:`ClockSpec.clock_for_port` returns ``None`` — that covers
+    both "no ``set_input_delay``" and "``set_input_delay`` without
+    ``-clock``" (the parser warning at ``_handle_set_delay`` already
+    surfaces the latter as a misuse).
+
+    Called by the CLI after SDC parse and netlist load, before
+    :func:`rtl_buddy_cdc.domain.find_crossings`. The sentinel
+    propagates through the port-walk as the crossing's ``src_clock``;
+    :func:`ClockSpec.are_async` treats it as async to every real
+    clock, so the resulting port-sourced crossings reach the rule
+    pack. CDC-011 owns them; CDC-001 / CDC-002 / CDC-006 skip them to
+    avoid double-firing with a fix-advice mismatch.
+    """
+    sentinel_ports: list[str] = []
+    for port in module.ports.values():
+        if port.direction != "input":
+            continue
+        if spec.clock_for_port(port.name) is not None:
+            continue
+        spec.port_clock[port.name] = UNCONSTRAINED_SENTINEL
+        sentinel_ports.append(port.name)
+    return sentinel_ports
 
 
 # ---- internals --------------------------------------------------------------

--- a/tests/fixtures/bad_bus_crossing/bad_bus_crossing.sdc
+++ b/tests/fixtures/bad_bus_crossing/bad_bus_crossing.sdc
@@ -1,3 +1,7 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `src_data` is sourced from src_clk's domain — declare it so CDC-011
+# doesn't pick it up as unconstrained (this fixture exercises CDC-004's
+# bus-crossing detection, not the unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports src_data]

--- a/tests/fixtures/bad_comb_before_sync/bad_comb_before_sync.sdc
+++ b/tests/fixtures/bad_comb_before_sync/bad_comb_before_sync.sdc
@@ -1,3 +1,8 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `a` and `b` originate in src_clk's domain — declare to keep CDC-011
+# silent (this fixture targets CDC-003 / comb-before-sync, not the
+# unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports a]
+set_input_delay -clock src_clk 1.0 [get_ports b]

--- a/tests/fixtures/bad_comb_before_sync_with_if/bad_comb_before_sync_with_if.sdc
+++ b/tests/fixtures/bad_comb_before_sync_with_if/bad_comb_before_sync_with_if.sdc
@@ -1,3 +1,9 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `sel`, `a`, `b` originate in src_clk's domain — declare to keep
+# CDC-011 silent (this fixture targets CDC-003, not the
+# unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports sel]
+set_input_delay -clock src_clk 1.0 [get_ports a]
+set_input_delay -clock src_clk 1.0 [get_ports b]

--- a/tests/fixtures/bad_comb_case_before_sync/bad_comb_case_before_sync.sdc
+++ b/tests/fixtures/bad_comb_case_before_sync/bad_comb_case_before_sync.sdc
@@ -1,3 +1,10 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `sel`, `a`, `b`, `c` originate in src_clk's domain — declare to keep
+# CDC-011 silent (this fixture targets CDC-003 on a case-statement
+# shape, not the unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports sel]
+set_input_delay -clock src_clk 1.0 [get_ports a]
+set_input_delay -clock src_clk 1.0 [get_ports b]
+set_input_delay -clock src_clk 1.0 [get_ports c]

--- a/tests/fixtures/bad_comb_source/bad_comb_source.sdc
+++ b/tests/fixtures/bad_comb_source/bad_comb_source.sdc
@@ -1,3 +1,10 @@
-# Only one declared clock; `a` and `b` are unclocked top-level inputs
-# (asynchronous logic-level signals from a foreign domain).
 create_clock -name dst_clk -period 7.5 [get_ports dst_clk]
+# `a` and `b` are async logic-level signals from a foreign domain —
+# model that with a virtual clock + async-group + set_input_delay
+# typing, so CDC-006 still fires on the glitchy-comb-source shape
+# (its real target) while CDC-011 stays silent on the port (the SDC
+# now answers "what domain does this port belong to?").
+create_clock -name vclk_ext -period 10.0
+set_clock_groups -asynchronous -group {vclk_ext} -group {dst_clk}
+set_input_delay -clock vclk_ext 1.0 [get_ports a]
+set_input_delay -clock vclk_ext 1.0 [get_ports b]

--- a/tests/fixtures/bad_reconvergent_sync/bad_reconvergent_sync.sdc
+++ b/tests/fixtures/bad_reconvergent_sync/bad_reconvergent_sync.sdc
@@ -1,3 +1,7 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `d_in` originates in src_clk's domain — declare to keep CDC-011
+# silent (this fixture targets CDC-005 / reconvergence, not the
+# unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/bad_reconvergent_with_recombine/bad_reconvergent_with_recombine.sdc
+++ b/tests/fixtures/bad_reconvergent_with_recombine/bad_reconvergent_with_recombine.sdc
@@ -1,3 +1,7 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `d_in` originates in src_clk's domain — declare to keep CDC-011
+# silent (this fixture targets CDC-005 / reconvergence + recombine,
+# not the unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/bad_reset_crossing/bad_reset_crossing.sdc
+++ b/tests/fixtures/bad_reset_crossing/bad_reset_crossing.sdc
@@ -1,3 +1,13 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `kill_req`, `d_in` originate in src_clk's domain — declare to keep
+# CDC-011 silent (this fixture targets CDC-007 / async reset crossing,
+# not the unconstrained-input shape). `global_rst_n` is an async reset
+# port driving ARST pins only; it never reaches a flop's D, so CDC-011
+# is already silent on it.
+set_input_delay -clock src_clk 1.0 [get_ports kill_req]
+# `d_in` is sampled by a flop on dst_clk (see the SV); type it
+# accordingly so the port→flop walk doesn't flag a CDC-001 — the rule
+# the fixture targets is CDC-007 on the reset, not the data path.
+set_input_delay -clock dst_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/bad_reset_tree/bad_reset_tree.sdc
+++ b/tests/fixtures/bad_reset_tree/bad_reset_tree.sdc
@@ -1,3 +1,9 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period  7.5 [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `ext_rst_assert` is sampled by a flop in src_clk's domain — declare
+# to keep CDC-011 silent (this fixture targets CDC-007's reset
+# distribution tree, not the unconstrained-input shape). `src_rst_n`
+# and `dst_rst_n` are async reset ports driving ARST pins only, so
+# they never reach a flop's D and CDC-011 stays silent on them.
+set_input_delay -clock src_clk 1.0 [get_ports ext_rst_assert]

--- a/tests/fixtures/bad_single_ff_sync/bad_single_ff_sync.sdc
+++ b/tests/fixtures/bad_single_ff_sync/bad_single_ff_sync.sdc
@@ -1,3 +1,7 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `d_in` originates in src_clk's domain — declare to keep CDC-011
+# silent (this fixture targets CDC-001's missing-synchronizer shape,
+# not the unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.json
+++ b/tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.json
@@ -1,0 +1,130 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_unconstrained_input_bus_two_domains": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:10.1-21.10"
+      },
+      "ports": {
+        "clk_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "clk_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "in": {
+          "direction": "input",
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ]
+        },
+        "q_a": {
+          "direction": "output",
+          "bits": [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+        },
+        "q_b": {
+          "direction": "output",
+          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ]
+        }
+      },
+      "cells": {
+        "$procdff$3": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:19.5-19.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+            "Q": [ 20, 21, 22, 23, 24, 25, 26, 27 ]
+          }
+        },
+        "$procdff$4": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:18.5-18.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+            "Q": [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\q_a[7:0]": {
+          "hide_name": 1,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:18.5-18.42"
+          }
+        },
+        "$0\\q_b[7:0]": {
+          "hide_name": 1,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:19.5-19.42"
+          }
+        },
+        "clk_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:11.24-11.29"
+          }
+        },
+        "clk_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:12.24-12.29"
+          }
+        },
+        "in": {
+          "hide_name": 0,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:13.24-13.26"
+          }
+        },
+        "q_a": {
+          "hide_name": 0,
+          "bits": [ 12, 13, 14, 15, 16, 17, 18, 19 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:14.24-14.27"
+          }
+        },
+        "q_b": {
+          "hide_name": 0,
+          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv:15.24-15.27"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sdc
+++ b/tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sdc
@@ -1,0 +1,5 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period 7.5  [get_ports clk_b]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
+# Intentionally NO `set_input_delay` on `in[7:0]` — that's the gap
+# CDC-011 (issue #97) surfaces.

--- a/tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv
+++ b/tests/fixtures/bad_unconstrained_input_bus_two_domains/bad_unconstrained_input_bus_two_domains.sv
@@ -1,0 +1,21 @@
+// Negative-case fixture for CDC-011 (#97), multi-bit shape.
+//
+// 8-bit input `in[7:0]` has no `set_input_delay -clock` typing and is
+// captured by flop banks in two distinct clock domains (`clk_a` and
+// `clk_b`). Vector variant of `bad_unconstrained_input_two_domains` —
+// guards against the rule firing per-bit and either deduplicating
+// wrong or missing the bus shape entirely. Expected: one error-
+// severity CDC-011 violation naming both destination clocks.
+
+module bad_unconstrained_input_bus_two_domains (
+    input  logic       clk_a,
+    input  logic       clk_b,
+    input  logic [7:0] in,
+    output logic [7:0] q_a,
+    output logic [7:0] q_b
+);
+
+    always_ff @(posedge clk_a) q_a <= in;
+    always_ff @(posedge clk_b) q_b <= in;
+
+endmodule

--- a/tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.json
+++ b/tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.json
@@ -1,0 +1,170 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_unconstrained_input_derived_clock": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:11.1-22.10"
+      },
+      "ports": {
+        "clk_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "clk_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "clk_c": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "in": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "q": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$and$tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19$1": {
+          "hide_name": 1,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19.20-19.33"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "B": [ 3 ],
+            "Y": [ 7 ]
+          }
+        },
+        "$and$tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19$2": {
+          "hide_name": 1,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19.20-19.41"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 7 ],
+            "B": [ 4 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$procdff$4": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:20.5-20.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 8 ],
+            "D": [ 5 ],
+            "Q": [ 6 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:20.5-20.42"
+          }
+        },
+        "$and$tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19$1_Y": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19.20-19.33"
+          }
+        },
+        "$and$tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19$2_Y": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19.20-19.41"
+          }
+        },
+        "clk_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:12.18-12.23"
+          }
+        },
+        "clk_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:13.18-13.23"
+          }
+        },
+        "clk_c": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:14.18-14.23"
+          }
+        },
+        "derived": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:19.10-19.17"
+          }
+        },
+        "in": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:15.18-15.20"
+          }
+        },
+        "q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv:16.18-16.19"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sdc
+++ b/tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sdc
@@ -1,0 +1,7 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period  7.5 [get_ports clk_b]
+create_clock -name clk_c -period  5.0 [get_ports clk_c]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b} -group {clk_c}
+# Intentionally NO `set_input_delay` on `in` — CDC-011's purpose is
+# to flag the missing constraint. Adding typing would invalidate the
+# fixture.

--- a/tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv
+++ b/tests/fixtures/bad_unconstrained_input_derived_clock/bad_unconstrained_input_derived_clock.sv
@@ -1,0 +1,22 @@
+// Negative-case fixture for CDC-011 (#97).
+//
+// Input `in` has no `set_input_delay -clock` typing and is captured
+// by a flop whose clock is a combinational function of three declared
+// clocks (`clk_a & clk_b & clk_c`). There's no single declared domain
+// the port could "obviously" belong to — the SDC author has to assert
+// one explicitly. CDC-011 should fire as a warning (single resolved
+// destination domain — whichever one trace_clock_root picks first
+// out of the AND tree).
+
+module bad_unconstrained_input_derived_clock (
+    input  logic clk_a,
+    input  logic clk_b,
+    input  logic clk_c,
+    input  logic in,
+    output logic q
+);
+
+    wire derived = clk_a & clk_b & clk_c;
+    always_ff @(posedge derived) q <= in;
+
+endmodule

--- a/tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.json
+++ b/tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.json
@@ -1,0 +1,137 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_unconstrained_input_muxed_clock": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:11.1-22.10"
+      },
+      "ports": {
+        "tclk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "sclk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "tm": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "d": {
+          "direction": "input",
+          "bits": [ 5, 6, 7, 8 ]
+        },
+        "q": {
+          "direction": "output",
+          "bits": [ 9, 10, 11, 12 ]
+        }
+      },
+      "cells": {
+        "$procdff$3": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:20.5-20.41"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 13 ],
+            "D": [ 5, 6, 7, 8 ],
+            "Q": [ 9, 10, 11, 12 ]
+          }
+        },
+        "$ternary$tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:19$1": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:19.20-19.36"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "B": [ 2 ],
+            "S": [ 4 ],
+            "Y": [ 13 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\q[3:0]": {
+          "hide_name": 1,
+          "bits": [ 5, 6, 7, 8 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:20.5-20.41"
+          }
+        },
+        "$ternary$tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:19$1_Y": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:19.20-19.36"
+          }
+        },
+        "d": {
+          "hide_name": 0,
+          "bits": [ 5, 6, 7, 8 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:15.24-15.25"
+          }
+        },
+        "muxedCP": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:19.10-19.17"
+          }
+        },
+        "q": {
+          "hide_name": 0,
+          "bits": [ 9, 10, 11, 12 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:16.24-16.25"
+          }
+        },
+        "sclk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:13.24-13.28"
+          }
+        },
+        "tclk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:12.24-12.28"
+          }
+        },
+        "tm": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv:14.24-14.26"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sdc
+++ b/tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sdc
@@ -1,0 +1,7 @@
+create_clock -name tclk -period 10.0 [get_ports tclk]
+create_clock -name sclk -period  7.5 [get_ports sclk]
+set_clock_groups -asynchronous -group {tclk} -group {sclk}
+# Intentionally NO `set_input_delay` on `d[3:0]` — CDC-011 (#97)
+# surfaces the missing constraint. `tm` is a mode pin; left untyped
+# here because it never reaches a flop's D pin (it only fans into
+# the clock mux's S input), so CDC-011 doesn't trip on it.

--- a/tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv
+++ b/tests/fixtures/bad_unconstrained_input_muxed_clock/bad_unconstrained_input_muxed_clock.sv
@@ -1,0 +1,22 @@
+// Negative-case fixture for CDC-011 (#97), muxed-clock destination.
+//
+// 4-bit input `d[3:0]` has no `set_input_delay -clock` typing and is
+// captured by a flop whose clock is a test-mode mux between two
+// declared clocks (`tm ? tclk : sclk`). The destination clock isn't a
+// single `create_clock` name, so even a methodologically diligent SDC
+// author couldn't default `d` to one of them. CDC-011 should fire as
+// a warning (single resolved destination domain — whichever side of
+// the mux trace_clock_root picks first).
+
+module bad_unconstrained_input_muxed_clock (
+    input  logic       tclk,
+    input  logic       sclk,
+    input  logic       tm,
+    input  logic [3:0] d,
+    output logic [3:0] q
+);
+
+    wire muxedCP = tm ? tclk : sclk;
+    always_ff @(posedge muxedCP) q <= d;
+
+endmodule

--- a/tests/fixtures/good_2ff_sync/good_2ff_sync.sdc
+++ b/tests/fixtures/good_2ff_sync/good_2ff_sync.sdc
@@ -1,3 +1,7 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `d_in` originates in src_clk's domain — declare to keep CDC-011
+# silent (this fixture is the textbook 2FF synchronizer, not the
+# unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.json
+++ b/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.json
@@ -1,0 +1,174 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_unconstrained_input_bus_two_domains_typed": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:8.1-24.10"
+      },
+      "ports": {
+        "clk_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "clk_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "in": {
+          "direction": "input",
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ]
+        },
+        "q_a": {
+          "direction": "output",
+          "bits": [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+        },
+        "q_b": {
+          "direction": "output",
+          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ]
+        }
+      },
+      "cells": {
+        "$procdff$4": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:21.5-21.55"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 28, 29, 30, 31, 32, 33, 34, 35 ],
+            "Q": [ 20, 21, 22, 23, 24, 25, 26, 27 ]
+          }
+        },
+        "$procdff$5": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:20.5-20.48"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+            "Q": [ 28, 29, 30, 31, 32, 33, 34, 35 ]
+          }
+        },
+        "$procdff$6": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:16.5-16.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+            "Q": [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\q_a[7:0]": {
+          "hide_name": 1,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:16.5-16.42"
+          }
+        },
+        "$0\\sync_meta[7:0]": {
+          "hide_name": 1,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:20.5-20.48"
+          }
+        },
+        "$0\\sync_q[7:0]": {
+          "hide_name": 1,
+          "bits": [ 28, 29, 30, 31, 32, 33, 34, 35 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:21.5-21.55"
+          }
+        },
+        "clk_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:9.24-9.29"
+          }
+        },
+        "clk_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:10.24-10.29"
+          }
+        },
+        "in": {
+          "hide_name": 0,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:11.24-11.26"
+          }
+        },
+        "q_a": {
+          "hide_name": 0,
+          "bits": [ 12, 13, 14, 15, 16, 17, 18, 19 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:12.24-12.27"
+          }
+        },
+        "q_b": {
+          "hide_name": 0,
+          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:13.24-13.27"
+          }
+        },
+        "sync_meta": {
+          "hide_name": 0,
+          "bits": [ 28, 29, 30, 31, 32, 33, 34, 35 ],
+          "attributes": {
+            "cdc_sync": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:18.32-18.41"
+          }
+        },
+        "sync_q": {
+          "hide_name": 0,
+          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:19.32-19.38"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sdc
+++ b/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sdc
@@ -1,0 +1,8 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period 7.5  [get_ports clk_b]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
+# `in[7:0]` arrives synchronous to clk_a. CDC-011 silent (typed),
+# CDC-004 silent (bus crossing into clk_b uses a registered pre-
+# stage in the same source domain — the typed clk_a port is treated
+# as the source register from the rule's perspective).
+set_input_delay -clock clk_a 1.0 [get_ports in]

--- a/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv
+++ b/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv
@@ -1,0 +1,24 @@
+// Positive counterpart to bad_unconstrained_input_bus_two_domains.
+//
+// Bus variant of good_unconstrained_input_two_domains_typed — `in`
+// is typed against clk_a; the clk_b capture passes through a
+// 2-stage flop chain per bit. CDC-011 and CDC-001/-004 all stay
+// silent.
+
+module good_unconstrained_input_bus_two_domains_typed (
+    input  logic       clk_a,
+    input  logic       clk_b,
+    input  logic [7:0] in,
+    output logic [7:0] q_a,
+    output logic [7:0] q_b
+);
+
+    always_ff @(posedge clk_a) q_a <= in;
+
+    (* cdc_sync *) logic [7:0] sync_meta;
+    logic [7:0]                sync_q;
+    always_ff @(posedge clk_b) sync_meta <= in;
+    always_ff @(posedge clk_b) sync_q    <= sync_meta;
+    assign q_b = sync_q;
+
+endmodule

--- a/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.json
+++ b/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.json
@@ -1,0 +1,170 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_unconstrained_input_derived_clock_typed": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:9.1-20.10"
+      },
+      "ports": {
+        "clk_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "clk_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "clk_c": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "in": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "q": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$and$tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17$1": {
+          "hide_name": 1,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.20-17.33"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 2 ],
+            "B": [ 3 ],
+            "Y": [ 7 ]
+          }
+        },
+        "$and$tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17$2": {
+          "hide_name": 1,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.20-17.41"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 7 ],
+            "B": [ 4 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$procdff$4": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:18.5-18.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 8 ],
+            "D": [ 5 ],
+            "Q": [ 6 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:18.5-18.42"
+          }
+        },
+        "$and$tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17$1_Y": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.20-17.33"
+          }
+        },
+        "$and$tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17$2_Y": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.20-17.41"
+          }
+        },
+        "clk_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:10.18-10.23"
+          }
+        },
+        "clk_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:11.18-11.23"
+          }
+        },
+        "clk_c": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:12.18-12.23"
+          }
+        },
+        "derived": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.10-17.17"
+          }
+        },
+        "in": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:13.18-13.20"
+          }
+        },
+        "q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:14.18-14.19"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sdc
+++ b/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sdc
@@ -1,0 +1,12 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period  7.5 [get_ports clk_b]
+create_clock -name clk_c -period  5.0 [get_ports clk_c]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b} -group {clk_c}
+# `in` arrives synchronous to clk_a — the SDC author asserts a single
+# domain rather than leaving the analyzer to default through the
+# AND-of-clocks. clk_a specifically because that's the root the
+# destination flop resolves to (the trace walks the outer `$and`'s
+# inputs and the "A" arm's resolution wins via `a_root or b_root`).
+# CDC-011 stays silent (port is typed) and CDC-001 stays silent
+# (source/destination domains match after resolution).
+set_input_delay -clock clk_a 1.0 [get_ports in]

--- a/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv
+++ b/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv
@@ -1,0 +1,20 @@
+// Positive counterpart to bad_unconstrained_input_derived_clock.
+//
+// The SDC types `in` against the same clock the derived-clock flop
+// resolves to (whichever input of the AND tree trace_clock_root picks
+// first). CDC-011 stays silent because the port is typed; CDC-001
+// stays silent because the resolved source domain matches the
+// destination.
+
+module good_unconstrained_input_derived_clock_typed (
+    input  logic clk_a,
+    input  logic clk_b,
+    input  logic clk_c,
+    input  logic in,
+    output logic q
+);
+
+    wire derived = clk_a & clk_b & clk_c;
+    always_ff @(posedge derived) q <= in;
+
+endmodule

--- a/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.json
+++ b/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.json
@@ -1,0 +1,137 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_unconstrained_input_muxed_clock_typed": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:7.1-18.10"
+      },
+      "ports": {
+        "tclk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "sclk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "tm": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "d": {
+          "direction": "input",
+          "bits": [ 5, 6, 7, 8 ]
+        },
+        "q": {
+          "direction": "output",
+          "bits": [ 9, 10, 11, 12 ]
+        }
+      },
+      "cells": {
+        "$procdff$3": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:16.5-16.41"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 13 ],
+            "D": [ 5, 6, 7, 8 ],
+            "Q": [ 9, 10, 11, 12 ]
+          }
+        },
+        "$ternary$tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15$1": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15.20-15.36"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "B": [ 2 ],
+            "S": [ 4 ],
+            "Y": [ 13 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\q[3:0]": {
+          "hide_name": 1,
+          "bits": [ 5, 6, 7, 8 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:16.5-16.41"
+          }
+        },
+        "$ternary$tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15$1_Y": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15.20-15.36"
+          }
+        },
+        "d": {
+          "hide_name": 0,
+          "bits": [ 5, 6, 7, 8 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:11.24-11.25"
+          }
+        },
+        "muxedCP": {
+          "hide_name": 0,
+          "bits": [ 13 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15.10-15.17"
+          }
+        },
+        "q": {
+          "hide_name": 0,
+          "bits": [ 9, 10, 11, 12 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:12.24-12.25"
+          }
+        },
+        "sclk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:9.24-9.28"
+          }
+        },
+        "tclk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:8.24-8.28"
+          }
+        },
+        "tm": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:10.24-10.26"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sdc
+++ b/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sdc
@@ -1,0 +1,9 @@
+create_clock -name tclk -period 10.0 [get_ports tclk]
+create_clock -name sclk -period  7.5 [get_ports sclk]
+set_clock_groups -asynchronous -group {tclk} -group {sclk}
+# `d[3:0]` is typed against whichever side of the mux trace_clock_root
+# resolves to. Here Yosys' conditional-operator lowering puts `sclk`
+# on the mux's A arm (the "false" branch of `tm ? tclk : sclk`), so
+# the trace's `for in_port in ("A", "B")` walk returns sclk. CDC-011
+# silent (typed), CDC-001 silent (src==dst once resolved).
+set_input_delay -clock sclk 1.0 [get_ports d]

--- a/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv
+++ b/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv
@@ -1,0 +1,18 @@
+// Positive counterpart to bad_unconstrained_input_muxed_clock.
+//
+// SDC types `d` against the same clock the muxed-clock flop resolves
+// to. CDC-011 stays silent because the port is typed; CDC-001 stays
+// silent because the source/destination domains match.
+
+module good_unconstrained_input_muxed_clock_typed (
+    input  logic       tclk,
+    input  logic       sclk,
+    input  logic       tm,
+    input  logic [3:0] d,
+    output logic [3:0] q
+);
+
+    wire muxedCP = tm ? tclk : sclk;
+    always_ff @(posedge muxedCP) q <= d;
+
+endmodule

--- a/tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.json
+++ b/tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.json
@@ -1,0 +1,174 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_unconstrained_input_two_domains_typed": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:9.1-27.10"
+      },
+      "ports": {
+        "clk_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "clk_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "in": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "q_a": {
+          "direction": "output",
+          "bits": [ 5 ]
+        },
+        "q_b": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$procdff$4": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:24.5-24.55"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 7 ],
+            "Q": [ 6 ]
+          }
+        },
+        "$procdff$5": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:23.5-23.48"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 4 ],
+            "Q": [ 7 ]
+          }
+        },
+        "$procdff$6": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:18.5-18.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 4 ],
+            "Q": [ 5 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\q_a[0:0]": {
+          "hide_name": 1,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:18.5-18.42"
+          }
+        },
+        "$0\\sync_meta[0:0]": {
+          "hide_name": 1,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:23.5-23.48"
+          }
+        },
+        "$0\\sync_q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:24.5-24.55"
+          }
+        },
+        "clk_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:10.18-10.23"
+          }
+        },
+        "clk_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:11.18-11.23"
+          }
+        },
+        "in": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:12.18-12.20"
+          }
+        },
+        "q_a": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:13.18-13.21"
+          }
+        },
+        "q_b": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:14.18-14.21"
+          }
+        },
+        "sync_meta": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "cdc_sync": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:21.26-21.35"
+          }
+        },
+        "sync_q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv:22.26-22.32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sdc
+++ b/tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sdc
@@ -1,0 +1,7 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period 7.5  [get_ports clk_b]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
+# `in` arrives synchronous to clk_a — the SDC author has answered
+# CDC-011's question. The clk_b-side capture goes through a 2FF
+# synchronizer in the RTL, so CDC-001 stays silent too.
+set_input_delay -clock clk_a 1.0 [get_ports in]

--- a/tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv
+++ b/tests/fixtures/good_unconstrained_input_two_domains_typed/good_unconstrained_input_two_domains_typed.sv
@@ -1,0 +1,27 @@
+// Positive counterpart to bad_unconstrained_input_two_domains.
+//
+// The SDC types `in` against `clk_a` via `set_input_delay -clock` and
+// the RTL adds a 2FF synchronizer on the `clk_b` side, so the
+// methodology gap CDC-011 surfaced is fully resolved: CDC-011 stays
+// silent (port is typed), CDC-001 stays silent (chain depth >= 2 on
+// the foreign-domain capture). The textbook fix shape.
+
+module good_unconstrained_input_two_domains_typed (
+    input  logic clk_a,
+    input  logic clk_b,
+    input  logic in,
+    output logic q_a,
+    output logic q_b
+);
+
+    // Native-domain capture: no synchronizer needed.
+    always_ff @(posedge clk_a) q_a <= in;
+
+    // Foreign-domain capture: 2FF synchronizer.
+    (* cdc_sync *) logic sync_meta;
+    logic                sync_q;
+    always_ff @(posedge clk_b) sync_meta <= in;
+    always_ff @(posedge clk_b) sync_q    <= sync_meta;
+    assign q_b = sync_q;
+
+endmodule

--- a/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.sdc
+++ b/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.sdc
@@ -16,3 +16,10 @@ create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous \
     -group {src_clk} \
     -group {dst_clk}
+
+# Declare the data inputs as members of their respective clock domains
+# so CDC-011 doesn't flag them as unconstrained primary inputs (this
+# fixture exercises the req/ack handshake shape, not the
+# unconstrained-input shape).
+set_input_delay -clock src_clk 1.0 [get_ports src_valid]
+set_input_delay -clock src_clk 1.0 [get_ports src_data]

--- a/tests/test_bad_unconstrained_input_bus_two_domains.py
+++ b/tests/test_bad_unconstrained_input_bus_two_domains.py
@@ -1,0 +1,56 @@
+"""Bus-width multi-domain capture — CDC-011 still escalates to error.
+
+Issue rtl-buddy-cdc#97. Same shape as the scalar two-domains fixture
+but the input is ``[7:0]``. The post-pass groups crossings by
+``src_port`` (not by ``(src_port, bit)``), so a fanout-of-bits doesn't
+multiply the violation count — one error per port, listing every
+distinct destination clock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_unconstrained_input_bus_two_domains"
+JSON = FIX_DIR / "bad_unconstrained_input_bus_two_domains.json"
+SDC = FIX_DIR / "bad_unconstrained_input_bus_two_domains.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    return module, crossings, spec
+
+
+def test_port_crossings_carry_full_bus_width(context) -> None:
+    """Each (port, dst flop) pair collapses across all 8 source bits;
+    the resulting crossings should each have width 8 — guards against
+    a regression where the port-walk emits per-bit crossings."""
+    _module, crossings, _spec = context
+    in_crossings = [c for c in crossings if c.src_port == "in"]
+    assert len(in_crossings) == 2  # one per destination flop
+    assert {c.width for c in in_crossings} == {8}
+
+
+def test_cdc_011_fires_once_at_error_severity(context) -> None:
+    module, crossings, spec = context
+    violations = run_all_rules(module, crossings, spec)
+    cdc_011 = [v for v in violations if v.rule_id == "CDC-011"]
+    assert len(cdc_011) == 1
+    v = cdc_011[0]
+    assert v.severity == "error"
+    assert "'in'" in v.message
+    assert "clk_a" in v.message
+    assert "clk_b" in v.message

--- a/tests/test_bad_unconstrained_input_derived_clock.py
+++ b/tests/test_bad_unconstrained_input_derived_clock.py
@@ -1,0 +1,57 @@
+"""Derived-clock destination — CDC-011 fires as a single-domain warning.
+
+Issue rtl-buddy-cdc#97. ``in`` is untyped; the destination flop's CLK
+is ``clk_a & clk_b & clk_c`` (a two-level ``$and`` tree). The clock-
+trace's ``a_root or b_root`` short-circuit picks one of the three
+inputs as the resolved root, so CDC-011's grouping sees a single
+destination clock for ``in`` and emits a **warning**, not the multi-
+domain ``error`` shape (that's covered by
+``test_bad_unconstrained_input_two_domains``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_unconstrained_input_derived_clock"
+JSON = FIX_DIR / "bad_unconstrained_input_derived_clock.json"
+SDC = FIX_DIR / "bad_unconstrained_input_derived_clock.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    return module, crossings, spec
+
+
+def test_cdc_011_fires_as_warning_with_resolved_dst_clock(context) -> None:
+    module, crossings, spec = context
+    violations = run_all_rules(module, crossings, spec)
+    cdc_011 = [v for v in violations if v.rule_id == "CDC-011"]
+    assert len(cdc_011) == 1
+    v = cdc_011[0]
+    assert v.severity == "warning", (
+        f"single resolved destination → warning; got {v.severity}"
+    )
+    assert "'in'" in v.message
+    # The message must include exactly one of the three declared
+    # clocks (whichever trace_clock_root resolved to). We don't pin
+    # which one because the $and-tree short-circuit order is a
+    # trace-implementation detail; what matters is the rule decided
+    # on a single domain rather than reporting "multiple".
+    assert sum(1 for clk in ("clk_a", "clk_b", "clk_c") if clk in v.message) == 1, (
+        f"warning message should name a single resolved destination "
+        f"clock from the AND tree; got: {v.message}"
+    )

--- a/tests/test_bad_unconstrained_input_muxed_clock.py
+++ b/tests/test_bad_unconstrained_input_muxed_clock.py
@@ -1,0 +1,57 @@
+"""Muxed-clock destination — CDC-011 fires as a single-domain warning.
+
+Issue rtl-buddy-cdc#97. ``d`` is untyped; the destination flop's CLK
+is ``tm ? tclk : sclk``. ``trace_clock_root``'s mux walk returns the
+first arm that resolves (``A`` first), so CDC-011 sees a single
+resolved destination clock and emits a **warning**. The SDC author
+has to assert a domain explicitly — the analyzer can't statically
+know which side of the mux the chip actually runs on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_unconstrained_input_muxed_clock"
+JSON = FIX_DIR / "bad_unconstrained_input_muxed_clock.json"
+SDC = FIX_DIR / "bad_unconstrained_input_muxed_clock.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    return module, crossings, spec
+
+
+def test_tm_port_not_walked(context) -> None:
+    """``tm`` only fans into the clock mux's ``S`` input — it never
+    reaches a flop's ``D``. So even though it gets a sentinel entry
+    (it's an untyped input), the port-walk yields no crossings for
+    it. Pin: CDC-011 must not fire on ``tm``."""
+    _module, crossings, _spec = context
+    assert [c for c in crossings if c.src_port == "tm"] == []
+
+
+def test_cdc_011_fires_as_warning_with_resolved_mux_clock(context) -> None:
+    module, crossings, spec = context
+    violations = run_all_rules(module, crossings, spec)
+    cdc_011 = [v for v in violations if v.rule_id == "CDC-011"]
+    assert len(cdc_011) == 1
+    v = cdc_011[0]
+    assert v.severity == "warning"
+    assert "'d'" in v.message
+    # Whichever side of the mux resolved first; we just pin "exactly
+    # one of the declared clocks appears" rather than which one.
+    assert sum(1 for clk in ("tclk", "sclk") if clk in v.message) == 1

--- a/tests/test_bad_unconstrained_input_two_domains.py
+++ b/tests/test_bad_unconstrained_input_two_domains.py
@@ -1,18 +1,20 @@
-"""Regression-baseline test for the untyped-input multi-domain gap.
+"""Multi-domain untyped-input shape — CDC-011 must escalate to error.
 
-Issue: rtl-buddy-cdc#97 — when a top-level input port has no
-``set_input_delay -clock`` typing, ``find_crossings`` never iterates
-it (the port-walk at ``domain.py:413-481`` is keyed off
-``ClockSpec.port_clock``), so a crossing that physically lands the
-port in two distinct clock domains reports clean. This test pins that
-current behaviour so any later change (CDC-011 landing, or a
-data-model change that retroactively walks untyped ports) is forced
-to update the assertions here.
+Issue rtl-buddy-cdc#97. The fixture's SDC omits ``set_input_delay`` for
+``in``; :func:`sdc.synthesize_unconstrained_inputs` synthesises the
+:data:`sdc.UNCONSTRAINED_SENTINEL` entry so the existing port-walk in
+:func:`find_crossings` emits one port-sourced crossing per (port,
+destination flop). ``check_cdc_011``'s post-pass groups by ``src_port``;
+because ``in`` lands in two distinct clock domains (``clk_a``,
+``clk_b``), the rule fires once at **error** severity rather than two
+independent warnings — a single port cannot be synchronous to two
+clocks, so this is intrinsically wrong regardless of the SDC opinion.
 
-When CDC-011 lands, flip the assertions to expect one error-severity
-violation naming ``in`` and both ``{clk_a, clk_b}`` destinations — a
-single port cannot be synchronous to two distinct clocks, so it is
-intrinsically wrong regardless of SDC opinion.
+The fixture was originally landed (PR #98, commit 4eb5f49) as a
+regression-baseline pinning the *pre*-CDC-011 behaviour
+(``violations == []``). When CDC-011 shipped, the assertions were
+flipped here; the SV / SDC / JSON were left unchanged so the same
+disk-level artifact exercises both eras of behaviour.
 """
 
 from __future__ import annotations
@@ -37,46 +39,63 @@ def context():
         pytest.skip(f"fixture not built: {JSON}")
     module = netlist.load(JSON)
     spec = sdc_mod.parse_file(SDC)
+    sentinel_ports = sdc_mod.synthesize_unconstrained_inputs(spec, module)
     crossings = find_crossings(module, port_clock=spec.port_clock)
-    return module, crossings, spec
+    return module, crossings, spec, sentinel_ports
 
 
-def test_sdc_has_no_input_delay(context) -> None:
-    """Sanity: confirm the SDC really omits ``set_input_delay`` for
-    ``in``. If a future SDC edit adds typing, this fixture stops
-    documenting the gap and should be re-thought."""
-    _module, _crossings, spec = context
-    assert "in" not in spec.port_clock, (
-        "Fixture invariant violated: `in` got a port_clock entry. "
-        "The SDC must leave `in` untyped to exercise the #97 gap."
+def test_sentinel_synthesised_for_unconstrained_port(context) -> None:
+    """``in`` has no ``set_input_delay`` typing in the SDC →
+    :func:`synthesize_unconstrained_inputs` assigns the sentinel."""
+    _module, _crossings, spec, sentinel_ports = context
+    assert "in" in sentinel_ports
+    assert spec.port_clock["in"] == sdc_mod.UNCONSTRAINED_SENTINEL
+
+
+def test_sentinel_emits_port_crossings_to_both_domains(context) -> None:
+    """Port-walk emits one port-sourced crossing per (port, dst flop);
+    ``in`` lands on flops in both ``clk_a`` and ``clk_b`` domains."""
+    _module, crossings, _spec, _sentinel = context
+    in_crossings = [c for c in crossings if c.src_port == "in"]
+    assert len(in_crossings) == 2, (
+        f"expected one port-sourced crossing per destination flop "
+        f"(2 total); got {[(c.src_port, c.dst_clock) for c in in_crossings]}"
     )
+    assert {c.dst_clock for c in in_crossings} == {"clk_a", "clk_b"}
+    for c in in_crossings:
+        assert c.src_clock == sdc_mod.UNCONSTRAINED_SENTINEL
 
 
-def test_untyped_port_emits_no_crossings(context) -> None:
-    """Today: ``in`` has no ``port_clock`` entry → no port-sourced
-    Crossing is emitted, even though it physically lands on flops in
-    two different clock domains. When CDC-011 lands, flip this to
-    assert >=1 port-sourced crossing whose ``src_port == 'in'``."""
-    _module, crossings, _spec = context
-    port_crossings = [c for c in crossings if c.src_port == "in"]
-    assert port_crossings == [], (
-        f"Untyped port `in` was walked unexpectedly: got "
-        f"{[(c.src_port, c.dst_clock) for c in port_crossings]}. "
-        "CDC-011 (#97) may now be implemented — flip this assertion "
-        "to expect crossings landing in both clk_a and clk_b."
-    )
-
-
-def test_rule_pack_reports_clean(context) -> None:
-    """Today: with no port-sourced crossings, the rule pack stays
-    silent on the untyped-port-to-two-domains shape. When CDC-011
-    lands, flip to expect one error-severity violation naming ``in``
-    and both destination clocks ``{clk_a, clk_b}``."""
-    module, crossings, spec = context
+def test_cdc_011_fires_once_at_error_severity(context) -> None:
+    """Multi-domain post-pass consolidates the two crossings into one
+    ``error``-severity violation naming both destination clocks."""
+    module, crossings, spec, _sentinel = context
     violations = run_all_rules(module, crossings, spec)
-    assert violations == [], (
-        f"Expected zero violations today; got "
-        f"{[(v.rule_id, v.severity, v.message) for v in violations]}. "
-        "CDC-011 (#97) may now fire — update the assertion to expect "
-        "one error-severity violation naming `in` and both clk_a/clk_b."
+    cdc_011 = [v for v in violations if v.rule_id == "CDC-011"]
+    assert len(cdc_011) == 1, (
+        f"expected exactly one CDC-011 violation (consolidated by the "
+        f"multi-domain post-pass); got {[(v.rule_id, v.severity, v.message) for v in cdc_011]}"
+    )
+    v = cdc_011[0]
+    assert v.severity == "error", (
+        f"multi-domain capture must escalate to error; got {v.severity}"
+    )
+    assert "'in'" in v.message
+    # Both destination clocks must appear in the message.
+    assert "clk_a" in v.message
+    assert "clk_b" in v.message
+    # Make sure the message points the user at SDC typing as the fix.
+    assert "set_input_delay" in v.message
+
+
+def test_no_double_fire_on_cdc_001(context) -> None:
+    """CDC-001's sentinel guard must prevent it from firing on the
+    sentinel-sourced crossing (CDC-011 owns this shape, with different
+    fix advice)."""
+    module, crossings, spec, _sentinel = context
+    violations = run_all_rules(module, crossings, spec)
+    cdc_001 = [v for v in violations if v.rule_id == "CDC-001"]
+    assert cdc_001 == [], (
+        f"CDC-001 must skip sentinel-sourced crossings — they're "
+        f"CDC-011's territory. Got {[(v.rule_id, v.message) for v in cdc_001]}"
     )

--- a/tests/test_good_fixtures.py
+++ b/tests/test_good_fixtures.py
@@ -75,6 +75,23 @@ GOOD_FIXTURES = [
     # still recognise the originating mux. Two async crossings (the
     # synced load_req + the gated data bus).
     ("good_buffered_gated_bus_crossing", 2),
+    # CDC-011 (#97) positive shapes: SDC types the unconstrained
+    # input via ``set_input_delay -clock``, with a 2FF synchronizer
+    # on any cross-domain capture.
+    #
+    # _two_domains_typed: port→clk_a direct (same domain, dropped) +
+    # port→clk_b through 2FF sync (1 async port-sourced crossing).
+    ("good_unconstrained_input_two_domains_typed", 1),
+    # _derived_clock_typed: port typed to the same clock the AND-
+    # tree resolves to → same domain → 0 async crossings.
+    ("good_unconstrained_input_derived_clock_typed", 0),
+    # _bus_two_domains_typed: same shape as _two_domains_typed but
+    # width 8 (the port-walk emits one crossing with width=8, not
+    # eight width=1 crossings).
+    ("good_unconstrained_input_bus_two_domains_typed", 1),
+    # _muxed_clock_typed: port typed to whichever mux side
+    # trace_clock_root picks → same domain → 0 async crossings.
+    ("good_unconstrained_input_muxed_clock_typed", 0),
 ]
 
 

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -329,3 +329,41 @@ def test_filter_clause_is_partial_warning() -> None:
     # Without filter evaluation the parser may still pick up the
     # name from -name, but the filter-presence flag should surface.
     assert any("filter" in w for w in spec.partial_warnings)
+
+
+def test_set_input_delay_without_clock_warns_and_leaves_port_untyped() -> None:
+    """set_input_delay needs -clock to anchor the delay to a clock
+    edge; without it the constraint has no STA semantics. Real timers
+    reject it. The parser previously dropped this silently — now it
+    surfaces a partial_warning and leaves the port untyped so CDC-011
+    (issue #97) can pick the port up as unconstrained."""
+    spec = parse(
+        """
+        create_clock -name clk -period 10 [get_ports clk]
+        set_input_delay 1.5 [get_ports d_in]
+        """
+    )
+    assert "d_in" not in spec.port_clock, (
+        "Port without -clock anchor must stay untyped — adding it to "
+        "port_clock would fabricate a clock relationship the user "
+        "never declared."
+    )
+    assert any(
+        "no -clock anchor" in w and "d_in" in w for w in spec.partial_warnings
+    ), (
+        f"Expected a partial_warning naming d_in and 'no -clock anchor'; "
+        f"got {spec.partial_warnings!r}"
+    )
+
+
+def test_set_input_delay_without_clock_and_without_ports_stays_silent() -> None:
+    """Bare delay with no port target is a delay-only / defaults-style
+    usage. No port mapping to fabricate, nothing actionable for CDC,
+    and not the misuse pattern the warning targets — stay silent."""
+    spec = parse(
+        """
+        create_clock -name clk -period 10 [get_ports clk]
+        set_input_delay 1.5
+        """
+    )
+    assert spec.partial_warnings == []


### PR DESCRIPTION
## Summary

Closes #97. New rule **CDC-011** surfaces the SDC-discipline gap
where a top-level input port has no `set_input_delay -clock <name>`
typing but physically reaches a flop's `D` pin. Severity escalates
by shape: `warning` for single-domain capture (typical fix is SDC
typing), `error` for multi-domain capture (a single port cannot be
synchronous to two clocks — intrinsically wrong regardless of SDC
opinion).

Two commits:

1. **`d43e45f`** — `sdc:` warn on `set_*_delay` with ports but no
   `-clock` anchor. Parser previously dropped it silently; real STA
   tools reject it. Surfaces a `partial_warnings` entry pointing
   the user at `set_input_delay -clock` / `set_input_transition` /
   `set_load`.
2. **`58ee99b`** — `rules:` add CDC-011 itself, including:
   - `sdc.UNCONSTRAINED_SENTINEL` + `synthesize_unconstrained_inputs`
     helper (called from the CLI after SDC parse).
   - `ClockSpec.are_async` sentinel short-circuit.
   - `check_cdc_011` with multi-domain grouping post-pass.
   - Sentinel skip guards in CDC-001 / CDC-002 / CDC-006 to prevent
     double-fire with wrong fix advice.
   - Four paired fixtures (multi-domain scalar, AND-of-clocks
     derived dst, multi-domain bus, test-mode mux) + tests.
   - Flipped the regression-baseline test from PR #98 to assert
     the new positive shape (SV/SDC/JSON unchanged).
   - Camp B audit: 10 existing `bad_*` fixtures + `good_2ff_sync`
     + `ip_cdc_handshake` retro-typed with `set_input_delay` on
     their data inputs so each fires only the rule it was
     authored to test.
   - Proposal at `docs/proposals/unconstrained-input-domain.md`,
     README rule-table + intro updated, CHANGELOG entry under
     `[Unreleased]`.

Design discussion is in #97's "Suggested approach" section.

## Test plan

- [x] `uv run pytest -q` — 300 passed, 2 skipped (was 290 on main;
  +10 are the new CDC-011 fixtures' tests).
- [x] `uv run ruff check` — all checks passed.
- [x] `uv run ruff format --check` — all formatted.
- [x] `uv run mypy` — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)