### PR TITLE
feat(reset): structural reset-synchronizer recognizer (stacked on #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Reset-synchronizer recognizer** (second slice of #107).
+  `rtl_buddy_cdc.reset_domain.find_reset_synchronizers(module,
+  clock_domains, *, min_depth=2)` returns the set of flop cell names
+  participating in a textbook async-assert / sync-deassert reset
+  chain: ≥`min_depth` same-clock flops sharing the same async-reset
+  source, chained Q→D, whose head flop's D pin is a constant. The
+  load-bearing distinction vs. the naive "same ARST + same clock"
+  walk is that data-path register chains which *happen* to share an
+  upstream reset are correctly rejected — the head's D must be a
+  constant. No rule consumes this yet; subsequent RDC rules (polarity
+  mismatch, comb-driven reset) will skip recognised synchronizers to
+  avoid false positives on legitimate ones.
 - **`reset_domain` analysis module — foundation pass** (first slice of
   #107). New `src/rtl_buddy_cdc/reset_domain.py` exposing
   `ResetSource`, `ResetDomain`, and `assign_reset_domains(module)` —

--- a/src/rtl_buddy_cdc/reset_domain.py
+++ b/src/rtl_buddy_cdc/reset_domain.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-from rtl_buddy_cdc.flops import find_flops
+from rtl_buddy_cdc.flops import Flop, find_flops
 from rtl_buddy_cdc.netlist import Bit, Module
 
 # Cell types with an asynchronous reset pin. Each maps to the pin name
@@ -197,6 +197,123 @@ def _classify_reset_source(
     if out_port == "Q":
         return (cell_name, "inferred")
     return ("", "comb")
+
+
+def find_reset_synchronizers(
+    module: Module,
+    clock_domains: dict[str, str | None],
+    *,
+    min_depth: int = 2,
+) -> set[str]:
+    """Identify flop cells that participate in a reset-synchronizer chain.
+
+    The canonical reset-synchronizer is the textbook async-assert /
+    sync-deassert pattern: N≥2 flops in the destination clock domain
+    sharing the same async reset, chained Q→D, with the chain's head
+    flop's ``D`` tied to a constant (typically ``1'b1`` for an active-
+    low reset, ``1'b0`` for an active-high reset). The synchronizer's
+    last flop's ``Q`` is the synchronised reset that downstream
+    consumers connect to their own ``ARST``.
+
+    Returns the set of cell names of *every* flop participating in
+    such a chain (head, tail, and anything in between) — RDC-002
+    onward will skip these flops to avoid false-positive findings on
+    legitimate synchronizers.
+
+    A flop is recognised iff:
+
+    * it is async-reset (has an ``ARST`` / ``ALOAD`` / ``CLR`` pin
+      per :data:`_ASYNC_RESET_PINS`),
+    * the chain walking backward through its ``D`` pin (following
+      same-clock, same-reset-source flops only) reaches a flop whose
+      ``D`` is a constant within ``min_depth - 1`` hops, and
+    * the chain length (from head constant to tail) is at least
+      ``min_depth`` flops.
+
+    ``clock_domains`` is the per-flop clock-domain map that the rule
+    pack already builds in ``_RuleContext.domains`` — passed in to
+    avoid re-running :func:`rtl_buddy_cdc.domain.assign_domains`. The
+    recogniser tolerates ``None`` entries (untraceable clock); those
+    flops never match because their domain cannot be compared.
+    """
+    if min_depth < 1:
+        raise ValueError("min_depth must be >= 1")
+    domains = assign_reset_domains(module)
+    flop_by_name = {f.cell.name: f for f in find_flops(module)}
+    bit_drivers = _bit_drivers(module)
+    out: set[str] = set()
+
+    for name, rd in domains.items():
+        if rd.reset is None or rd.reset.type != "async":
+            continue
+        chain = _trace_reset_sync_chain(
+            name,
+            flop_by_name,
+            domains,
+            clock_domains,
+            bit_drivers,
+            max_depth=min_depth + 4,
+        )
+        if len(chain) >= min_depth:
+            out.update(chain)
+    return out
+
+
+def _trace_reset_sync_chain(
+    start: str,
+    flop_by_name: dict[str, Flop],
+    reset_domains: dict[str, ResetDomain],
+    clock_domains: dict[str, str | None],
+    bit_drivers: dict[Bit, tuple[str, str]],
+    *,
+    max_depth: int,
+) -> list[str]:
+    """Walk Q→D back from ``start``; return the chain iff its head is constant-fed.
+
+    The returned chain includes ``start`` (as the tail) and every
+    intermediate flop up to the constant-fed head. If the walk
+    terminates on anything other than a constant — a foreign-domain
+    flop, a port, a multi-bit ``D``, a combinational signal, depth
+    exhaustion — the chain is **not** a reset synchroniser and an
+    empty list is returned. This is the load-bearing distinction:
+    without it, any 2-flop ARST-sharing chain in the same clock domain
+    (including data-path register chains that happen to share a
+    reset) would be mis-identified as a synchroniser."""
+    chain = [start]
+    cur_name = start
+    cur_rd = reset_domains[cur_name]
+    cur_clk = clock_domains.get(cur_name)
+    if cur_clk is None or cur_rd.reset is None:
+        return []
+    reset_signature = (cur_rd.reset.name, cur_rd.reset.source)
+
+    for _ in range(max_depth):
+        cur_flop = flop_by_name[cur_name]
+        d_bits = cur_flop.d
+        if len(d_bits) != 1:
+            return []  # Multi-bit chains aren't the reset-sync shape.
+        d_bit = d_bits[0]
+        if not isinstance(d_bit, int):
+            # D is a constant — chain head found. Return the chain as
+            # collected so far; the constant itself isn't a flop.
+            return chain
+        drv = bit_drivers.get(d_bit)
+        if drv is None:
+            return []  # Port- or constant-net-fed D isn't the recogniser's shape.
+        drv_name, drv_port = drv
+        if drv_port != "Q" or drv_name not in flop_by_name:
+            return []
+        drv_rd = reset_domains.get(drv_name)
+        drv_clk = clock_domains.get(drv_name)
+        if drv_rd is None or drv_rd.reset is None or drv_clk is None:
+            return []
+        if drv_clk != cur_clk:
+            return []
+        if (drv_rd.reset.name, drv_rd.reset.source) != reset_signature:
+            return []
+        chain.append(drv_name)
+        cur_name = drv_name
+    return []
 
 
 def _polarity_from_param(raw: str) -> ResetPolarity:

--- a/tests/test_reset_domain.py
+++ b/tests/test_reset_domain.py
@@ -13,9 +13,11 @@ from pathlib import Path
 import pytest
 
 from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc.domain import assign_domains
 from rtl_buddy_cdc.reset_domain import (
     ResetSource,
     assign_reset_domains,
+    find_reset_synchronizers,
 )
 
 FIX_ROOT = Path(__file__).parent / "fixtures"
@@ -92,6 +94,60 @@ def test_no_reset_pin_yields_none() -> None:
     has_reset = sum(1 for rd in domains.values() if rd.reset is not None)
     no_reset = sum(1 for rd in domains.values() if rd.reset is None)
     assert has_reset + no_reset == len(domains)
+
+
+def test_recognizer_finds_good_reset_sync_chain() -> None:
+    """The good-reset-sync fixture's 2FF chain (``dst_rst_meta`` and
+    ``dst_rst_n_sync``) must be recognised as a reset synchronizer.
+
+    The data-path flops (``src_q``, ``sync_meta``, ``sync_q``) are
+    *consumers* of the synchronised reset, not part of the synchronizer
+    chain itself — they must NOT be flagged. The chain head
+    (``dst_rst_meta``)'s ``D`` is tied to ``1'b1``; the tail
+    (``dst_rst_n_sync``)'s ``D`` is the head's ``Q``.
+    """
+    module = _load("good_reset_sync")
+    flop_clocks = {fd.flop.cell.name: fd.clock for fd in assign_domains(module)}
+    syncs = find_reset_synchronizers(module, flop_clocks)
+    names = {name.split(".")[-1].lstrip("\\") for name in syncs}
+    # The chain head and tail (and only those) — the fixture uses
+    # Yosys auto-names (``$procdff$N``) so we filter by membership and
+    # count rather than asserting on the names.
+    assert len(syncs) == 2, f"expected 2 sync stages, got {sorted(syncs)}"
+    # Sanity check that the recognised flops are exactly the ones whose
+    # D pin is either a constant (chain head) or another recognised
+    # sync stage's Q (chain tail).
+    assert all("$procdff" in n or "rst" in n for n in names), names
+
+
+def test_recognizer_skips_bad_reset_crossing() -> None:
+    """``bad_reset_crossing`` has no constant-fed reset chain at all
+    (``src_kill_n``'s D is ``~kill_req``, ``dst_q``'s D is a data
+    port). The recogniser must return an empty set so RDC-001 cannot
+    misclassify either flop as a synchroniser and let the crossing
+    through."""
+    module = _load("bad_reset_crossing")
+    flop_clocks = {fd.flop.cell.name: fd.clock for fd in assign_domains(module)}
+    syncs = find_reset_synchronizers(module, flop_clocks)
+    assert syncs == set()
+
+
+def test_recognizer_min_depth_validation() -> None:
+    module = _load("good_reset_sync")
+    flop_clocks = {fd.flop.cell.name: fd.clock for fd in assign_domains(module)}
+    with pytest.raises(ValueError):
+        find_reset_synchronizers(module, flop_clocks, min_depth=0)
+
+
+def test_recognizer_min_depth_three_drops_the_2ff_chain() -> None:
+    """Bumping ``min_depth`` past the chain length excludes it.
+
+    Mirrors how the rule pack can let projects raise the bar (analogous
+    to CDC-002's ``required_depth``). At depth=3 the good fixture's
+    2FF chain no longer qualifies."""
+    module = _load("good_reset_sync")
+    flop_clocks = {fd.flop.cell.name: fd.clock for fd in assign_domains(module)}
+    assert find_reset_synchronizers(module, flop_clocks, min_depth=3) == set()
 
 
 def test_dataclasses_frozen() -> None:


### PR DESCRIPTION
## Summary

Second slice of #107. Stacks on PR #110 (the foundation module).
Adds `find_reset_synchronizers(module, clock_domains, *, min_depth=2)`
to `reset_domain.py` — the structural detector RDC-002 (polarity
mismatch) and RDC-004 (comb-driven reset) will use to suppress false
positives on legitimate reset synchronizers.

**Stacked on #110** — `gh pr create --base feat/reset-domain-foundation`.
After #110 merges, this PR will auto-rebase against `main`. Merge
order: #110 first.

## What ships

- `find_reset_synchronizers(module, clock_domains, *, min_depth=2)`:
  returns the set of flop cell names in a textbook async-assert /
  sync-deassert chain: ≥`min_depth` same-clock flops sharing the
  same async-reset source, chained Q→D, whose chain-head flop's D
  pin is a constant. Returns chain members (head + tail + any
  intermediate flops).

- Four new tests in `test_reset_domain.py`:
  - Recogniser identifies the 2FF chain in `good_reset_sync` and
    explicitly skips the data-path consumer flops (`sync_meta`,
    `sync_q`) which share the synchronised reset but are not part
    of the synchroniser itself.
  - Recogniser returns empty on `bad_reset_crossing` (no
    constant-fed chain).
  - `min_depth=0` raises `ValueError` (parallel to CDC-002's
    `required_depth` guard).
  - `min_depth=3` excludes the 2FF chain (project-tunable bar for
    high-MTBF designs).

## The load-bearing design choice

The recogniser returns an empty chain unless the walk **terminates
on a constant `D` pin**. A naive "same-clock, same-ARST" walk would
mis-identify any register chain that happens to share an upstream
reset as a synchroniser. The `test_recognizer_finds_good_reset_sync_chain`
test pins exactly this case: `sync_meta` and `sync_q` in the good
fixture share the synchronised `dst_rst_n_sync` reset and are
chained Q→D in the same clock domain, but their chain head (`src_q`
through the cross-domain crossing) is a *data* signal, not a
constant — so they must NOT be recognised as a synchroniser.

## No consumer yet

The recogniser isn't called by any rule in this PR. Adding it now
keeps the foundation module self-contained for subsequent rule PRs
(each RDC-NNN can call the recogniser without re-implementing the
detection). The existing CDC-007 already gets the right answer via
its same-domain-driver check; rerooting it (and the eventual rename
to RDC-001) is a separate cross-repo PR.

## Verification

```
uv run ruff check              # all checks passed
uv run ruff format --check     # 69 files
uv run mypy                    # success, no issues in 16 source files
uv run pytest -q               # 325 passed, 2 skipped (4 added)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)