### PR TITLE
test(cdc-010): paired async-clock-mux fixtures + slang parity (#134)

### DIFF
--- a/tests/fixtures/bad_async_clock_mux/bad_async_clock_mux.json
+++ b/tests/fixtures/bad_async_clock_mux/bad_async_clock_mux.json
@@ -1,0 +1,182 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "bad_async_clock_mux": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "bad_async_clock_mux.sv:17.1-47.10"
+      },
+      "ports": {
+        "ck0_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "ck0_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "ck1": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "sel_d": {
+          "direction": "input",
+          "bits": [ 6 ]
+        },
+        "d_in": {
+          "direction": "input",
+          "bits": [ 7 ]
+        },
+        "q_out": {
+          "direction": "output",
+          "bits": [ 8 ]
+        }
+      },
+      "cells": {
+        "$procdff$10": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_async_clock_mux.sv:43.5-45.35"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 5 ],
+            "CLK": [ 9 ],
+            "D": [ 7 ],
+            "Q": [ 8 ]
+          }
+        },
+        "$procdff$15": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "bad_async_clock_mux.sv:29.5-31.36"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 5 ],
+            "CLK": [ 4 ],
+            "D": [ 6 ],
+            "Q": [ 10 ]
+          }
+        },
+        "$ternary$bad_async_clock_mux.sv:38$3": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:38.21-38.42"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "B": [ 2 ],
+            "S": [ 10 ],
+            "Y": [ 9 ]
+          }
+        }
+      },
+      "netnames": {
+        "ck0_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:18.18-18.23"
+          }
+        },
+        "ck0_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:19.18-19.23"
+          }
+        },
+        "ck1": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:20.18-20.21"
+          }
+        },
+        "ck_out": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:37.11-37.17"
+          }
+        },
+        "d_in": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:23.18-23.22"
+          }
+        },
+        "q_out": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:24.18-24.23"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:21.18-21.23"
+          }
+        },
+        "sel_d": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:22.18-22.23"
+          }
+        },
+        "sel_q": {
+          "hide_name": 0,
+          "bits": [ 10 ],
+          "attributes": {
+            "src": "bad_async_clock_mux.sv:28.11-28.16"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_async_clock_mux/bad_async_clock_mux.sdc
+++ b/tests/fixtures/bad_async_clock_mux/bad_async_clock_mux.sdc
@@ -1,0 +1,7 @@
+create_clock -name ck0 -period 10.0  [get_ports {ck0_a ck0_b}]
+create_clock -name ck1 -period 13.3  [get_ports ck1]
+set_clock_groups -asynchronous -group {ck0} -group {ck1}
+# Type the data ports so CDC-011 stays silent — the rule under
+# test is CDC-010, not the unconstrained-input rule.
+set_input_delay -clock ck1 0.0 [get_ports sel_d]
+set_input_delay -clock ck0 0.0 [get_ports d_in]

--- a/tests/fixtures/bad_async_clock_mux/bad_async_clock_mux.sv
+++ b/tests/fixtures/bad_async_clock_mux/bad_async_clock_mux.sv
@@ -1,0 +1,47 @@
+// CDC-010 negative case — a clock mux whose select is driven by a
+// flop in a foreign clock domain.
+//
+// Without synchronization the select's transition (on a ck1 edge)
+// chops the muxed output clock mid-cycle, producing a sub-period
+// runt pulse that the downstream flop will sample as a real edge.
+// Even with both mux inputs in the ck0 domain — same upstream
+// source, only differing by which leg the user picked — the
+// asynchronous select is unsafe: the analyzer fires structurally
+// rather than try to prove input equivalence at the AC level.
+//
+// Both ck0_a / ck0_b are declared as the same clock (`ck0`) in the
+// SDC so the cell's clock-input-domain set collapses to `{ck0}`.
+// `sel_q` sits in `ck1`, which is in a different async group than
+// `ck0` — CDC-010 fires once on the `$mux`'s S pin.
+
+module bad_async_clock_mux (
+    input  logic ck0_a,
+    input  logic ck0_b,
+    input  logic ck1,
+    input  logic rst_n,
+    input  logic sel_d,
+    input  logic d_in,
+    output logic q_out
+);
+
+    // Select is in ck1's domain — the foreign-domain source.
+    logic sel_q;
+    always_ff @(posedge ck1 or negedge rst_n)
+        if (!rst_n) sel_q <= 1'b0;
+        else        sel_q <= sel_d;
+
+    // "Clock mux" — both inputs are legitimate clocks (both ck0),
+    // but the select is from ck1. The structural shape — flop-Q on
+    // a `$mux.S` whose A / B trace back to a different clock domain
+    // — is what the rule detects.
+    logic ck_out;
+    assign ck_out = sel_q ? ck0_a : ck0_b;
+
+    // Downstream flop driven by the muxed clock — every flop on
+    // this leg of the design is exposed to the runt pulse on every
+    // sel_q transition.
+    always_ff @(posedge ck_out or negedge rst_n)
+        if (!rst_n) q_out <= 1'b0;
+        else        q_out <= d_in;
+
+endmodule

--- a/tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.json
+++ b/tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.json
@@ -1,0 +1,249 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_sync_clock_mux": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:18.1-56.10"
+      },
+      "ports": {
+        "ck0_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "ck0_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "ck1": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "sel_d": {
+          "direction": "input",
+          "bits": [ 6 ]
+        },
+        "d_in": {
+          "direction": "input",
+          "bits": [ 7 ]
+        },
+        "q_out": {
+          "direction": "output",
+          "bits": [ 8 ]
+        }
+      },
+      "cells": {
+        "$procdff$12": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:52.5-54.35"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 5 ],
+            "CLK": [ 9 ],
+            "D": [ 7 ],
+            "Q": [ 8 ]
+          }
+        },
+        "$procdff$17": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:39.5-47.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 5 ],
+            "CLK": [ 2 ],
+            "D": [ 10 ],
+            "Q": [ 11 ]
+          }
+        },
+        "$procdff$22": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:39.5-47.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 5 ],
+            "CLK": [ 2 ],
+            "D": [ 11 ],
+            "Q": [ 12 ]
+          }
+        },
+        "$procdff$27": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:29.5-31.36"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 5 ],
+            "CLK": [ 4 ],
+            "D": [ 6 ],
+            "Q": [ 10 ]
+          }
+        },
+        "$ternary$tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:50$5": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:50.21-50.45"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 3 ],
+            "B": [ 2 ],
+            "S": [ 12 ],
+            "Y": [ 9 ]
+          }
+        }
+      },
+      "netnames": {
+        "ck0_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:19.18-19.23"
+          }
+        },
+        "ck0_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:20.18-20.23"
+          }
+        },
+        "ck1": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:21.18-21.21"
+          }
+        },
+        "ck_out": {
+          "hide_name": 0,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:49.11-49.17"
+          }
+        },
+        "d_in": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:24.18-24.22"
+          }
+        },
+        "q_out": {
+          "hide_name": 0,
+          "bits": [ 8 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:25.18-25.23"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:22.18-22.23"
+          }
+        },
+        "sel_d": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:23.18-23.23"
+          }
+        },
+        "sel_meta": {
+          "hide_name": 0,
+          "bits": [ 11 ],
+          "attributes": {
+            "cdc_sync": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:37.26-37.34"
+          }
+        },
+        "sel_q": {
+          "hide_name": 0,
+          "bits": [ 10 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:28.11-28.16"
+          }
+        },
+        "sel_sync": {
+          "hide_name": 0,
+          "bits": [ 12 ],
+          "attributes": {
+            "src": "tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv:38.24-38.32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sdc
+++ b/tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sdc
@@ -1,0 +1,5 @@
+create_clock -name ck0 -period 10.0  [get_ports {ck0_a ck0_b}]
+create_clock -name ck1 -period 13.3  [get_ports ck1]
+set_clock_groups -asynchronous -group {ck0} -group {ck1}
+set_input_delay -clock ck1 0.0 [get_ports sel_d]
+set_input_delay -clock ck0 0.0 [get_ports d_in]

--- a/tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv
+++ b/tests/fixtures/good_sync_clock_mux/good_sync_clock_mux.sv
@@ -1,0 +1,56 @@
+// CDC-010 paired fix — synchronize the mux select into the
+// destination-clock domain before it reaches the clock mux.
+//
+// (For a real clock mux you'd use a glitch-free clock-mux library
+// cell with its own internal hand-off; this fixture shows the
+// structural fix the rule recognises: with the select sampled into
+// `ck0` via a 2FF synchronizer, the rule's backward-flop-fanin walk
+// finds a same-domain flop on the mux's select pin and stays
+// silent.)
+//
+// The ck1-domain `sel_q` flop is still present (carrying the user
+// request); it crosses into the ck0 domain through the
+// `(* cdc_sync *)` 2FF synchronizer (`sel_meta` → `sel_sync`). The
+// downstream clock mux sees `sel_sync` — a ck0-domain flop — on its
+// `S` pin, which falls inside the cell's clock-input-domain set
+// `{ck0}`, so CDC-010 is silent.
+
+module good_sync_clock_mux (
+    input  logic ck0_a,
+    input  logic ck0_b,
+    input  logic ck1,
+    input  logic rst_n,
+    input  logic sel_d,
+    input  logic d_in,
+    output logic q_out
+);
+
+    logic sel_q;
+    always_ff @(posedge ck1 or negedge rst_n)
+        if (!rst_n) sel_q <= 1'b0;
+        else        sel_q <= sel_d;
+
+    // 2FF synchronizer into ck0's domain. (* cdc_sync *) marks the
+    // first stage so the rule pack recognises the chain even when
+    // the depth detector would already accept it structurally —
+    // belt and braces.
+    (* cdc_sync *) logic sel_meta;
+    logic              sel_sync;
+    always_ff @(posedge ck0_a or negedge rst_n) begin
+        if (!rst_n) begin
+            sel_meta <= 1'b0;
+            sel_sync <= 1'b0;
+        end else begin
+            sel_meta <= sel_q;
+            sel_sync <= sel_meta;
+        end
+    end
+
+    logic ck_out;
+    assign ck_out = sel_sync ? ck0_a : ck0_b;  // select now in ck0
+
+    always_ff @(posedge ck_out or negedge rst_n)
+        if (!rst_n) q_out <= 1'b0;
+        else        q_out <= d_in;
+
+endmodule

--- a/tests/test_bad_async_clock_mux.py
+++ b/tests/test_bad_async_clock_mux.py
@@ -1,0 +1,97 @@
+"""Negative-case fixture for CDC-010 (#134, phase 2 of #95).
+
+A clock mux whose ``S`` is driven by a flop in a foreign clock
+domain. The rule must fire exactly once and only CDC-010 — the
+shape is invisible to CDC-001 / CDC-004 (the select sits on a
+``$mux``, not a flop's ``D``) and to CDC-008 (no clock signal lands
+on a data pin here).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.cli import _filter_async
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_async_clock_mux"
+JSON = FIX_DIR / "bad_async_clock_mux.json"
+SDC = FIX_DIR / "bad_async_clock_mux.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    async_crossings = _filter_async(crossings, spec)
+    return module, async_crossings, spec
+
+
+def _sel_q_cell_name(module) -> str:
+    """Yosys auto-names the always_ff flop ``$procdff$N``; recover the
+    cell whose ``Q`` drives the ``sel_q`` netname so the test can
+    assert on a stable identity instead of the unstable cell name."""
+    sel_q = module.netnames["sel_q"]
+    for cell in module.cells.values():
+        if "$adff" not in cell.type and "$dff" not in cell.type:
+            continue
+        if cell.connections.get("Q", ()) == sel_q.bits:
+            return cell.name
+    raise AssertionError("no flop drives the sel_q netname")
+
+
+def _mux_cell(module):
+    muxes = [c for c in module.cells.values() if c.type == "$mux"]
+    assert len(muxes) == 1, f"expected one $mux, got {len(muxes)}"
+    return muxes[0]
+
+
+def test_cdc_010_fires_exactly_once(context) -> None:
+    module, async_crossings, spec = context
+    violations = run_all_rules(module, async_crossings, spec)
+    cdc_010 = [v for v in violations if v.rule_id == "CDC-010"]
+    assert len(cdc_010) == 1, [v.message for v in cdc_010]
+    assert cdc_010[0].severity == "error"
+
+
+def test_violation_names_the_mux_cell(context) -> None:
+    module, async_crossings, spec = context
+    violations = run_all_rules(module, async_crossings, spec)
+    cdc_010 = [v for v in violations if v.rule_id == "CDC-010"]
+    mux = _mux_cell(module)
+    assert cdc_010[0].cell_name == mux.name
+    assert "$mux" in cdc_010[0].message
+    assert "control pin S" in cdc_010[0].message
+
+
+def test_violation_names_sel_q_as_source(context) -> None:
+    module, async_crossings, spec = context
+    violations = run_all_rules(module, async_crossings, spec)
+    cdc_010 = [v for v in violations if v.rule_id == "CDC-010"]
+    sel_q = _sel_q_cell_name(module)
+    assert sel_q in cdc_010[0].message, (
+        f"sel_q cell {sel_q!r} missing from message: {cdc_010[0].message!r}"
+    )
+    # And the domains — sel_q is ck1, the gated clock is ck0.
+    assert "ck1" in cdc_010[0].message
+    assert "ck0" in cdc_010[0].message
+
+
+def test_no_other_rule_fires(context) -> None:
+    """CDC-001 / -004 can't see a select-on-$mux shape (it's not a
+    flop D); CDC-008 must stay silent here (no clock signal sits on
+    a non-CLK data pin). CDC-011 is suppressed by ``set_input_delay``
+    in the SDC. CDC-010 should be the only rule that fires."""
+    module, async_crossings, spec = context
+    violations = run_all_rules(module, async_crossings, spec)
+    rule_ids = sorted({v.rule_id for v in violations})
+    assert rule_ids == ["CDC-010"], rule_ids

--- a/tests/test_good_fixtures.py
+++ b/tests/test_good_fixtures.py
@@ -117,6 +117,13 @@ GOOD_FIXTURES = [
     # unambiguous — exactly one source is active at a time — so the
     # mux-on-reset exemption keeps RDC-005 silent. Single-clock.
     ("good_rdc_005_muxed_reset", 0),
+    # CDC-010 (#95/#134) positive shape: foreign-domain mux select
+    # passed through a (* cdc_sync *) 2FF synchroniser into the
+    # gated-clock (ck0) domain before reaching the mux. The mux's S
+    # is then driven by a same-domain flop, so CDC-010 stays silent
+    # and the 2FF chain keeps CDC-001 silent on the underlying
+    # async crossing. 1 async crossing (ck1 sel_q → ck0 sel_meta).
+    ("good_sync_clock_mux", 1),
     # CDC-009 (#47/#101/#102) positive shapes: textbook fixes for the
     # fast-to-slow pulse-loss case.
     #

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -96,6 +96,20 @@ def test_cdc_008_fires_on_bad_clock_as_data() -> None:
     assert _run("bad_clock_as_data") == ["CDC-008"]
 
 
+def test_cdc_010_fires_on_bad_async_clock_mux() -> None:
+    """Clock-mux select driven by a foreign-domain flop — CDC-010
+    must fire under slang too. Relies on the slang frontend emitting
+    a Yosys-shape ``$mux`` for the SV ternary on the clock signal."""
+    assert _run("bad_async_clock_mux") == ["CDC-010"]
+
+
+def test_cdc_010_silent_on_good_sync_clock_mux() -> None:
+    """Paired positive case — synchronizing the select into the
+    gated-clock domain via a (* cdc_sync *) 2FF chain makes the
+    rule silent (and CDC-001 too, via the chain-depth detector)."""
+    assert _run("good_sync_clock_mux") == []
+
+
 def test_cdc_004_silent_on_good_gray_counter_crossing() -> None:
     """Gray-coded bus crossing into a multi-bit sync chain — the
     structural gray-code detector should accept it.


### PR DESCRIPTION
## Summary

Closes #134. Phase 2 of #95 — pairs the CDC-010 rule pack (PR
#133) with the regression net deliberately split out in phase 1.

- New `tests/fixtures/bad_async_clock_mux/` — clock mux whose
  select is driven by a foreign-domain (ck1) flop while the mux
  inputs are both gated versions of ck0. Per proposal §5.1 in
  `docs/proposals/clock-network-glitch.md`.
- New `tests/fixtures/good_sync_clock_mux/` — paired textbook
  fix: synchronise the select into ck0 via a `(* cdc_sync *)` 2FF
  chain before reaching the mux. Per proposal §5.2.
- New `tests/test_bad_async_clock_mux.py` — four targeted
  assertions per the issue acceptance: exactly one CDC-010 at
  `error` severity, violation cell is the `$mux`, message names
  the foreign-domain source flop and both clock domains, no other
  rule fires across the entire rule pack.
- `GOOD_FIXTURES` gains the paired good entry with `expected_async=1`
  (the underlying sel_q ck1 → sel_meta ck0 crossing is real but
  resolved by the 2FF synchronizer).
- `test_slang_elaboration.py` gains parity confirmations for both
  fixtures (slang produces the same Yosys-shape `\$mux` and the
  rule pack agrees on the verdict).

Yosys JSON pre-built and committed per the AGENTS.md
"Adding a fixture" convention — the test suite has no Yosys
runtime dependency.

## Test plan

- [x] `uv run ruff check tests/test_bad_async_clock_mux.py tests/test_good_fixtures.py tests/test_slang_elaboration.py` — passes
- [x] `uv run ruff format --check` — three files already formatted
- [x] `uv run mypy` — Success: no issues found in 18 source files
- [x] `uv run pytest -q` — 387 passed, 24 skipped (all skips gated on the `[hints]` extra or pyslang install-hint path; not touched by this PR)
- [x] `uv run pytest tests/test_bad_async_clock_mux.py -v` — 4 passed
- [x] `uv run pytest -k clock_mux tests/test_slang_elaboration.py` — 2 passed (slang frontend parity)

## Out of scope

- Phase 3 (#135) — tech-mapped library cell shapes (`CE` / `E`
  / `GATE` / `SE`) + heuristic fallback. The phase-3 issue notes
  that the fixture extension may produce a tech-mapped sibling
  rather than modify these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)