### PR TITLE
feat(cdc-009): pulse-width / fast-to-slow data-loss rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CDC-009 — Pulse-width / fast-to-slow data-loss** (#47 design,
+  #101 detection, #102 fixtures, #103 integration). Catches the
+  textbook fast-to-slow case where a single-cycle src-domain pulse may
+  land entirely between two slower dst-clock rising edges and be lost
+  (data loss without metastability ever entering the picture). Fires
+  on flop-sourced, single-bit, async crossings when the SDC declares
+  both clock periods, ``src_period * 1.5 < dst_period``, and the src
+  flop's ``D`` pin matches the edge-detector pattern ``A & ~A_d``
+  (with ``A_d`` the 1-cycle delay of ``A``). Severity ``warning`` —
+  single-bit pulse loss is a methodology smell, pairs cleanly with
+  CDC-001/002 (missing sync). Detection lives in
+  ``rtl_buddy_cdc.pulse.classify_d_pin_shape``; the rule is
+  deliberately false-negative-biased so handshake / pulse-stretcher /
+  toggle-sync idioms naturally fall outside the matched pattern and
+  stay silent without an explicit waiver. Three paired fixtures:
+  ``bad_pulse_width_fast_to_slow`` (must fire), and good counterparts
+  ``good_pulse_width_stretched`` (counter-based pulse stretcher) and
+  ``good_pulse_width_handshake`` (req/ack handshake with synced-back
+  ack). The implementation deviates from the issue body's §2 in one
+  detail — see ``pulse.py``'s module docstring; the corrected pattern
+  is the textbook one from Cummings SNUG 2008 §4.5.
 - **CDC-011 — Unconstrained primary input captured by clocked logic**
   (#97). Surfaces the SDC-discipline gap where a top-level input port
   has no `set_input_delay -clock <name>` typing but physically reaches

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ If no SDC is supplied, the tool prints a structural summary and skips all rule c
 | **CDC-006** | error | Glitchy combinational source — synchronizer is fed by combinational logic with no registering flop, reaching unregistered top-level ports. Suppressed when `set_input_delay -clock <my_clk>` types the port into the destination flop's own clock domain (port is asserted same-domain). |
 | **CDC-007** | error | Async reset crossing — flop's `ARST` is driven by a flop in a different async clock domain, no reset synchronizer. Violations are grouped by the shared async source: one report per source listing every destination flop it feeds (the typical reset-distribution-tree shape). |
 | **CDC-008** | error | Clock signal used as data — clock-network bit reaches a non-CLK input (flop `D`/`ARST`, comb input, etc.); cells that themselves drive a flop CLK are exempted (legitimate ICG / clock muxes / dividers) |
+| **CDC-009** | warning | Pulse-width / fast-to-slow data loss — single-bit src-domain pulse may land entirely between two slower dst-clock rising edges and never be sampled. Fires when the SDC declares both clock periods, `src_period × 1.5 < dst_period`, and the src flop's `D` pin matches the textbook edge-detector pattern `A & ~A_d` (with `A_d` the 1-cycle delay of `A`). False-negative-biased: handshake / pulse-stretcher / toggle-sync idioms naturally fall outside the pattern and stay silent. |
 | **CDC-011** | warning / error | Unconstrained primary input captured by clocked logic — top-level input port has no `set_input_delay -clock <name>` typing yet physically reaches a flop's `D` pin. Fires as `warning` when the port lands in a single destination clock domain (the fix is usually adding SDC typing); escalates to `error` when the same port lands in **two or more** distinct domains (a single port cannot be synchronous to multiple clocks — intrinsically wrong regardless of SDC opinion). One violation per source port, listing every destination clock. |
 
 Each violation carries:
@@ -262,7 +263,7 @@ Implemented:
 - [x] SDC parser (`create_clock`, `set_clock_groups -asynchronous`)
 - [x] Clock-domain tracing through buffers / ICGs / clock muxes / dividers
 - [x] Flop→flop crossing detection (single-bit + bus, deduped per pair)
-- [x] CDC-001 through CDC-008, plus CDC-011 (unconstrained primary inputs)
+- [x] CDC-001 through CDC-009 (skipping CDC-010, drafted in [`docs/proposals/clock-network-glitch.md`](docs/proposals/clock-network-glitch.md)) and CDC-011 (unconstrained primary inputs)
 - [x] `lint` standalone wrapper (yosys → analyzer)
 - [x] Text / JSON / SARIF reporters with source locations
 - [x] Waiver file suppression
@@ -285,7 +286,6 @@ Not yet:
 - [ ] DFT / scan-mode awareness — exempt scan_en, scan_in, test-mode controls from CDC checks under a configurable scan-mode pragma
 - [ ] In-RTL pragma comments (`// rtl-buddy-cdc disable-rule …`, Spyglass-style block suppression) for inline waiving without an external file
 - [ ] Instance-scoped waivers (`waive CDC-001 inst:u_block_a/.*`) — natural follow-on to hierarchical reporting now that `instance_path` is on every violation
-- [ ] Pulse-width / fast-to-slow data-loss checks (CDC-009-class: data on src_clk shorter than one dst_clk period) — designed in [#47](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/47); implementation tracked in [#101](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/101) / [#102](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/102) / [#103](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/103)
 - [ ] Glitch detection on data path through async muxes / clock-gate enables
 
 ## License

--- a/src/rtl_buddy_cdc/pulse.py
+++ b/src/rtl_buddy_cdc/pulse.py
@@ -1,0 +1,145 @@
+"""D-pin shape classifier for CDC-009 (pulse-width / fast-to-slow data-loss).
+
+Given the D pin of a src-domain flop whose Q crosses to a slower dst
+clock, classify the D pattern. The rule fires only on ``"pulse"`` —
+the bias is deliberately false-negative over false-positive: a missed
+pulse-width bug surfaces in silicon, where it can be investigated; a
+noisy rule trains users to ignore it.
+
+Note on the design proposal (#47 §2): the original proposal described
+the detection target as a ``$dffe`` whose D feeds back from Q via a
+``$mux`` keyed on EN. That shape actually produces a *latched* value on
+Q (the flop holds whatever was captured when EN last pulsed), not a
+single-cycle pulse on Q — so it wouldn't be a data-loss case in the
+fast-to-slow sense. The textbook pulse-loss case (Cummings SNUG 2008
+§4.5) is structurally a plain ``$dff`` (or ``$dffe`` with always-on
+EN) whose D pin is an edge-detector output ``A & ~A_d`` — that's the
+pattern this classifier matches.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from rtl_buddy_cdc.flops import FF_CELL_TYPES
+from rtl_buddy_cdc.netlist import Bit, Module
+
+PulseShape = Literal["pulse", "other"]
+
+# Cell types where ``Y = ~A``. After ``proc; flatten``, ``~x`` lands as
+# one of these.
+_NOT_TYPES: frozenset[str] = frozenset({"$not", "$logic_not", "$_NOT_"})
+
+# Cell types where ``Y = A & B``. The edge-detector ``req & ~req_d``
+# materialises as one of these with two single-bit inputs.
+_AND_TYPES: frozenset[str] = frozenset({"$and", "$logic_and", "$_AND_"})
+
+
+def classify_d_pin_shape(
+    d_bit: Bit,
+    src_clock: str,
+    module: Module,
+    bit_drivers: dict[Bit, tuple[str, str, int]],
+    flop_domains: dict[str, str | None],
+) -> PulseShape:
+    """Classify the comb-cone driving a flop's D pin.
+
+    Returns ``"pulse"`` iff ``d_bit`` is the ``Y`` of an ``$and`` cell
+    whose two inputs are ``(F1.Q, ~F2.Q)`` where F1 and F2 are both
+    src-domain flops and F2's D[0] equals F1.Q[0] (so F2 is F1's
+    1-cycle delay). Anything else — including handshake / held-value
+    patterns whose D is a priority-encoded ``$mux`` nest — returns
+    ``"other"``.
+    """
+    if not isinstance(d_bit, int):
+        return "other"
+    if _matches_edge_detector(d_bit, src_clock, module, bit_drivers, flop_domains):
+        return "pulse"
+    return "other"
+
+
+def _matches_edge_detector(
+    d_bit: Bit,
+    src_clock: str,
+    module: Module,
+    bit_drivers: dict[Bit, tuple[str, str, int]],
+    flop_domains: dict[str, str | None],
+) -> bool:
+    drv = bit_drivers.get(d_bit)
+    if drv is None:
+        return False
+    cell_name, port, _ = drv
+    cell = module.cells.get(cell_name)
+    if cell is None or cell.type not in _AND_TYPES or port != "Y":
+        return False
+    a_bits = cell.connections.get("A", ())
+    b_bits = cell.connections.get("B", ())
+    if len(a_bits) != 1 or len(b_bits) != 1:
+        return False
+    a_bit, b_bit = a_bits[0], b_bits[0]
+    if not (isinstance(a_bit, int) and isinstance(b_bit, int)):
+        return False
+    # Try both orderings — Yosys may place the inverted operand on either pin.
+    for direct, inverted in ((a_bit, b_bit), (b_bit, a_bit)):
+        if _is_edge_detector_pair(
+            direct, inverted, src_clock, module, bit_drivers, flop_domains
+        ):
+            return True
+    return False
+
+
+def _is_edge_detector_pair(
+    direct_bit: Bit,
+    inverted_bit: Bit,
+    src_clock: str,
+    module: Module,
+    bit_drivers: dict[Bit, tuple[str, str, int]],
+    flop_domains: dict[str, str | None],
+) -> bool:
+    direct_d = _src_flop_d_pin(direct_bit, src_clock, module, bit_drivers, flop_domains)
+    if direct_d is None:
+        return False
+    drv = bit_drivers.get(inverted_bit)
+    if drv is None:
+        return False
+    cell_name, port, _ = drv
+    cell = module.cells.get(cell_name)
+    if cell is None or cell.type not in _NOT_TYPES or port != "Y":
+        return False
+    not_a = cell.connections.get("A", ())
+    if len(not_a) != 1 or not isinstance(not_a[0], int):
+        return False
+    delay_q = not_a[0]
+    delay_d = _src_flop_d_pin(delay_q, src_clock, module, bit_drivers, flop_domains)
+    if delay_d is None:
+        return False
+    # The delay flop's D must equal the direct flop's Q — that's what
+    # makes it the 1-cycle delayed version of the same signal.
+    return delay_d == direct_bit
+
+
+def _src_flop_d_pin(
+    q_bit: Bit,
+    src_clock: str,
+    module: Module,
+    bit_drivers: dict[Bit, tuple[str, str, int]],
+    flop_domains: dict[str, str | None],
+) -> Bit | None:
+    """If ``q_bit`` is the Q output of a single-bit flop in
+    ``src_clock``'s domain, return that flop's D[0]; otherwise None.
+    """
+    drv = bit_drivers.get(q_bit)
+    if drv is None:
+        return None
+    cell_name, port, _ = drv
+    if port != "Q":
+        return None
+    cell = module.cells.get(cell_name)
+    if cell is None or cell.type not in FF_CELL_TYPES:
+        return None
+    if flop_domains.get(cell_name) != src_clock:
+        return None
+    d_bits = cell.connections.get("D", ())
+    if len(d_bits) != 1:
+        return None
+    return d_bits[0]

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -16,6 +16,7 @@ from typing import Callable
 from rtl_buddy_cdc.domain import Crossing, assign_domains
 from rtl_buddy_cdc.flops import FF_CELL_TYPES, Flop, find_flops
 from rtl_buddy_cdc.netlist import Bit, Module
+from rtl_buddy_cdc.pulse import classify_d_pin_shape
 from rtl_buddy_cdc.sdc import UNCONSTRAINED_SENTINEL, ClockSpec
 
 
@@ -1543,6 +1544,78 @@ def check_cdc_011(
     return violations
 
 
+# Cummings's rule of thumb: the src pulse must be ≥ PULSE_FACTOR × dst
+# period for the dst flop to reliably capture it. 1.5× absorbs a
+# typical dst-clock phase + metastability resolution budget. Hard-coded
+# for v1 — a CLI flag is deferred (see #47 §7).
+PULSE_FACTOR = 1.5
+
+
+def check_cdc_009(
+    module: Module,
+    crossings: list[Crossing],
+    clock_spec: ClockSpec | None = None,
+    *,
+    ctx: _RuleContext | None = None,
+) -> list[Violation]:
+    """CDC-009: pulse-width risk on fast-to-slow data crossings.
+
+    Fires when a single-bit, flop-sourced crossing has:
+    - both clocks declared with periods in the SDC,
+    - ``src_period * PULSE_FACTOR < dst_period`` (src enough faster
+      that a 1-cycle pulse may slip between dst rising edges), and
+    - the src flop's D pin matches the edge-detector pattern
+      ``A & ~A_d`` (per :func:`rtl_buddy_cdc.pulse.classify_d_pin_shape`).
+
+    Severity is ``warning`` — single-bit pulse loss is a methodology
+    smell, not unconditional breakage. Pairs with CDC-001/002 (missing
+    sync). See issue #47 for the full design.
+    """
+    if ctx is None:
+        ctx = _build_context(module, clock_spec)
+    if clock_spec is None:
+        return []
+
+    out: list[Violation] = []
+    for c in crossings:
+        if c.src_clock == UNCONSTRAINED_SENTINEL:
+            continue
+        if c.src_flop is None or c.width != 1:
+            continue
+        src_clk = clock_spec.clocks.get(c.src_clock)
+        dst_clk = clock_spec.clocks.get(c.dst_clock)
+        if src_clk is None or dst_clk is None:
+            continue
+        if src_clk.period * PULSE_FACTOR >= dst_clk.period:
+            continue
+        d_bits = c.src_flop.cell.connections.get("D", ())
+        if len(d_bits) != 1:
+            continue
+        shape = classify_d_pin_shape(
+            d_bits[0], c.src_clock, module, ctx.bit_drivers, ctx.domains
+        )
+        if shape != "pulse":
+            continue
+        out.append(
+            Violation(
+                rule_id="CDC-009",
+                severity="warning",
+                message=(
+                    f"pulse-width risk on {c.src_flop.name!r} → "
+                    f"{c.dst_flop.name!r}: src clock {c.src_clock!r} "
+                    f"(period {src_clk.period}) is faster than dst "
+                    f"clock {c.dst_clock!r} (period {dst_clk.period}); "
+                    f"a 1-cycle src pulse may not be captured. "
+                    f"Consider a pulse-stretcher, toggle synchronizer, "
+                    f"or req/ack handshake."
+                ),
+                crossing=c,
+                cell_name=c.src_flop.cell.name,
+            )
+        )
+    return out
+
+
 RULES: dict[str, RuleFn] = {
     "CDC-001": check_cdc_001,
     "CDC-002": check_cdc_002,
@@ -1552,6 +1625,7 @@ RULES: dict[str, RuleFn] = {
     "CDC-006": check_cdc_006,
     "CDC-007": check_cdc_007,
     "CDC-008": check_cdc_008,
+    "CDC-009": check_cdc_009,
     "CDC-011": check_cdc_011,
 }
 

--- a/tests/fixtures/bad_pulse_width_fast_to_slow/bad_pulse_width_fast_to_slow.json
+++ b/tests/fixtures/bad_pulse_width_fast_to_slow/bad_pulse_width_fast_to_slow.json
@@ -1,0 +1,532 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_pulse_width_fast_to_slow": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "bad_pulse_width_fast_to_slow.sv:13.1-45.10"
+      },
+      "ports": {
+        "src_clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "dst_clk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "event_in": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "captured": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$and$bad_pulse_width_fast_to_slow.sv:30$4": {
+          "hide_name": 1,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:30.29-30.47"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 7 ],
+            "B": [ 8 ],
+            "Y": [ 9 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$12": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 10 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$17": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 11 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$22": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 12 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$27": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 13 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$7": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 14 ]
+          }
+        },
+        "$logic_not$bad_pulse_width_fast_to_slow.sv:23$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:23.13-23.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 15 ]
+          }
+        },
+        "$logic_not$bad_pulse_width_fast_to_slow.sv:36$6": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:36.13-36.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 16 ]
+          }
+        },
+        "$not$bad_pulse_width_fast_to_slow.sv:30$3": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:30.39-30.47"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 17 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$procdff$11": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_pulse_width_fast_to_slow.sv:35.5-43.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 18 ],
+            "Q": [ 6 ]
+          }
+        },
+        "$procdff$16": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_pulse_width_fast_to_slow.sv:35.5-43.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 19 ],
+            "Q": [ 18 ]
+          }
+        },
+        "$procdff$21": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_pulse_width_fast_to_slow.sv:22.5-32.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 5 ],
+            "Q": [ 7 ]
+          }
+        },
+        "$procdff$26": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_pulse_width_fast_to_slow.sv:22.5-32.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 7 ],
+            "Q": [ 17 ]
+          }
+        },
+        "$procdff$31": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_pulse_width_fast_to_slow.sv:22.5-32.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 9 ],
+            "Q": [ 19 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\captured[0:0]": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:35.5-43.8"
+          }
+        },
+        "$0\\captured_meta[0:0]": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:35.5-43.8"
+          }
+        },
+        "$0\\event_d[0:0]": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:22.5-32.8"
+          }
+        },
+        "$0\\event_q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:22.5-32.8"
+          }
+        },
+        "$0\\event_strobe[0:0]": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:22.5-32.8"
+          }
+        },
+        "$and$bad_pulse_width_fast_to_slow.sv:30$4_Y": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:30.29-30.47"
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$13": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$18": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$23": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$28": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$8": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$10": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$15": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$20": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$25": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$30": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$logic_not$bad_pulse_width_fast_to_slow.sv:23$2_Y": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:23.13-23.19"
+          }
+        },
+        "$logic_not$bad_pulse_width_fast_to_slow.sv:36$6_Y": {
+          "hide_name": 1,
+          "bits": [ 16 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:36.13-36.19"
+          }
+        },
+        "$not$bad_pulse_width_fast_to_slow.sv:30$3_Y": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:30.39-30.47"
+          }
+        },
+        "captured": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:18.18-18.26"
+          }
+        },
+        "captured_meta": {
+          "hide_name": 0,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:34.11-34.24"
+          }
+        },
+        "dst_clk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:15.18-15.25"
+          }
+        },
+        "event_d": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:21.20-21.27"
+          }
+        },
+        "event_in": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:17.18-17.26"
+          }
+        },
+        "event_q": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:21.11-21.18"
+          }
+        },
+        "event_strobe": {
+          "hide_name": 0,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:21.29-21.41"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:16.18-16.23"
+          }
+        },
+        "src_clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "bad_pulse_width_fast_to_slow.sv:14.18-14.25"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_pulse_width_fast_to_slow/bad_pulse_width_fast_to_slow.sdc
+++ b/tests/fixtures/bad_pulse_width_fast_to_slow/bad_pulse_width_fast_to_slow.sdc
@@ -1,0 +1,6 @@
+create_clock -name src_clk -period 2.0  [get_ports src_clk]
+create_clock -name dst_clk -period 20.0 [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# event_in is sourced from src_clk's domain externally — typed so
+# CDC-011 doesn't fire on the unconstrained port.
+set_input_delay -clock src_clk 0.5 [get_ports event_in]

--- a/tests/fixtures/bad_pulse_width_fast_to_slow/bad_pulse_width_fast_to_slow.sv
+++ b/tests/fixtures/bad_pulse_width_fast_to_slow/bad_pulse_width_fast_to_slow.sv
@@ -1,0 +1,45 @@
+// Negative-case fixture for CDC-009: a single-cycle src-domain pulse
+// is sampled by a 10x-slower dst clock. The pulse may land entirely
+// between two dst rising edges and be lost (data lost without
+// metastability ever entering the picture). CDC-009 must fire.
+//
+// Shape: event_q is the registered version of an external event;
+// event_d is its 1-cycle delay; event_strobe = event_q & ~event_d is
+// a 1-cycle pulse on event_q's rising edge. The pulse is sampled by
+// the dst-clock 2FF sync chain — which is structurally sound for
+// metastability (CDC-001/002 stay silent) but doesn't help with
+// pulse-width loss. See issue #47.
+
+module bad_pulse_width_fast_to_slow (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic event_in,
+    output logic captured
+);
+
+    logic event_q, event_d, event_strobe;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            event_q      <= 1'b0;
+            event_d      <= 1'b0;
+            event_strobe <= 1'b0;
+        end else begin
+            event_q      <= event_in;
+            event_d      <= event_q;
+            event_strobe <= event_q & ~event_d;
+        end
+    end
+
+    logic captured_meta;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            captured_meta <= 1'b0;
+            captured      <= 1'b0;
+        end else begin
+            captured_meta <= event_strobe;
+            captured      <= captured_meta;
+        end
+    end
+
+endmodule

--- a/tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.json
+++ b/tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.json
@@ -1,0 +1,712 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_pulse_width_handshake": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:9.1-51.10"
+      },
+      "ports": {
+        "src_clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "dst_clk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "req_in": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "captured": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$auto$proc_dff.cc:220:proc_dff$12": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 7 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$17": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$22": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 9 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$27": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 10 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$32": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 11 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$37": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 12 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$42": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 13 ]
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:20$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:20.13-20.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 14 ]
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:31$4": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:31.13-31.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 15 ]
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:38$6": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:38.13-38.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 16 ]
+          }
+        },
+        "$procdff$16": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:37.5-49.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 17 ],
+            "Q": [ 6 ]
+          }
+        },
+        "$procdff$21": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:37.5-49.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 17 ],
+            "Q": [ 18 ]
+          }
+        },
+        "$procdff$26": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:37.5-49.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 19 ],
+            "Q": [ 20 ]
+          }
+        },
+        "$procdff$31": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:37.5-49.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 20 ],
+            "Q": [ 17 ]
+          }
+        },
+        "$procdff$36": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:30.5-34.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 21 ],
+            "Q": [ 19 ]
+          }
+        },
+        "$procdff$41": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:19.5-27.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 18 ],
+            "Q": [ 22 ]
+          }
+        },
+        "$procdff$46": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:19.5-27.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 22 ],
+            "Q": [ 23 ]
+          }
+        },
+        "$procmux$10": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "full_case": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:32.18-32.24|tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:32.14-33.46"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 24 ],
+            "B": [ "1" ],
+            "S": [ 5 ],
+            "Y": [ 21 ]
+          }
+        },
+        "$procmux$7": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:33.18-33.26|tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:33.14-33.46"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 19 ],
+            "B": [ "0" ],
+            "S": [ 23 ],
+            "Y": [ 24 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\ack_meta[0:0]": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:19.5-27.8"
+          }
+        },
+        "$0\\ack_sync[0:0]": {
+          "hide_name": 1,
+          "bits": [ 22 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:19.5-27.8"
+          }
+        },
+        "$0\\captured[0:0]": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:37.5-49.8"
+          }
+        },
+        "$0\\dst_ack[0:0]": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:37.5-49.8"
+          }
+        },
+        "$0\\req_held[0:0]": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:30.5-34.8"
+          }
+        },
+        "$0\\req_meta[0:0]": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:37.5-49.8"
+          }
+        },
+        "$0\\req_sync[0:0]": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:37.5-49.8"
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$13": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$18": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$23": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$28": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$33": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$38": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$43": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$15": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$20": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$25": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$30": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$35": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$40": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$45": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:20$2_Y": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:20.13-20.19"
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:31$4_Y": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:31.13-31.19"
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:38$6_Y": {
+          "hide_name": 1,
+          "bits": [ 16 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:38.13-38.19"
+          }
+        },
+        "$procmux$10_Y": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$procmux$11_CMP": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+          }
+        },
+        "$procmux$7_Y": {
+          "hide_name": 1,
+          "bits": [ 24 ],
+          "attributes": {
+          }
+        },
+        "$procmux$8_CMP": {
+          "hide_name": 1,
+          "bits": [ 23 ],
+          "attributes": {
+          }
+        },
+        "ack_meta": {
+          "hide_name": 0,
+          "bits": [ 22 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:17.11-17.19"
+          }
+        },
+        "ack_sync": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:17.21-17.29"
+          }
+        },
+        "captured": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:14.18-14.26"
+          }
+        },
+        "dst_ack": {
+          "hide_name": 0,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:18.11-18.18"
+          }
+        },
+        "dst_clk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:11.18-11.25"
+          }
+        },
+        "req_held": {
+          "hide_name": 0,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:29.11-29.19"
+          }
+        },
+        "req_in": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:13.18-13.24"
+          }
+        },
+        "req_meta": {
+          "hide_name": 0,
+          "bits": [ 20 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:36.11-36.19"
+          }
+        },
+        "req_sync": {
+          "hide_name": 0,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:36.21-36.29"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:12.18-12.23"
+          }
+        },
+        "src_clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv:10.18-10.25"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sdc
+++ b/tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sdc
@@ -1,0 +1,4 @@
+create_clock -name src_clk -period 2.0  [get_ports src_clk]
+create_clock -name dst_clk -period 20.0 [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 0.5 [get_ports req_in]

--- a/tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv
+++ b/tests/fixtures/good_pulse_width_handshake/good_pulse_width_handshake.sv
@@ -1,0 +1,51 @@
+// Positive-case fixture for CDC-009: the textbook req/ack handshake
+// from issue #47 §5 idiom 3. The src request flop is held high until
+// the dst-side ack returns (synced back through a 2FF chain). Because
+// the value is held across many src cycles, dst always sees a stable
+// signal — no pulse-loss possible. CDC-009 must NOT fire (the src
+// flop's D pin is a priority-encoded $mux nest, not an ``A & ~A_d``
+// edge-detector).
+
+module good_pulse_width_handshake (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic req_in,
+    output logic captured
+);
+
+    logic ack_meta, ack_sync;
+    logic dst_ack;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            ack_meta <= 1'b0;
+            ack_sync <= 1'b0;
+        end else begin
+            ack_meta <= dst_ack;
+            ack_sync <= ack_meta;
+        end
+    end
+
+    logic req_held;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n)         req_held <= 1'b0;
+        else if (req_in)    req_held <= 1'b1;
+        else if (ack_sync)  req_held <= 1'b0;
+    end
+
+    logic req_meta, req_sync;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            req_meta <= 1'b0;
+            req_sync <= 1'b0;
+            dst_ack  <= 1'b0;
+            captured <= 1'b0;
+        end else begin
+            req_meta <= req_held;
+            req_sync <= req_meta;
+            dst_ack  <= req_sync;
+            captured <= req_sync;
+        end
+    end
+
+endmodule

--- a/tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.json
+++ b/tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.json
@@ -1,0 +1,818 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_pulse_width_stretched": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:9.1-53.10"
+      },
+      "ports": {
+        "src_clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "dst_clk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "event_in": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "captured": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$and$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:27$4": {
+          "hide_name": 1,
+          "type": "$and",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:27.26-27.44"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 7 ],
+            "B": [ 8 ],
+            "Y": [ 9 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$19": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 10 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$24": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 11 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$29": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 12 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$34": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 13 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$39": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 14 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$44": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 15 ]
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:19$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:19.13-19.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 16 ]
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:31$6": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:31.13-31.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 17 ]
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:38$10": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:38.13-38.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 18 ]
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:44$13": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:44.13-44.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 19 ]
+          }
+        },
+        "$ne$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33$7": {
+          "hide_name": 1,
+          "type": "$reduce_bool",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33.18-33.29"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 20, 21, 22, 23 ],
+            "Y": [ 24 ]
+          }
+        },
+        "$ne$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:39$11": {
+          "hide_name": 1,
+          "type": "$reduce_bool",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:39.42-39.53"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 20, 21, 22, 23 ],
+            "Y": [ 25 ]
+          }
+        },
+        "$not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:27$3": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:27.36-27.44"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 26 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$procdff$23": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:43.5-51.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 27 ],
+            "Q": [ 6 ]
+          }
+        },
+        "$procdff$28": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:43.5-51.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 28 ],
+            "Q": [ 27 ]
+          }
+        },
+        "$procdff$33": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:37.5-40.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 25 ],
+            "Q": [ 28 ]
+          }
+        },
+        "$procdff$38": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0000",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:30.5-34.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 29, 30, 31, 32 ],
+            "Q": [ 20, 21, 22, 23 ]
+          }
+        },
+        "$procdff$43": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:18.5-26.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 5 ],
+            "Q": [ 7 ]
+          }
+        },
+        "$procdff$48": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:18.5-26.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 7 ],
+            "Q": [ 26 ]
+          }
+        },
+        "$procmux$14": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33.18-33.29|tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33.14-33.51"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 20, 21, 22, 23 ],
+            "B": [ 33, 34, 35, 36 ],
+            "S": [ 24 ],
+            "Y": [ 37, 38, 39, 40 ]
+          }
+        },
+        "$procmux$17": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "full_case": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:32.18-32.29|tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:32.14-33.51"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 37, 38, 39, 40 ],
+            "B": [ "1", "1", "1", "1" ],
+            "S": [ 9 ],
+            "Y": [ 29, 30, 31, 32 ]
+          }
+        },
+        "$sub$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33$8": {
+          "hide_name": 1,
+          "type": "$sub",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000100",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33.40-33.50"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 20, 21, 22, 23 ],
+            "B": [ "1", "0", "0", "0" ],
+            "Y": [ 33, 34, 35, 36 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\captured[0:0]": {
+          "hide_name": 1,
+          "bits": [ 27 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:43.5-51.8"
+          }
+        },
+        "$0\\cnt[3:0]": {
+          "hide_name": 1,
+          "bits": [ 29, 30, 31, 32 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:30.5-34.8"
+          }
+        },
+        "$0\\event_d[0:0]": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:18.5-26.8"
+          }
+        },
+        "$0\\event_q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:18.5-26.8"
+          }
+        },
+        "$0\\stretched_strobe[0:0]": {
+          "hide_name": 1,
+          "bits": [ 25 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:37.5-40.8"
+          }
+        },
+        "$0\\strobe_meta[0:0]": {
+          "hide_name": 1,
+          "bits": [ 28 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:43.5-51.8"
+          }
+        },
+        "$and$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:27$4_Y": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:27.26-27.44"
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$20": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$25": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$30": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$35": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$40": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$45": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$22": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$27": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$32": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$37": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$42": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$47": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:19$2_Y": {
+          "hide_name": 1,
+          "bits": [ 16 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:19.13-19.19"
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:31$6_Y": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:31.13-31.19"
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:38$10_Y": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:38.13-38.19"
+          }
+        },
+        "$logic_not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:44$13_Y": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:44.13-44.19"
+          }
+        },
+        "$ne$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33$7_Y": {
+          "hide_name": 1,
+          "bits": [ 24 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33.18-33.29"
+          }
+        },
+        "$ne$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:39$11_Y": {
+          "hide_name": 1,
+          "bits": [ 25 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:39.42-39.53"
+          }
+        },
+        "$not$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:27$3_Y": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:27.36-27.44"
+          }
+        },
+        "$procmux$14_Y": {
+          "hide_name": 1,
+          "bits": [ 37, 38, 39, 40 ],
+          "attributes": {
+          }
+        },
+        "$procmux$15_CMP": {
+          "hide_name": 1,
+          "bits": [ 24 ],
+          "attributes": {
+          }
+        },
+        "$procmux$17_Y": {
+          "hide_name": 1,
+          "bits": [ 29, 30, 31, 32 ],
+          "attributes": {
+          }
+        },
+        "$procmux$18_CMP": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$sub$tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33$8_Y": {
+          "hide_name": 1,
+          "bits": [ 33, 34, 35, 36 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:33.40-33.50"
+          }
+        },
+        "captured": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:14.18-14.26"
+          }
+        },
+        "cnt": {
+          "hide_name": 0,
+          "bits": [ 20, 21, 22, 23 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:29.17-29.20"
+          }
+        },
+        "dst_clk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:11.18-11.25"
+          }
+        },
+        "event_d": {
+          "hide_name": 0,
+          "bits": [ 26 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:17.20-17.27"
+          }
+        },
+        "event_in": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:13.18-13.26"
+          }
+        },
+        "event_q": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:17.11-17.18"
+          }
+        },
+        "rising_edge": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:17.29-17.40"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:12.18-12.23"
+          }
+        },
+        "src_clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:10.18-10.25"
+          }
+        },
+        "stretched_strobe": {
+          "hide_name": 0,
+          "bits": [ 28 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:36.11-36.27"
+          }
+        },
+        "strobe_meta": {
+          "hide_name": 0,
+          "bits": [ 27 ],
+          "attributes": {
+            "src": "tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv:42.11-42.22"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sdc
+++ b/tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sdc
@@ -1,0 +1,4 @@
+create_clock -name src_clk -period 2.0  [get_ports src_clk]
+create_clock -name dst_clk -period 20.0 [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 0.5 [get_ports event_in]

--- a/tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv
+++ b/tests/fixtures/good_pulse_width_stretched/good_pulse_width_stretched.sv
@@ -1,0 +1,53 @@
+// Positive-case fixture for CDC-009: the textbook pulse-stretcher
+// fix from issue #47 §5 idiom 1. A 4-bit countdown counter widens the
+// src-domain strobe to 16 src cycles (~32 ns at 500 MHz) — comfortably
+// wider than the 20 ns dst period, so dst always captures it. CDC-009
+// must NOT fire (the src flop's D pin is ``cnt != 0``, which yosys
+// synthesises as a reduction, not the ``A & ~A_d`` edge-detector
+// pattern the rule keys on).
+
+module good_pulse_width_stretched (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic event_in,
+    output logic captured
+);
+
+    logic event_q, event_d, rising_edge;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            event_q <= 1'b0;
+            event_d <= 1'b0;
+        end else begin
+            event_q <= event_in;
+            event_d <= event_q;
+        end
+    end
+    assign rising_edge = event_q & ~event_d;
+
+    logic [3:0] cnt;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n)             cnt <= 4'd0;
+        else if (rising_edge)   cnt <= 4'd15;
+        else if (cnt != 4'd0)   cnt <= cnt - 4'd1;
+    end
+
+    logic stretched_strobe;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) stretched_strobe <= 1'b0;
+        else        stretched_strobe <= (cnt != 4'd0);
+    end
+
+    logic strobe_meta;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            strobe_meta <= 1'b0;
+            captured    <= 1'b0;
+        end else begin
+            strobe_meta <= stretched_strobe;
+            captured    <= strobe_meta;
+        end
+    end
+
+endmodule

--- a/tests/test_bad_pulse_width_fast_to_slow.py
+++ b/tests/test_bad_pulse_width_fast_to_slow.py
@@ -1,0 +1,74 @@
+"""Negative-case fixture for CDC-009: 1-cycle src pulse → slower dst clock.
+
+Issue #47 (design), implemented in #101. The src flop's D pin is an
+edge-detector ``event_q & ~event_d`` whose Q is a single src cycle
+wide; the dst clock is 10× slower, so the pulse may land entirely
+between dst rising edges. CDC-009 must fire as a single warning on
+this crossing; no other rule should fire (the dst-side 2FF sync chain
+keeps CDC-001/002 silent, and width=1 keeps CDC-004 silent).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_pulse_width_fast_to_slow"
+JSON = FIX_DIR / "bad_pulse_width_fast_to_slow.json"
+SDC = FIX_DIR / "bad_pulse_width_fast_to_slow.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    return module, crossings, spec
+
+
+def test_single_async_crossing(context) -> None:
+    """One 1-bit src→dst crossing (the event_strobe → captured_meta path)."""
+    _module, crossings, _spec = context
+    assert len(crossings) == 1
+    c = crossings[0]
+    assert c.width == 1
+    assert c.src_flop is not None
+    assert c.src_clock == "src_clk"
+    assert c.dst_clock == "dst_clk"
+
+
+def test_cdc_009_fires_once_at_warning(context) -> None:
+    module, crossings, spec = context
+    violations = run_all_rules(module, crossings, spec)
+    cdc_009 = [v for v in violations if v.rule_id == "CDC-009"]
+    assert len(cdc_009) == 1
+    v = cdc_009[0]
+    assert v.severity == "warning"
+    assert "pulse-width risk" in v.message
+    assert "'src_clk'" in v.message
+    assert "'dst_clk'" in v.message
+    # Render unit on both periods so the user can see the ratio.
+    assert "period 2.0" in v.message
+    assert "period 20.0" in v.message
+    # The fix advice nudges toward the three idioms documented in #47 §5.
+    assert "pulse-stretcher" in v.message
+    assert "toggle synchronizer" in v.message
+    assert "handshake" in v.message
+
+
+def test_no_other_rules_fire(context) -> None:
+    """Only CDC-009 should fire: the dst 2FF chain satisfies CDC-001/002,
+    width=1 dodges CDC-004, no comb-before-sync, no glitchy source."""
+    module, crossings, spec = context
+    violations = run_all_rules(module, crossings, spec)
+    rule_ids = {v.rule_id for v in violations}
+    assert rule_ids == {"CDC-009"}

--- a/tests/test_good_fixtures.py
+++ b/tests/test_good_fixtures.py
@@ -92,6 +92,21 @@ GOOD_FIXTURES = [
     # _muxed_clock_typed: port typed to whichever mux side
     # trace_clock_root picks → same domain → 0 async crossings.
     ("good_unconstrained_input_muxed_clock_typed", 0),
+    # CDC-009 (#47/#101/#102) positive shapes: textbook fixes for the
+    # fast-to-slow pulse-loss case.
+    #
+    # _stretched: a 4-bit countdown counter widens the src strobe to
+    # ~16 src cycles before it crosses; the src flop's D is the
+    # counter's "non-zero" reduction, not the edge-detector pattern,
+    # so CDC-009 stays silent. 1 async crossing (stretched_strobe →
+    # strobe_meta).
+    ("good_pulse_width_stretched", 1),
+    # _handshake: req/ack handshake — req_held is set on req_in and
+    # cleared only by a synced-back ack from dst, so the src flop
+    # holds its value across many cycles. D is a priority-encoded
+    # $mux nest, not an $and edge-detector. 2 async crossings (the
+    # synced-back ack and the held request).
+    ("good_pulse_width_handshake", 2),
 ]
 
 


### PR DESCRIPTION
## Summary

Implements CDC-009 across all three follow-ups spawned from #47:

- **#101 (detection)** — new helper `rtl_buddy_cdc.pulse.classify_d_pin_shape` recognises the edge-detector pattern `A & ~A_d` on a src flop's D pin. New rule `check_cdc_009` fires `warning` when the src flop's D matches, the src clock is at least 1.5× faster than the dst clock per SDC, and the crossing is flop-sourced + single-bit + async. Sentinel-skips CDC-011's `UNCONSTRAINED_SENTINEL`. Registered in `RULES`.
- **#102 (fixtures)** — `bad_pulse_width_fast_to_slow` (1 crossing, only CDC-009 fires), `good_pulse_width_stretched` (counter-based pulse stretcher, silent), `good_pulse_width_handshake` (req/ack with synced-back ack, silent). Yosys JSONs committed per AGENTS.md. New `test_bad_pulse_width_fast_to_slow.py` asserts CDC-009 fires exactly once with the documented severity / message anchors; both good fixtures registered in `GOOD_FIXTURES`.
- **#103 (integration)** — README CDC-009 row + roadmap tick; CHANGELOG `[Unreleased]` entry.

**Closes #101, #102, #103.**

## Deviation from #47 §2

The design proposal's §2 described the detection target as a `$dffe` whose D feeds back from Q via a `$mux` keyed on EN. That shape actually produces a *latched* value on Q (the flop holds whatever was captured when EN last pulsed), not a single-cycle pulse — so it wouldn't be the fast-to-slow data-loss case. The textbook case (Cummings SNUG 2008 §4.5) is structurally a plain `$dff` (or `$dffe` with always-on EN) whose D pin is the edge-detector output `A & ~A_d`. That's what `classify_d_pin_shape` matches. See `pulse.py`'s module docstring. The PR proceeds with the corrected pattern; a comment on the (closed) #47 documents the correction for the historical record.

## Deferred

- **`pyproject.toml [project].version` + `reporter.TOOL_VERSION` bump** — per AGENTS.md (\"Commit / branch / release conventions\"), version bumps happen \"when cutting a release\", not per-feature. The CHANGELOG entry lives under `[Unreleased]` until a release-cut PR.
- **Project-template regression sweep** (#103 acceptance criterion) — cross-repo work touching `rtl-buddy-project-template`'s `dev/local-rtl-buddy` worktree, not in scope here. Defer to a separate change. The false-negative bias means any regression in the template suite would be silent (no new findings), so this PR is safe to merge first and validate the template sweep afterwards.

## Test plan

- [x] `uv run pytest -q` — 305 passed, 2 skipped (was 300 before; +3 from the new bad-fixture test, +2 from the new good-fixture parameterisations).
- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run mypy` clean.
- [ ] CI will run on push (touches `src/**/*.py` and `tests/**/*.py`, both in `lint.yml` / `test.yml` path filters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)