### PR TITLE
feat(rules): (* reset_sync *) SV attribute escape hatch (closes #115 partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`(* reset_sync *)` SV attribute escape hatch** (#115, eighth
+  instalment of #107). Parallel to the existing
+  ``(* cdc_sync *)`` / ``(* cdc_gray *)`` annotations. Marks a flop
+  as a vetted reset-synchroniser stage even when the structural
+  recogniser in ``rtl_buddy_cdc.reset_domain.find_reset_synchronizers``
+  wouldn't match — the structural pass deliberately requires a
+  constant-fed chain head, so chains whose head's D is fed by an
+  upstream signal (rather than a literal constant) are otherwise
+  missed. RDC-002 / RDC-004 / RDC-005 skip flops marked with this
+  attribute and also skip consumers whose ARST is driven by a marked
+  flop's Q (matching the user's intent that "this reset arrives
+  cleanly downstream"). New helper
+  ``rtl_buddy_cdc.rules.user_reset_sync_flop_names(module)`` mirrors
+  the existing ``user_sync_flop_names`` shape. New optional
+  ``extra_synchronizers`` parameter on ``find_reset_synchronizers``
+  folds user-marked flops into the recogniser's output set.
+  Accepted aliases: ``reset_sync``, ``reset_synchronizer``. Coverage
+  fixture ``marked_reset_sync`` with a dedicated test module
+  (``test_marked_reset_sync.py``) pinning the attribute discovery,
+  recogniser overlay, and end-to-end RDC-002 suppression. The
+  companion ``(* reset_polarity *)`` attribute from the #115 scope
+  is deferred — no rule consumes source-side port polarity today,
+  so it would be dead code without a consumer rule extension.
 - **RDC-005 — Multiple reset sources converging without muxing**
   (fourth and final sub-PR of #114, seventh instalment of #107).
   New rule: a flop's async reset pin is the output of comb logic

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python-based open-source CDC (Clock Domain Crossing) linting tool for RTL design
 
 ## Status
 
-Usable on IP-block-sized designs. Fourteen rules implemented (CDC-001 through CDC-006, CDC-008, CDC-009, CDC-011, plus the RDC family RDC-001 through RDC-005 — RDC-001 is the reset-crossing rule formerly known as CDC-007), three output formats (text / JSON / SARIF), waiver-file suppression, `(* cdc_sync *)` / `(* cdc_gray *)` SV attributes for user-vetted synchronizers and gray-coded buses, structural gray-code recognition for CDC-004, and `rb cdc` / `rb cdc-regression` integration in rtl-buddy. Two elaboration frontends at parity on the regression fixture suite — Yosys (default) and slang (opt-in via the `[slang]` extra). Tested against paired *bad / good* RTL fixtures for each rule.
+Usable on IP-block-sized designs. Fourteen rules implemented (CDC-001 through CDC-006, CDC-008, CDC-009, CDC-011, plus the RDC family RDC-001 through RDC-005 — RDC-001 is the reset-crossing rule formerly known as CDC-007), three output formats (text / JSON / SARIF), waiver-file suppression, `(* cdc_sync *)` / `(* cdc_gray *)` / `(* reset_sync *)` SV attributes for user-vetted synchronizers, gray-coded buses, and reset-synchroniser stages, structural gray-code recognition for CDC-004, and `rb cdc` / `rb cdc-regression` integration in rtl-buddy. Two elaboration frontends at parity on the regression fixture suite — Yosys (default) and slang (opt-in via the `[slang]` extra). Tested against paired *bad / good* RTL fixtures for each rule.
 
 Known gaps and roadmap items are tracked at the end of this README.
 
@@ -197,11 +197,15 @@ Mark a flop as a user-vetted synchronizer first stage by attaching an attribute 
 (* async_reg = "TRUE" *) logic dst_q;   // Vivado-compatible alias
 (* cdc_gray *) logic [N-1:0] src_bus;   // source bus is gray-coded
 (* gray_code *) logic [N-1:0] src_bus;  // alias
+(* reset_sync *) logic rst_sync;        // vetted reset-synchroniser stage
+(* reset_synchronizer *) logic rst_sync;// alias
 ```
 
 `cdc_sync` / aliases mark a flop as a vetted synchronizer first stage — skipped by CDC-001, -002, -003, and -006. CDC-004 (bus crossings) and CDC-005 (reconvergence) still fire — those failure modes don't depend on individual sync-shape correctness.
 
 `cdc_gray` / `gray_code` mark a source bus as gray-coded so CDC-004 accepts it as a safe multi-bit crossing without needing the structural detector to find the canonical XOR-shift shape.
+
+`reset_sync` / `reset_synchronizer` mark a flop as a vetted reset-synchroniser stage — the structural recogniser in `rtl_buddy_cdc.reset_domain.find_reset_synchronizers` deliberately requires a constant-fed chain head, so chains whose head's D is fed by an upstream signal (rather than a literal constant) would normally be missed. RDC-002 / RDC-004 / RDC-005 skip flops marked with this attribute and skip consumers whose ARST is driven by a marked flop's Q.
 
 Yosys preserves SV attributes on the netname rather than the cell, so the analyzer maps tagged bits back to the originating flop's `Q` pin.
 

--- a/src/rtl_buddy_cdc/reset_domain.py
+++ b/src/rtl_buddy_cdc/reset_domain.py
@@ -204,6 +204,7 @@ def find_reset_synchronizers(
     clock_domains: dict[str, str | None],
     *,
     min_depth: int = 2,
+    extra_synchronizers: set[str] | None = None,
 ) -> set[str]:
     """Identify flop cells that participate in a reset-synchronizer chain.
 
@@ -235,13 +236,22 @@ def find_reset_synchronizers(
     avoid re-running :func:`rtl_buddy_cdc.domain.assign_domains`. The
     recogniser tolerates ``None`` entries (untraceable clock); those
     flops never match because their domain cannot be compared.
+
+    ``extra_synchronizers`` (optional) is the set of flop cell names
+    the caller wants treated as sync stages regardless of structural
+    shape — typically the result of
+    :func:`rtl_buddy_cdc.rules.user_reset_sync_flop_names` (flops the
+    user has marked with ``(* reset_sync *)``). Useful when the chain
+    head's D is fed by an upstream signal rather than a literal
+    constant — the structural recogniser is deliberately conservative
+    and would otherwise miss them.
     """
     if min_depth < 1:
         raise ValueError("min_depth must be >= 1")
     domains = assign_reset_domains(module)
     flop_by_name = {f.cell.name: f for f in find_flops(module)}
     bit_drivers = _bit_drivers(module)
-    out: set[str] = set()
+    out: set[str] = set(extra_synchronizers or ())
 
     for name, rd in domains.items():
         if rd.reset is None or rd.reset.type != "async":

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -195,6 +195,37 @@ def user_sync_flop_names(module: Module) -> set[str]:
 USER_GRAY_ATTRS: frozenset[str] = frozenset({"cdc_gray", "gray_code"})
 
 
+# Reset-side counterpart of USER_SYNC_ATTRS — mark a flop as a
+# user-vetted reset-synchroniser stage. Consumed by
+# :func:`rtl_buddy_cdc.reset_domain.find_reset_synchronizers` as an
+# alternate match path so RDC-002 / RDC-004 / RDC-005 skip the marked
+# flops without needing to match the constant-fed-D structural shape.
+# Useful for sync chains whose head's D is fed by an upstream signal
+# (rather than a literal constant) — the structural recogniser is
+# deliberately conservative and would otherwise miss them.
+USER_RESET_SYNC_ATTRS: frozenset[str] = frozenset({"reset_sync", "reset_synchronizer"})
+
+
+def user_reset_sync_flop_names(module: Module) -> set[str]:
+    """Cell names of flops whose Q is named via a wire annotated with
+    ``(* reset_sync *)`` (or :data:`USER_RESET_SYNC_ATTRS` aliases).
+    Treated by the RDC rule pack as a vetted reset-synchroniser stage
+    regardless of the flop's structural shape."""
+    sync_bits: set[Bit] = set()
+    for nn in module.netnames.values():
+        if USER_RESET_SYNC_ATTRS & set(nn.attributes):
+            for b in nn.bits:
+                if isinstance(b, int):
+                    sync_bits.add(b)
+    if not sync_bits:
+        return set()
+    out: set[str] = set()
+    for f in find_flops(module):
+        if any(isinstance(b, int) and b in sync_bits for b in f.q):
+            out.add(f.cell.name)
+    return out
+
+
 def user_gray_flop_names(module: Module) -> set[str]:
     """Cell names of source flops whose Q is named via a wire annotated
     with ``(* cdc_gray *)``. CDC-004 treats those bus crossings as safe
@@ -1588,7 +1619,9 @@ def check_rdc_004(
     if ctx is None:
         ctx = _build_context(module, clock_spec)
     reset_domains = assign_reset_domains(module)
-    recognised_syncs = find_reset_synchronizers(module, ctx.domains)
+    recognised_syncs = find_reset_synchronizers(
+        module, ctx.domains, extra_synchronizers=user_reset_sync_flop_names(module)
+    )
 
     violations: list[Violation] = []
     for f in ctx.flops:
@@ -1674,7 +1707,9 @@ def check_rdc_005(
     if ctx is None:
         ctx = _build_context(module, clock_spec)
     reset_domains = assign_reset_domains(module)
-    recognised_syncs = find_reset_synchronizers(module, ctx.domains)
+    recognised_syncs = find_reset_synchronizers(
+        module, ctx.domains, extra_synchronizers=user_reset_sync_flop_names(module)
+    )
 
     violations: list[Violation] = []
     for f in ctx.flops:
@@ -1823,7 +1858,9 @@ def check_rdc_002(
     if ctx is None:
         ctx = _build_context(module, clock_spec)
     reset_domains = assign_reset_domains(module)
-    recognised_syncs = find_reset_synchronizers(module, ctx.domains)
+    recognised_syncs = find_reset_synchronizers(
+        module, ctx.domains, extra_synchronizers=user_reset_sync_flop_names(module)
+    )
 
     # Group by (producer, producer_arst_value, consumer_polarity_bit)
     # so the typical "one upstream polarity wiring bug, N downstream
@@ -1850,6 +1887,13 @@ def check_rdc_002(
         producer_name = rd.reset.name
         producer = module.cells.get(producer_name)
         if producer is None:
+            continue
+        # If the producer is itself a recognised reset-synchroniser
+        # stage, the user has vetted that the reset arrives cleanly —
+        # any polarity inversion in the chain is intentional. Catches
+        # the ``(* reset_sync *)``-marked-tail shape where the user
+        # explicitly declared the chain trustworthy.
+        if producer_name in recognised_syncs:
             continue
         producer_arst_value = _trailing_bit(producer.parameters.get("ARST_VALUE", "0"))
         consumer_polarity_bit = "1" if rd.reset.polarity == "high" else "0"

--- a/tests/fixtures/marked_reset_sync/marked_reset_sync.json
+++ b/tests/fixtures/marked_reset_sync/marked_reset_sync.json
@@ -1,0 +1,154 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "marked_reset_sync": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:18.1-47.10"
+      },
+      "ports": {
+        "clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "upstream_rst_n": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "d_in": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "q_out": {
+          "direction": "output",
+          "bits": [ 5 ]
+        }
+      },
+      "cells": {
+        "$procdff$13": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:34.5-37.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 2 ],
+            "D": [ 6 ],
+            "Q": [ 7 ]
+          }
+        },
+        "$procdff$18": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:26.5-29.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 3 ],
+            "CLK": [ 2 ],
+            "D": [ 3 ],
+            "Q": [ 6 ]
+          }
+        },
+        "$procdff$8": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "1",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:42.5-45.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 7 ],
+            "CLK": [ 2 ],
+            "D": [ 4 ],
+            "Q": [ 5 ]
+          }
+        }
+      },
+      "netnames": {
+        "clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:19.18-19.21"
+          }
+        },
+        "d_in": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:21.18-21.22"
+          }
+        },
+        "q_out": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:22.18-22.23"
+          }
+        },
+        "rst_meta": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:25.11-25.19"
+          }
+        },
+        "rst_sync": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "reset_sync": "00000000000000000000000000000001",
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:33.28-33.36"
+          }
+        },
+        "upstream_rst_n": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/marked_reset_sync/marked_reset_sync.sv:20.18-20.32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/marked_reset_sync/marked_reset_sync.sdc
+++ b/tests/fixtures/marked_reset_sync/marked_reset_sync.sdc
@@ -1,0 +1,3 @@
+create_clock -name clk -period 10.0 [get_ports clk]
+set_input_delay -clock clk 1.0 [get_ports upstream_rst_n]
+set_input_delay -clock clk 1.0 [get_ports d_in]

--- a/tests/fixtures/marked_reset_sync/marked_reset_sync.sv
+++ b/tests/fixtures/marked_reset_sync/marked_reset_sync.sv
@@ -1,0 +1,47 @@
+// SV-attribute coverage fixture: (* reset_sync *) marks a flop as a
+// user-vetted reset-synchroniser stage even when the structural
+// recogniser wouldn't match.
+//
+// The chain head's D pin is fed by `upstream_rst_n` (a port), not a
+// constant — the structural detector in
+// :func:`rtl_buddy_cdc.reset_domain.find_reset_synchronizers`
+// deliberately requires a constant-fed head, so it would normally
+// NOT classify these flops as a synchroniser. The `(* reset_sync *)`
+// annotation overrides that decision.
+//
+// Without the attribute, RDC-002 would fire on the consumer flop
+// (`q_out`) because the producer's ARST_VALUE (=0) doesn't match
+// q_out's ARST_POLARITY (=1). With the attribute marking the second
+// stage of the would-be sync as recognised, RDC-002 skips q_out and
+// no rule fires.
+
+module marked_reset_sync (
+    input  logic clk,
+    input  logic upstream_rst_n,
+    input  logic d_in,
+    output logic q_out
+);
+
+    logic rst_meta;
+    always_ff @(posedge clk or negedge upstream_rst_n) begin
+        if (!upstream_rst_n) rst_meta <= 1'b0;
+        else                 rst_meta <= upstream_rst_n;  // not constant — D=port
+    end
+
+    // (* reset_sync *) marks this flop as a vetted sync stage even
+    // though the chain head's D isn't a constant.
+    (* reset_sync *) logic rst_sync;
+    always_ff @(posedge clk or negedge upstream_rst_n) begin
+        if (!upstream_rst_n) rst_sync <= 1'b0;
+        else                 rst_sync <= rst_meta;
+    end
+
+    // Consumer with deliberately mismatched polarity — would normally
+    // trigger RDC-002, but the (* reset_sync *) on `rst_sync` makes
+    // it count as a synchroniser stage and the rule skips q_out.
+    always_ff @(posedge clk or posedge rst_sync) begin
+        if (rst_sync) q_out <= 1'b0;
+        else          q_out <= d_in;
+    end
+
+endmodule

--- a/tests/test_marked_reset_sync.py
+++ b/tests/test_marked_reset_sync.py
@@ -1,0 +1,126 @@
+"""SV-attribute coverage: ``(* reset_sync *)`` user escape hatch.
+
+Issue #115 (first slice — ``reset_sync`` attribute; the
+``reset_polarity`` attribute is deferred since no rule consumes
+source-side port polarity today).
+
+The fixture wires a 2-stage chain whose head's D pin is a *port*
+(not a constant), so the structural recogniser in
+:func:`rtl_buddy_cdc.reset_domain.find_reset_synchronizers`
+deliberately does NOT classify it. The ``(* reset_sync *)`` annotation
+on the chain tail overrides that decision; RDC-002 then sees the
+consumer flop as fed by a vetted sync stage and skips it.
+
+The dual contract:
+
+1. ``user_reset_sync_flop_names(module)`` returns the marked flop's
+   cell name.
+2. Without the attribute the same wiring fires RDC-002; with it,
+   the rule pack is silent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.reset_domain import find_reset_synchronizers
+from rtl_buddy_cdc.rules import (
+    USER_RESET_SYNC_ATTRS,
+    run_all as run_all_rules,
+    user_reset_sync_flop_names,
+)
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "marked_reset_sync"
+JSON = FIX_DIR / "marked_reset_sync.json"
+SDC = FIX_DIR / "marked_reset_sync.sdc"
+
+
+def _load():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    return netlist.load(JSON)
+
+
+def test_attribute_constants() -> None:
+    """The aliases users may write are part of the public surface."""
+    assert "reset_sync" in USER_RESET_SYNC_ATTRS
+    assert "reset_synchronizer" in USER_RESET_SYNC_ATTRS
+
+
+def test_user_reset_sync_flop_names_finds_marked_flop() -> None:
+    module = _load()
+    marked = user_reset_sync_flop_names(module)
+    assert len(marked) == 1, f"expected 1 marked flop, got {marked}"
+    # The marked flop is the chain tail (Q is named ``rst_sync``); the
+    # cell name is a Yosys auto-name so we don't pin it, but it should
+    # be one of the $procdff cells.
+    assert all(n.startswith("$procdff") for n in marked)
+
+
+def test_recognizer_consumes_extra_synchronizers() -> None:
+    """``find_reset_synchronizers`` accepts ``extra_synchronizers`` and
+    folds them into its output set."""
+    module = _load()
+    flop_clocks = {
+        f.cell.name: clk
+        for f, clk in [(f, _module_clock_for(module, f)) for f in _flops(module)]
+    }
+    marked = user_reset_sync_flop_names(module)
+    # Structural pass alone wouldn't match (head D is a port).
+    structural = find_reset_synchronizers(module, flop_clocks)
+    # With the user-marked overlay the marked flop is in the set.
+    augmented = find_reset_synchronizers(
+        module, flop_clocks, extra_synchronizers=marked
+    )
+    assert marked.issubset(augmented)
+    assert structural.isdisjoint(marked) or marked.issubset(structural), (
+        "structural and user paths should be additive, not overlapping "
+        "in a way that hides the user contribution"
+    )
+
+
+def test_rule_pack_silent_when_attribute_marks_chain_tail() -> None:
+    """End-to-end: with ``(* reset_sync *)`` on the chain tail, the
+    full rule pack should not fire on the consumer flop (whose
+    polarity is deliberately mismatched in the fixture). Pins the
+    integration between the attribute helper, the recogniser, and
+    RDC-002's producer-side skip."""
+    module = _load()
+    spec = sdc_mod.parse_file(SDC)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    async_crossings = []
+    for c in crossings:
+        a = spec.clock_for_port(c.src_clock) or c.src_clock
+        b = spec.clock_for_port(c.dst_clock) or c.dst_clock
+        if spec.is_unreachable_crossing(a, b):
+            continue
+        if spec.are_async(a, b):
+            async_crossings.append(c)
+    violations = run_all_rules(module, async_crossings, spec)
+    assert violations == [], (
+        f"expected no violations on marked fixture, got "
+        f"{[(v.rule_id, v.cell_name) for v in violations]}"
+    )
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _flops(module):
+    from rtl_buddy_cdc.flops import find_flops
+
+    return find_flops(module)
+
+
+def _module_clock_for(module, f) -> str | None:
+    from rtl_buddy_cdc.domain import assign_domains
+
+    for fd in assign_domains(module):
+        if fd.flop.cell.name == f.cell.name:
+            return fd.clock
+    return None


### PR DESCRIPTION
## Summary

Eighth instalment of #107. Implements the \`(* reset_sync *)\` half of #115. The companion \`(* reset_polarity *)\` attribute is deferred — no rule currently consumes source-side port polarity, so it would be dead code without a consumer rule extension.

## What it does

Marks a flop as a vetted reset-synchroniser stage even when the structural recogniser in \`reset_domain.find_reset_synchronizers\` wouldn't match. The recogniser deliberately requires a constant-fed chain head, so chains whose head's D is fed by an upstream signal (rather than a literal constant) are otherwise missed.

RDC-002 / RDC-004 / RDC-005 skip flops marked with this attribute and also skip consumers whose ARST is driven by a marked flop's Q (matching the user's intent that \"this reset arrives cleanly downstream\").

## Surface

- \`rtl_buddy_cdc.rules.USER_RESET_SYNC_ATTRS\` — frozenset of accepted aliases: \`reset_sync\`, \`reset_synchronizer\`.
- \`user_reset_sync_flop_names(module)\` — returns the set of flop cell names with the attribute on their Q wire.
- \`find_reset_synchronizers(module, clock_domains, *, min_depth, extra_synchronizers=None)\` — new optional parameter folds the user-marked set into the recogniser's output.
- RDC-002 producer-side skip extended: if \`producer in recognised_syncs\`, skip the consumer too.

## Fixture + test

\`marked_reset_sync\` — a 2-stage chain whose head's D is a port (not a constant). The \`(* reset_sync *)\` annotation on the tail makes RDC-002 stay silent.

\`test_marked_reset_sync.py\` (4 tests): attribute constants, helper discovery, recogniser overlay, end-to-end suppression.

## Deferred (separate follow-up if/when needed)

\`(* reset_polarity *)\` — overrides polarity inference. No rule today looks at *source-side port* polarity, so the override has no observable effect without also extending a consuming rule (likely RDC-002's port-source check, which today only handles flop-source cases).

## Verification

\`\`\`
uv run ruff check              # all checks passed
uv run ruff format --check     # 74 files
uv run mypy                    # success
uv run pytest -q               # 342 passed, 2 skipped (+4 net)
\`\`\`

## Closes

Closes #115 (the \`reset_polarity\` half is documented as deferred in the closing comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)