### PR TITLE
docs(wiki): point §8.3 to #129 instead of "deferred"

### DIFF
--- a/wiki/raw/articles/rtl-buddy-cdc-reset-domain-analysis.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-reset-domain-analysis.md
@@ -254,6 +254,15 @@ authoritative. Attached to the input port:
 (* reset_polarity = "high" *) input logic rst;
 ```
 
+The two accepted values are the analyzer-wide convention for
+reset polarity throughout the codebase, the JSON artefacts, and
+the (planned) external YAML hints (#129):
+
+- `"low"` — **active-low** reset (asserts when the signal is `0`;
+  the classic `rst_n` idiom).
+- `"high"` — **active-high** reset (asserts when the signal is
+  `1`).
+
 Discovery via `rtl_buddy_cdc.rules.user_reset_polarity_overrides`,
 which returns `dict[port_name, "high"|"low"]`. Internal nets with
 the attribute are silently ignored — the declaration is a


### PR DESCRIPTION
The reset-domain analysis article landed in #128 with §8.3 framing
the YAML hints work as "deferred against the AGENTS.md no-deps
policy". That framing is sharper than what AGENTS.md actually says
— the rule is "no new top-level dependencies without strong
reason" (Development rules section), which the YAML hints use
case meets and the existing ``[slang]`` optional-extra pattern
already accommodates.

Reframe §8.3 from "deferred" to "planned, tracked in #129", point
at the optional-extra plan, and stop implying a policy blocker
that doesn't exist.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>