### PR TITLE
docs(readme): link CDC-009 roadmap item to design + implementation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Not yet:
 - [ ] DFT / scan-mode awareness — exempt scan_en, scan_in, test-mode controls from CDC checks under a configurable scan-mode pragma
 - [ ] In-RTL pragma comments (`// rtl-buddy-cdc disable-rule …`, Spyglass-style block suppression) for inline waiving without an external file
 - [ ] Instance-scoped waivers (`waive CDC-001 inst:u_block_a/.*`) — natural follow-on to hierarchical reporting now that `instance_path` is on every violation
-- [ ] Pulse-width / fast-to-slow data-loss checks (CDC-009-class: data on src_clk shorter than one dst_clk period)
+- [ ] Pulse-width / fast-to-slow data-loss checks (CDC-009-class: data on src_clk shorter than one dst_clk period) — designed in [#47](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/47); implementation tracked in [#101](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/101) / [#102](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/102) / [#103](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/103)
 - [ ] Glitch detection on data path through async muxes / clock-gate enables
 
 ## License


### PR DESCRIPTION
## Summary

- Annotates README roadmap line 288 (the CDC-009 pulse-width entry) with links to the now-recorded design issue (#47) and the three spawned implementation follow-ups (#101 / #102 / #103).
- Closes the loop on #47 from the README side: the checkbox stays `[ ]` (not yet implemented), but readers can discover where the design lives and where the open work is tracked.

The design itself was recorded as the body of #47 — per `AGENTS.md`'s "Design proposals live on GitHub, not in `docs/proposals/`" directive (landed in #100), no `docs/proposals/cdc-009-pulse-width.md` file was created.

## Test plan

- [x] CI will not run on this PR — `lint.yml` / `test.yml` path filters exclude `README.md` (see `.github/workflows/lint.yml:6-21`). Same shape as #100. Visual review only.
- [x] Skim the rendered README to confirm the three issue links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)