### PR TITLE
Fix create_generated_clock source parsing

### DIFF
--- a/src/rtl_buddy_cdc/sdc.py
+++ b/src/rtl_buddy_cdc/sdc.py
@@ -374,15 +374,10 @@ def _handle_create_generated_clock(spec: ClockSpec, args: list[str]) -> None:
         elif tok == "-source":
             # The source expression is bracketed (``[get_ports ck_a]``
             # or ``[get_pins u_a/clk_out]``) and shlex splits the
-            # opening bracket from the trailing ``]``-suffixed name —
-            # so we consume forward until the next ``-`` flag rather
-            # than a fixed token count. The source is currently used
-            # only as documentation; the master identity comes from
-            # ``-master_clock``.
-            j = i + 1
-            while j < len(args) and not args[j].startswith("-"):
-                j += 1
-            i = j
+            # opening bracket from the trailing ``]``-suffixed name.
+            # Consume exactly that one collection; the following
+            # collection is the generated-clock target.
+            i = _skip_collection_arg(args, i + 1)
         elif tok == "-divide_by" and i + 1 < len(args):
             try:
                 divide_by = int(args[i + 1])
@@ -507,6 +502,37 @@ def _extract_ports_or_pins(rest: list[str]) -> tuple[list[str], bool]:
             continue
         cleaned.append(tok)
     return cleaned, saw_filter
+
+
+def _skip_collection_arg(args: list[str], index: int) -> int:
+    """Return the index after one Tcl-ish collection argument.
+
+    ``shlex`` turns ``[get_ports clk]`` into ``["[get_ports", "clk]"]``.
+    It also leaves simple clock names as a single token. This helper is
+    deliberately small: it is used for option operands such as
+    ``create_generated_clock -source`` where the operand is syntactically
+    one collection, not the rest of the command.
+    """
+    if index >= len(args):
+        return index
+    first = args[index]
+    if first.startswith("["):
+        index += 1
+        while index < len(args):
+            token = args[index]
+            index += 1
+            if token.endswith("]"):
+                break
+        return index
+    if first.startswith("{"):
+        index += 1
+        while index < len(args):
+            token = args[index]
+            index += 1
+            if token.endswith("}"):
+                break
+        return index
+    return index + 1
 
 
 def _strip_get_clocks(token: str) -> str:

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -99,6 +99,20 @@ def test_create_generated_clock_div2_resolves_to_master() -> None:
     assert not spec2.are_async("clk", "clk_div2")
 
 
+def test_create_generated_clock_source_does_not_consume_target_port() -> None:
+    spec = parse(
+        """
+        create_clock -name clk -period 10.0 [get_ports clk]
+        create_generated_clock -name clk_fwd -master_clock clk \\
+            -source [get_ports clk] [get_ports clk_fwd]
+        """
+    )
+
+    assert spec.clocks["clk_fwd"].ports == ("clk_fwd",)
+    assert spec.clock_for_port("clk_fwd") == "clk_fwd"
+    assert spec.resolve("clk_fwd") == "clk"
+
+
 def test_generated_clock_async_override_wins() -> None:
     spec = parse(
         """

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from rtl_buddy_cdc.sdc import parse
 
 
@@ -111,6 +113,98 @@ def test_create_generated_clock_source_does_not_consume_target_port() -> None:
     assert spec.clocks["clk_fwd"].ports == ("clk_fwd",)
     assert spec.clock_for_port("clk_fwd") == "clk_fwd"
     assert spec.resolve("clk_fwd") == "clk"
+
+
+# --- Issue #140 shape coverage ------------------------------------------------
+#
+# The tests above pin the port-target shape. The cases below extend
+# the regression net to the other trailing-target forms that share
+# the same parser path:
+#
+#   1. pin target (lands in ``pin_clocks`` rather than ``Clock.ports``)
+#   2. pin source + pin target (chained-forwarded-clock idiom)
+#   3. brace-form source ``{ck_a}`` (Tcl-legal, single-token collection)
+#   4. ``-source`` not last (the ordering existing fixtures use today —
+#      kept here as a non-regression sentinel)
+
+
+def test_cgc_source_last_pin_target_retains_target() -> None:
+    """Pin target lands in ``pin_clocks``. With the bug, ``pin_clocks``
+    is empty and the analyzer's clock-network trace walks past the pin
+    to the upstream port — flops downstream get the wrong clock root."""
+    spec = parse(
+        """
+        create_clock -name ck_a -period 10.0 [get_ports ck_a]
+        create_generated_clock -name ck_b0 -master_clock ck_a \\
+            -source [get_ports ck_a] [get_pins u_buf/Y]
+        """
+    )
+    assert spec.pin_clocks == {"u_buf/Y": "ck_b0"}
+    assert spec.clocks["ck_b0"].ports == ()
+    assert spec.resolve("ck_b0") == "ck_a"
+
+
+def test_cgc_source_last_pin_source_with_pin_target() -> None:
+    """Pin-source + pin-target — the chained-forwarded-clock shape
+    (B0's pin source → C0). Both collections are pin-form, so neither
+    one would be mistaken for a flag even before the fix; the test
+    pins the parser's behaviour on the chained idiom end-to-end."""
+    spec = parse(
+        """
+        create_clock -name ck_a -period 10.0 [get_ports ck_a]
+        create_generated_clock -name ck_b0 -master_clock ck_a \\
+            -source [get_ports ck_a] [get_pins u_a/clk_out_b0]
+        create_generated_clock -name ck_c0 -master_clock ck_b0 \\
+            -source [get_pins u_a/clk_out_b0] [get_pins u_b0/clk_out]
+        """
+    )
+    assert spec.pin_clocks == {
+        "u_a/clk_out_b0": "ck_b0",
+        "u_b0/clk_out": "ck_c0",
+    }
+    assert spec.resolve("ck_c0") == "ck_a"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "_skip_collection_arg pre-increments past the first token before "
+        "checking for the closer, so a single-token collection like "
+        "``{ck_a}`` or ``[clk]`` is mis-counted and the trailing target "
+        "gets swallowed. Fix: add an ``if first.endswith(...)`` early "
+        "return after the initial ``index += 1`` in each branch. Flip "
+        "this xfail when the helper is corrected."
+    ),
+)
+def test_cgc_source_last_brace_source_retains_target() -> None:
+    """Tcl brace-form source ``{ck_a}`` — uncommon but legal. Same
+    failure shape (and same one-line fix) applies to single-token
+    bracket sources like ``[clk]``."""
+    spec = parse(
+        """
+        create_clock -name ck_a -period 10.0 [get_ports ck_a]
+        create_generated_clock -name ck_b0 -master_clock ck_a \\
+            -source {ck_a} [get_ports ck_b0]
+        """
+    )
+    assert spec.clocks["ck_b0"].ports == ("ck_b0",)
+
+
+def test_cgc_source_followed_by_other_flag_still_works() -> None:
+    """Non-regression: when ``-source`` is followed by another flag
+    (the ordering all existing fixtures use), the target must still
+    be captured. This case passed on the buggy parser too — it is
+    here so the fix doesn't accidentally trade one regression for
+    another."""
+    spec = parse(
+        """
+        create_clock -name clk -period 10.0 [get_ports clk]
+        create_generated_clock -name clk_div2 -master_clock clk \\
+            -source [get_ports clk] -divide_by 2 [get_pins div_q/Q]
+        """
+    )
+    assert spec.pin_clocks == {"div_q/Q": "clk_div2"}
+    assert spec.resolve("clk_div2") == "clk"
 
 
 def test_generated_clock_async_override_wins() -> None:

--- a/tests/test_sdc_cgc_trailing_target.py
+++ b/tests/test_sdc_cgc_trailing_target.py
@@ -1,0 +1,122 @@
+"""Issue #140 end-to-end regression net.
+
+Re-uses the ``good_source_sync_internal`` netlist (committed .json,
+no Yosys at test time) but feeds it an SDC rewritten to the buggy
+``create_generated_clock ... -source [...] [target]`` shape — the
+form where ``-source`` is the trailing flag before the positional
+target collection.
+
+On the unpatched parser the trailing target is silently swallowed,
+so ``pin_clocks`` is empty and ``trace_clock_root`` walks past each
+forwarded-clock pin to ``ck_a``. The fixture then degenerates into
+"every flop is on ck_a", which is structurally invisible (zero
+cross-domain pairs) — i.e. the analyzer produces a *different*
+view of the same design from the canonical SDC. With the #141 fix
+the trailing-target shape is parsed identically to the canonical
+flag-interleaved form, so analyzer output matches the original
+``good_source_sync_internal`` results.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import assign_domains, find_crossings
+
+JSON = (
+    Path(__file__).parent
+    / "fixtures"
+    / "good_source_sync_internal"
+    / "good_source_sync_internal.json"
+)
+
+# Identical semantics to good_source_sync_internal.sdc but with
+# ``-source`` placed as the trailing flag before the positional
+# target — the shape called out in issue #140.
+TRAILING_TARGET_SDC = """
+create_clock -name ck_a -period 10.0 [get_ports ck_a]
+
+create_generated_clock -name ck_b0 -master_clock ck_a \\
+    -source [get_ports ck_a] [get_pins u_a/clk_out_b0]
+create_generated_clock -name ck_b1 -master_clock ck_a \\
+    -source [get_ports ck_a] [get_pins u_a/clk_out_b1]
+create_generated_clock -name ck_c0 -master_clock ck_b0 \\
+    -source [get_pins u_a/clk_out_b0] [get_pins u_b0/clk_out]
+create_generated_clock -name ck_c1 -master_clock ck_b1 \\
+    -source [get_pins u_a/clk_out_b1] [get_pins u_b1/clk_out]
+
+set_input_delay -clock ck_a 0.0 [get_ports d_in]
+"""
+
+EXPECTED_PIN_CLOCKS = {
+    "u_a/clk_out_b0": "ck_b0",
+    "u_a/clk_out_b1": "ck_b1",
+    "u_b0/clk_out": "ck_c0",
+    "u_b1/clk_out": "ck_c1",
+}
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture netlist not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse(TRAILING_TARGET_SDC)
+    return module, spec
+
+
+def test_trailing_target_sdc_populates_pin_clocks(context) -> None:
+    """The four pin-targeted generated clocks land in ``pin_clocks``
+    even though their declarations put ``-source`` last."""
+    _module, spec = context
+    assert spec.pin_clocks == EXPECTED_PIN_CLOCKS
+
+
+def test_trailing_target_sdc_resolves_to_ck_a(context) -> None:
+    """Every generated clock collapses to ck_a's master — the same
+    invariant the canonical good fixture relies on."""
+    _module, spec = context
+    for c in ("ck_b0", "ck_b1", "ck_c0", "ck_c1"):
+        assert spec.resolve(c) == "ck_a", f"{c} did not resolve to ck_a"
+
+
+def test_trailing_target_sdc_produces_four_block_domains(context) -> None:
+    """Pin-clock retention is load-bearing for ``trace_clock_root``:
+    each forwarded-clock pin must stop the walk and adopt the
+    generated clock's identity, so flops downstream of u_a, u_b0,
+    u_b1 carry distinct clock roots. With the bug the walk continues
+    past the pin to ck_a and every flop collapses onto a single
+    domain."""
+    module, spec = context
+    domains = assign_domains(module, pin_clocks=spec.pin_clocks)
+    clock_roots = {fd.clock for fd in domains}
+    assert clock_roots == {"ck_a", "ck_b0", "ck_b1", "ck_c0", "ck_c1"}
+
+
+def test_trailing_target_sdc_emits_canonical_crossings(context) -> None:
+    """Same crossing inventory as the canonical good fixture: four
+    structural pairs (ck_a→ck_b0, ck_a→ck_b1, ck_b0→ck_c0,
+    ck_b1→ck_c1), zero async after master collapse."""
+    module, spec = context
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    pairs = {(c.src_clock, c.dst_clock) for c in crossings}
+    assert pairs == {
+        ("ck_a", "ck_b0"),
+        ("ck_a", "ck_b1"),
+        ("ck_b0", "ck_c0"),
+        ("ck_b1", "ck_c1"),
+    }
+    async_pairs = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    assert async_pairs == []


### PR DESCRIPTION
## Summary

- Fix `create_generated_clock -source` parsing so it consumes only the source collection
- Preserve the following target collection as the generated clock port/pin target
- Add regression coverage for source followed by a target port

Closes #140.

## Verification

- `uv run pytest -q tests/test_sdc.py tests/test_good_fixtures.py tests/test_bad_source_sync_chain.py`