### PR TITLE
Type positive fixture inputs for CDC-011

### DIFF
--- a/tests/fixtures/clock_gating/clock_gating.sdc
+++ b/tests/fixtures/clock_gating/clock_gating.sdc
@@ -1,1 +1,2 @@
 create_clock -name clk -period 10.0 [get_ports clk]
+set_input_delay -clock clk 1.0 [get_ports d]

--- a/tests/fixtures/good_buffered_gated_bus_crossing/good_buffered_gated_bus_crossing.sdc
+++ b/tests/fixtures/good_buffered_gated_bus_crossing/good_buffered_gated_bus_crossing.sdc
@@ -1,3 +1,5 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports src_data]
+set_input_delay -clock src_clk 1.0 [get_ports src_load_req]

--- a/tests/fixtures/good_dffe_gated_bus_crossing/good_dffe_gated_bus_crossing.sdc
+++ b/tests/fixtures/good_dffe_gated_bus_crossing/good_dffe_gated_bus_crossing.sdc
@@ -1,3 +1,5 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports src_data]
+set_input_delay -clock src_clk 1.0 [get_ports src_load_req]

--- a/tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sdc
+++ b/tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sdc
@@ -1,3 +1,4 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/good_exclusive_clock_mux/good_exclusive_clock_mux.sdc
+++ b/tests/fixtures/good_exclusive_clock_mux/good_exclusive_clock_mux.sdc
@@ -1,5 +1,6 @@
 create_clock -name ck0 -period 10.0 [get_ports ck0]
 create_clock -name ck1 -period  7.5 [get_ports ck1]
+set_input_delay -clock ck0 1.0 [get_ports d_in]
 # Declare async (so the rule pack would normally check this crossing
 # as a CDC issue) AND physically_exclusive (so the analyzer treats
 # the apparent crossing as unreachable and drops it before rule

--- a/tests/fixtures/good_false_path_pair/good_false_path_pair.sdc
+++ b/tests/fixtures/good_false_path_pair/good_false_path_pair.sdc
@@ -1,5 +1,6 @@
 create_clock -name ck_a -period 10.0 [get_ports ck_a]
 create_clock -name ck_b -period  7.5 [get_ports ck_b]
+set_input_delay -clock ck_a 1.0 [get_ports d_in]
 # No set_clock_groups -asynchronous in this file — the async
 # relationship is declared via set_false_path instead, which is
 # equivalent for CDC purposes.

--- a/tests/fixtures/good_generated_clock_div2/good_generated_clock_div2.sdc
+++ b/tests/fixtures/good_generated_clock_div2/good_generated_clock_div2.sdc
@@ -1,5 +1,6 @@
 create_clock -name clk -period 10.0 [get_ports clk]
 create_generated_clock -name clk_div2 -master_clock clk \
     -source [get_ports clk] -divide_by 2 [get_pins clk_div2]
+set_input_delay -clock clk 1.0 [get_ports d_in]
 # clk and clk_div2 are NOT in any async group: they share a master and
 # must be treated as the same domain for CDC.

--- a/tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sdc
+++ b/tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sdc
@@ -1,3 +1,4 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports incr]

--- a/tests/fixtures/good_marked_reset_polarity/good_marked_reset_polarity.sdc
+++ b/tests/fixtures/good_marked_reset_polarity/good_marked_reset_polarity.sdc
@@ -1,1 +1,2 @@
 create_clock -name clk -period 10 [get_ports clk]
+set_input_delay -clock clk 1.0 [get_ports d_in]

--- a/tests/fixtures/good_registered_before_sync/good_registered_before_sync.sdc
+++ b/tests/fixtures/good_registered_before_sync/good_registered_before_sync.sdc
@@ -1,3 +1,5 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports a]
+set_input_delay -clock src_clk 1.0 [get_ports b]

--- a/tests/fixtures/good_registered_source/good_registered_source.sdc
+++ b/tests/fixtures/good_registered_source/good_registered_source.sdc
@@ -1,3 +1,5 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports a]
+set_input_delay -clock src_clk 1.0 [get_ports b]

--- a/tests/fixtures/good_reset_sync/good_reset_sync.sdc
+++ b/tests/fixtures/good_reset_sync/good_reset_sync.sdc
@@ -1,3 +1,4 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/marked_user_sync/marked_user_sync.sdc
+++ b/tests/fixtures/marked_user_sync/marked_user_sync.sdc
@@ -1,3 +1,4 @@
 create_clock -name src_clk -period 10.0 [get_ports src_clk]
 create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
 set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/test_good_fixtures.py
+++ b/tests/test_good_fixtures.py
@@ -152,6 +152,7 @@ def test_good_fixture_has_no_violations(name: str, expected_async: int) -> None:
 
     module = netlist.load(json_path)
     spec = sdc_mod.parse_file(sdc_path)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
     crossings = find_crossings(
         module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
     )


### PR DESCRIPTION
## Summary

- Add `set_input_delay -clock ...` typing to older positive fixtures whose known source-domain data/control inputs were previously unconstrained
- Update `test_good_fixtures.py` to call `synthesize_unconstrained_inputs`, matching the CLI analysis path used by `rtl-buddy-cdc analyze` and compare tooling
- Keep CDC-011 active while making positive fixtures clean under the real CLI path

Closes #147.

## Verification

- `uv run pytest -q tests/test_good_fixtures.py tests/test_sdc.py tests/test_sdc_cgc_trailing_target.py`
- Representative CLI checks for `good_registered_before_sync`, `good_buffered_gated_bus_crossing`, `good_generated_clock_div2`, `marked_user_sync`, and `clock_gating` all return 0 violations.
