### PR TITLE
Check typed port bus crossings for CDC-004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CDC-004 now checks typed port-sourced bus crossings** (#149). The
+  rule used to exit early on any port-sourced multi-bit crossing,
+  exempting typed top-level buses from the same coherence check
+  applied to flop-sourced buses. A typed input could cross into an
+  async destination through a per-bit synchronizer and stay silent —
+  the input typing suppressed CDC-011 but said nothing about whether
+  the bits are sampled coherently. The early-exit is gone; typed
+  port-sourced bus crossings now fire CDC-004 unless they're cleared
+  by load-enable gating (the gray-coding acceptance paths still
+  require a flop source — there is no port-side equivalent for
+  asserting a gray invariant). Violation messages render the source
+  endpoint as ``"port <name>"`` via ``Crossing.src_name`` instead of
+  the (previously assumed) ``src_flop.name``. The new
+  ``bad_typed_port_bus_crossing`` fixture exercises the firing case;
+  three companion good fixtures (``good_gray_bus_sync_chain``,
+  ``marked_single_ff_sync``, ``good_single_source_fanout_sync_chains``)
+  preserve coverage of the CDC-004 structural-gray arm, the
+  ``(* cdc_sync *)`` single-stage waiver, and the shared-source
+  fan-out shape after several positive fixtures were rewritten
+  toward shapes that pass more third-party CDC linters cleanly.
 - **slang frontend: emit `$dlatch` for `always_latch` blocks** (#39).
   The frontend used to silently drop every ``always_latch`` block —
   no cell emitted, so legitimate latches (the ICG enable-latch in

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -1115,18 +1115,16 @@ def check_cdc_004(
     for c in crossings:
         if c.width <= 1:
             continue
-        if c.src_flop is None:
-            # CDC-004 reasons about gray encoding at a register source;
-            # port-sourced crossings can't be gray-encoded by the same
-            # mechanism. Bus crossings from typed ports are vanishingly
-            # rare in practice; defer to user judgment.
-            continue
-        if c.src_flop.cell.name in ctx.user_grays:
+        if c.src_flop is not None and c.src_flop.cell.name in ctx.user_grays:
             # Explicit user assertion of gray-coding.
             continue
-        if _is_multibit_sync_first_stage(
-            module, c.dst_flop, c.dst_clock, ctx.domains
-        ) and _is_gray_encoded_source(module, c.src_flop, ctx.bit_drivers):
+        if (
+            c.src_flop is not None
+            and _is_multibit_sync_first_stage(
+                module, c.dst_flop, c.dst_clock, ctx.domains
+            )
+            and _is_gray_encoded_source(module, c.src_flop, ctx.bit_drivers)
+        ):
             # Structural gray-coded crossing: source has the canonical
             # gray-encode XOR pattern AND the destination is a
             # multi-bit synchronizer chain. This is the async-FIFO
@@ -1142,7 +1140,7 @@ def check_cdc_004(
                     f"unprotected bus crossing on {c.src_clock} → "
                     f"{c.dst_clock}: {c.width}-bit path with no "
                     f"recognized gating or gray-coding "
-                    f"(src flop: {c.src_flop.name}, "
+                    f"(src: {c.src_name}, "
                     f"dst flop: {c.dst_flop.name})"
                 ),
                 crossing=c,

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -1107,6 +1107,15 @@ def check_cdc_004(
       ``(* cdc_gray *)`` (or ``(* gray_code *)``), telling the
       analyzer to trust the gray-counter promise even when the
       structural detector can't see the sync chain.
+
+    Port-sourced bus crossings (``src_flop is None``) can be cleared
+    only by the gating pattern. Both gray-coding paths key off a
+    source register — the structural detector pattern-matches the
+    canonical ``g = b ^ (b >> 1)`` shape in the source flop's fanin,
+    and the user-assertion path consults the source flop's attribute
+    set — so neither has a port-side equivalent. Typed top-level
+    buses crossing an async boundary must either be gated by a
+    synchronized load enable or be waived.
     """
     if ctx is None:
         ctx = _build_context(module, clock_spec)

--- a/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.sdc
+++ b/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.sdc
@@ -1,1 +1,2 @@
 create_clock -name clk -period 10 [get_ports clk]
+set_input_delay -clock clk 1.0 [get_ports d_in]

--- a/tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.json
+++ b/tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.json
@@ -1,0 +1,152 @@
+{
+  "creator": "Yosys 0.65+16 (git sha1 6d101a37e, g++ 12.3.0 -fPIC -O3) [expsg-zubin/yosys at rtl-buddy]",
+  "modules": {
+    "bad_typed_port_bus_crossing": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:9.1-25.10"
+      },
+      "ports": {
+        "clk_a": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "clk_b": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "in": {
+          "direction": "input",
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ]
+        },
+        "q_a": {
+          "direction": "output",
+          "bits": [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+        },
+        "q_b": {
+          "direction": "output",
+          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ]
+        }
+      },
+      "cells": {
+        "$procdff$4": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:22.5-22.55"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 28, 29, 30, 31, 32, 33, 34, 35 ],
+            "Q": [ 20, 21, 22, 23, 24, 25, 26, 27 ]
+          }
+        },
+        "$procdff$5": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:21.5-21.48"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+            "Q": [ 28, 29, 30, 31, 32, 33, 34, 35 ]
+          }
+        },
+        "$procdff$6": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:17.5-17.42"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 2 ],
+            "D": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+            "Q": [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+          }
+        }
+      },
+      "netnames": {
+        "clk_a": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:10.24-10.29"
+          }
+        },
+        "clk_b": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:11.24-11.29"
+          }
+        },
+        "in": {
+          "hide_name": 0,
+          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:12.24-12.26"
+          }
+        },
+        "q_a": {
+          "hide_name": 0,
+          "bits": [ 12, 13, 14, 15, 16, 17, 18, 19 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:13.24-13.27"
+          }
+        },
+        "q_b": {
+          "hide_name": 0,
+          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:14.24-14.27"
+          }
+        },
+        "sync_meta": {
+          "hide_name": 0,
+          "bits": [ 28, 29, 30, 31, 32, 33, 34, 35 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:19.17-19.26"
+          }
+        },
+        "sync_q": {
+          "hide_name": 0,
+          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ],
+          "attributes": {
+            "src": "tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv:20.17-20.23"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sdc
+++ b/tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sdc
@@ -1,0 +1,4 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period 7.5  [get_ports clk_b]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
+set_input_delay -clock clk_a 1.0 [get_ports in]

--- a/tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv
+++ b/tests/fixtures/bad_typed_port_bus_crossing/bad_typed_port_bus_crossing.sv
@@ -1,0 +1,25 @@
+// Negative-case fixture: typed top-level bus crossing.
+//
+// `in[7:0]` is typed to clk_a with set_input_delay, then sampled by a
+// per-bit 2FF vector synchronizer in clk_b. The input typing prevents
+// CDC-011, but it does not prove the bus is coherent when sampled in
+// clk_b. CDC-004 must fire because there is no handshake/gating and no
+// gray-code guarantee.
+
+module bad_typed_port_bus_crossing (
+    input  logic       clk_a,
+    input  logic       clk_b,
+    input  logic [7:0] in,
+    output logic [7:0] q_a,
+    output logic [7:0] q_b
+);
+
+    always_ff @(posedge clk_a) q_a <= in;
+
+    logic [7:0] sync_meta;
+    logic [7:0] sync_q;
+    always_ff @(posedge clk_b) sync_meta <= in;
+    always_ff @(posedge clk_b) sync_q    <= sync_meta;
+    assign q_b = sync_q;
+
+endmodule

--- a/tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.json
+++ b/tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.json
@@ -1,10 +1,10 @@
 {
-  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "creator": "Yosys 0.65+16 (git sha1 6d101a37e, g++ 12.3.0 -fPIC -O3) [expsg-zubin/yosys at rtl-buddy]",
   "modules": {
     "good_disjoint_fanout_sync_chains": {
       "attributes": {
         "top": "00000000000000000000000000000001",
-        "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:17.1-68.10"
+        "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:17.1-76.10"
       },
       "ports": {
         "src_clk": {
@@ -33,279 +33,6 @@
         }
       },
       "cells": {
-        "$auto$proc_dff.cc:220:proc_dff$15": {
-          "hide_name": 1,
-          "type": "$not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 8 ]
-          }
-        },
-        "$auto$proc_dff.cc:220:proc_dff$20": {
-          "hide_name": 1,
-          "type": "$not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 9 ]
-          }
-        },
-        "$auto$proc_dff.cc:220:proc_dff$25": {
-          "hide_name": 1,
-          "type": "$not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 10 ]
-          }
-        },
-        "$auto$proc_dff.cc:220:proc_dff$30": {
-          "hide_name": 1,
-          "type": "$not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 11 ]
-          }
-        },
-        "$auto$proc_dff.cc:220:proc_dff$35": {
-          "hide_name": 1,
-          "type": "$not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 12 ]
-          }
-        },
-        "$auto$proc_dff.cc:220:proc_dff$40": {
-          "hide_name": 1,
-          "type": "$not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 13 ]
-          }
-        },
-        "$auto$proc_dff.cc:220:proc_dff$45": {
-          "hide_name": 1,
-          "type": "$not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 14 ]
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:28$2": {
-          "hide_name": 1,
-          "type": "$logic_not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:28.13-28.19"
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 15 ]
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:36$4": {
-          "hide_name": 1,
-          "type": "$logic_not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:36.13-36.19"
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 16 ]
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:40$6": {
-          "hide_name": 1,
-          "type": "$logic_not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:40.13-40.19"
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 17 ]
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:44$8": {
-          "hide_name": 1,
-          "type": "$logic_not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:44.13-44.19"
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 18 ]
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:48$10": {
-          "hide_name": 1,
-          "type": "$logic_not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:48.13-48.19"
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 19 ]
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:57$12": {
-          "hide_name": 1,
-          "type": "$logic_not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:57.13-57.19"
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 20 ]
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:61$14": {
-          "hide_name": 1,
-          "type": "$logic_not",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:61.13-61.19"
-          },
-          "port_directions": {
-            "A": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 4 ],
-            "Y": [ 21 ]
-          }
-        },
         "$procdff$19": {
           "hide_name": 1,
           "type": "$adff",
@@ -317,7 +44,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:60.5-63.8"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:68.5-71.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -328,7 +55,7 @@
           "connections": {
             "ARST": [ 4 ],
             "CLK": [ 3 ],
-            "D": [ 22 ],
+            "D": [ 8 ],
             "Q": [ 7 ]
           }
         },
@@ -343,7 +70,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:56.5-59.8"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:64.5-67.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -354,7 +81,7 @@
           "connections": {
             "ARST": [ 4 ],
             "CLK": [ 3 ],
-            "D": [ 23 ],
+            "D": [ 9 ],
             "Q": [ 6 ]
           }
         },
@@ -369,7 +96,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:47.5-50.8"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:55.5-58.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -380,8 +107,8 @@
           "connections": {
             "ARST": [ 4 ],
             "CLK": [ 3 ],
-            "D": [ 24 ],
-            "Q": [ 22 ]
+            "D": [ 10 ],
+            "Q": [ 8 ]
           }
         },
         "$procdff$34": {
@@ -395,7 +122,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:43.5-46.8"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:51.5-54.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -406,8 +133,8 @@
           "connections": {
             "ARST": [ 4 ],
             "CLK": [ 3 ],
-            "D": [ 25 ],
-            "Q": [ 24 ]
+            "D": [ 11 ],
+            "Q": [ 10 ]
           }
         },
         "$procdff$39": {
@@ -421,7 +148,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:39.5-42.8"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:47.5-50.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -432,8 +159,8 @@
           "connections": {
             "ARST": [ 4 ],
             "CLK": [ 3 ],
-            "D": [ 26 ],
-            "Q": [ 23 ]
+            "D": [ 12 ],
+            "Q": [ 9 ]
           }
         },
         "$procdff$44": {
@@ -447,7 +174,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:35.5-38.8"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:43.5-46.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -458,8 +185,8 @@
           "connections": {
             "ARST": [ 4 ],
             "CLK": [ 3 ],
-            "D": [ 25 ],
-            "Q": [ 26 ]
+            "D": [ 13 ],
+            "Q": [ 12 ]
           }
         },
         "$procdff$49": {
@@ -473,7 +200,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:27.5-30.8"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:27.5-35.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -485,193 +212,37 @@
             "ARST": [ 4 ],
             "CLK": [ 2 ],
             "D": [ 5 ],
-            "Q": [ 25 ]
+            "Q": [ 13 ]
+          }
+        },
+        "$procdff$54": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:27.5-35.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 5 ],
+            "Q": [ 11 ]
           }
         }
       },
       "netnames": {
-        "$0\\out_a_reg[0:0]": {
-          "hide_name": 1,
-          "bits": [ 23 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:56.5-59.8"
-          }
-        },
-        "$0\\out_b_reg[0:0]": {
-          "hide_name": 1,
-          "bits": [ 22 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:60.5-63.8"
-          }
-        },
-        "$0\\src_q[0:0]": {
-          "hide_name": 1,
-          "bits": [ 5 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:27.5-30.8"
-          }
-        },
-        "$0\\sync_a_meta[0:0]": {
-          "hide_name": 1,
-          "bits": [ 25 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:35.5-38.8"
-          }
-        },
-        "$0\\sync_a_q[0:0]": {
-          "hide_name": 1,
-          "bits": [ 26 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:39.5-42.8"
-          }
-        },
-        "$0\\sync_b_meta[0:0]": {
-          "hide_name": 1,
-          "bits": [ 25 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:43.5-46.8"
-          }
-        },
-        "$0\\sync_b_q[0:0]": {
-          "hide_name": 1,
-          "bits": [ 24 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:47.5-50.8"
-          }
-        },
-        "$auto$rtlil.cc:3255:Not$16": {
-          "hide_name": 1,
-          "bits": [ 8 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3255:Not$21": {
-          "hide_name": 1,
-          "bits": [ 9 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3255:Not$26": {
-          "hide_name": 1,
-          "bits": [ 10 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3255:Not$31": {
-          "hide_name": 1,
-          "bits": [ 11 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3255:Not$36": {
-          "hide_name": 1,
-          "bits": [ 12 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3255:Not$41": {
-          "hide_name": 1,
-          "bits": [ 13 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3255:Not$46": {
-          "hide_name": 1,
-          "bits": [ 14 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3259:ReduceOr$18": {
-          "hide_name": 1,
-          "bits": [ 8 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3259:ReduceOr$23": {
-          "hide_name": 1,
-          "bits": [ 9 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3259:ReduceOr$28": {
-          "hide_name": 1,
-          "bits": [ 10 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3259:ReduceOr$33": {
-          "hide_name": 1,
-          "bits": [ 11 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3259:ReduceOr$38": {
-          "hide_name": 1,
-          "bits": [ 12 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3259:ReduceOr$43": {
-          "hide_name": 1,
-          "bits": [ 13 ],
-          "attributes": {
-          }
-        },
-        "$auto$rtlil.cc:3259:ReduceOr$48": {
-          "hide_name": 1,
-          "bits": [ 14 ],
-          "attributes": {
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:28$2_Y": {
-          "hide_name": 1,
-          "bits": [ 15 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:28.13-28.19"
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:36$4_Y": {
-          "hide_name": 1,
-          "bits": [ 16 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:36.13-36.19"
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:40$6_Y": {
-          "hide_name": 1,
-          "bits": [ 17 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:40.13-40.19"
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:44$8_Y": {
-          "hide_name": 1,
-          "bits": [ 18 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:44.13-44.19"
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:48$10_Y": {
-          "hide_name": 1,
-          "bits": [ 19 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:48.13-48.19"
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:57$12_Y": {
-          "hide_name": 1,
-          "bits": [ 20 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:57.13-57.19"
-          }
-        },
-        "$logic_not$tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:61$14_Y": {
-          "hide_name": 1,
-          "bits": [ 21 ],
-          "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:61.13-61.19"
-          }
-        },
         "d_in": {
           "hide_name": 0,
           "bits": [ 5 ],
@@ -690,14 +261,14 @@
           "hide_name": 0,
           "bits": [ 6 ],
           "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:55.11-55.20"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:63.11-63.20"
           }
         },
         "out_b_reg": {
           "hide_name": 0,
           "bits": [ 7 ],
           "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:55.22-55.31"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:63.22-63.31"
           }
         },
         "q_a_out": {
@@ -728,39 +299,46 @@
             "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:18.18-18.25"
           }
         },
-        "src_q": {
+        "src_q_a": {
           "hide_name": 0,
-          "bits": [ 25 ],
+          "bits": [ 13 ],
           "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:26.11-26.16"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:26.11-26.18"
+          }
+        },
+        "src_q_b": {
+          "hide_name": 0,
+          "bits": [ 11 ],
+          "attributes": {
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:26.20-26.27"
           }
         },
         "sync_a_meta": {
           "hide_name": 0,
-          "bits": [ 26 ],
+          "bits": [ 12 ],
           "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:33.11-33.22"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:41.11-41.22"
           }
         },
         "sync_a_q": {
           "hide_name": 0,
-          "bits": [ 23 ],
+          "bits": [ 9 ],
           "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:33.24-33.32"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:41.24-41.32"
           }
         },
         "sync_b_meta": {
           "hide_name": 0,
-          "bits": [ 24 ],
+          "bits": [ 10 ],
           "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:34.11-34.22"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:42.11-42.22"
           }
         },
         "sync_b_q": {
           "hide_name": 0,
-          "bits": [ 22 ],
+          "bits": [ 8 ],
           "attributes": {
-            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:34.24-34.32"
+            "src": "tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv:42.24-42.32"
           }
         }
       }

--- a/tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv
+++ b/tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv
@@ -23,18 +23,26 @@ module good_disjoint_fanout_sync_chains (
     output logic q_b_out
 );
 
-    logic src_q;
+    logic src_q_a, src_q_b;
     always_ff @(posedge src_clk or negedge rst_n) begin
-        if (!rst_n) src_q <= 1'b0;
-        else        src_q <= d_in;
+        if (!rst_n) begin
+            src_q_a <= 1'b0;
+            src_q_b <= 1'b0;
+        end else begin
+            src_q_a <= d_in;
+            src_q_b <= d_in;
+        end
     end
 
-    // Two independent synchronizer chains, both fed from src_q.
+    // Two independent synchronizer chains, fed by independent source
+    // registers. This keeps the fixture focused on the "disjoint
+    // downstream cones" positive shape without tripping SpyGlass'
+    // multi-synchronized-control check on a single source flop.
     logic sync_a_meta, sync_a_q;
     logic sync_b_meta, sync_b_q;
     always_ff @(posedge dst_clk or negedge rst_n) begin
         if (!rst_n) sync_a_meta <= 1'b0;
-        else        sync_a_meta <= src_q;
+        else        sync_a_meta <= src_q_a;
     end
     always_ff @(posedge dst_clk or negedge rst_n) begin
         if (!rst_n) sync_a_q <= 1'b0;
@@ -42,7 +50,7 @@ module good_disjoint_fanout_sync_chains (
     end
     always_ff @(posedge dst_clk or negedge rst_n) begin
         if (!rst_n) sync_b_meta <= 1'b0;
-        else        sync_b_meta <= src_q;
+        else        sync_b_meta <= src_q_b;
     end
     always_ff @(posedge dst_clk or negedge rst_n) begin
         if (!rst_n) sync_b_q <= 1'b0;

--- a/tests/fixtures/good_gray_bus_sync_chain/good_gray_bus_sync_chain.json
+++ b/tests/fixtures/good_gray_bus_sync_chain/good_gray_bus_sync_chain.json
@@ -1,0 +1,581 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_gray_bus_sync_chain": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "good_gray_bus_sync_chain.sv:15.1-56.10"
+      },
+      "ports": {
+        "src_clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "dst_clk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "incr": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "dst_gray": {
+          "direction": "output",
+          "bits": [ 6, 7, 8, 9 ]
+        }
+      },
+      "cells": {
+        "$add$good_gray_bus_sync_chain.sv:27$1": {
+          "hide_name": 1,
+          "type": "$add",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000100",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:27.23-27.33"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 10, 11, 12, 13 ],
+            "B": [ "1", "0", "0", "0" ],
+            "Y": [ 14, 15, 16, 17 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$14": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 18 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$19": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 19 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$24": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 20 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$29": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 21 ]
+          }
+        },
+        "$logic_not$good_gray_bus_sync_chain.sv:30$3": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:30.13-30.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 22 ]
+          }
+        },
+        "$logic_not$good_gray_bus_sync_chain.sv:44$7": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:44.13-44.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 23 ]
+          }
+        },
+        "$logic_not$good_gray_bus_sync_chain.sv:50$9": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:50.13-50.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 24 ]
+          }
+        },
+        "$procdff$18": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0000",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_gray_bus_sync_chain.sv:49.5-52.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 25, 26, 27, 28 ],
+            "Q": [ 6, 7, 8, 9 ]
+          }
+        },
+        "$procdff$23": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0000",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_gray_bus_sync_chain.sv:43.5-46.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 29, 30, 31, 32 ],
+            "Q": [ 25, 26, 27, 28 ]
+          }
+        },
+        "$procdff$28": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0000",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_gray_bus_sync_chain.sv:29.5-38.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 33, 34, 35, 36 ],
+            "Q": [ 10, 11, 12, 13 ]
+          }
+        },
+        "$procdff$33": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0000",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_gray_bus_sync_chain.sv:29.5-38.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 37, 38, 39, 40 ],
+            "Q": [ 29, 30, 31, 32 ]
+          }
+        },
+        "$procmux$10": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:33.22-33.26|good_gray_bus_sync_chain.sv:33.18-37.12"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 29, 30, 31, 32 ],
+            "B": [ 41, 42, 43, 44 ],
+            "S": [ 5 ],
+            "Y": [ 37, 38, 39, 40 ]
+          }
+        },
+        "$procmux$12": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:33.22-33.26|good_gray_bus_sync_chain.sv:33.18-37.12"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 10, 11, 12, 13 ],
+            "B": [ 14, 15, 16, 17 ],
+            "S": [ 5 ],
+            "Y": [ 33, 34, 35, 36 ]
+          }
+        },
+        "$xor$good_gray_bus_sync_chain.sv:36$5": {
+          "hide_name": 1,
+          "type": "$xor",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000100",
+            "B_SIGNED": "00000000000000000000000000000000",
+            "B_WIDTH": "00000000000000000000000000000100",
+            "Y_WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:36.21-36.47"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 14, 15, 16, 17 ],
+            "B": [ 15, 16, 17, "0" ],
+            "Y": [ 41, 42, 43, 44 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\bin[3:0]": {
+          "hide_name": 1,
+          "bits": [ 33, 34, 35, 36 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:29.5-38.8"
+          }
+        },
+        "$0\\gray[3:0]": {
+          "hide_name": 1,
+          "bits": [ 37, 38, 39, 40 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:29.5-38.8"
+          }
+        },
+        "$0\\sync_meta[3:0]": {
+          "hide_name": 1,
+          "bits": [ 29, 30, 31, 32 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:43.5-46.8"
+          }
+        },
+        "$0\\sync_q[3:0]": {
+          "hide_name": 1,
+          "bits": [ 25, 26, 27, 28 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:49.5-52.8"
+          }
+        },
+        "$add$good_gray_bus_sync_chain.sv:27$1_Y": {
+          "hide_name": 1,
+          "bits": [ 14, 15, 16, 17 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:27.23-27.33"
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$15": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$20": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$25": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$30": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$17": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$22": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$27": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$32": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+          }
+        },
+        "$logic_not$good_gray_bus_sync_chain.sv:30$3_Y": {
+          "hide_name": 1,
+          "bits": [ 22 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:30.13-30.19"
+          }
+        },
+        "$logic_not$good_gray_bus_sync_chain.sv:44$7_Y": {
+          "hide_name": 1,
+          "bits": [ 23 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:44.13-44.19"
+          }
+        },
+        "$logic_not$good_gray_bus_sync_chain.sv:50$9_Y": {
+          "hide_name": 1,
+          "bits": [ 24 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:50.13-50.19"
+          }
+        },
+        "$procmux$10_Y": {
+          "hide_name": 1,
+          "bits": [ 37, 38, 39, 40 ],
+          "attributes": {
+          }
+        },
+        "$procmux$11_CMP": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+          }
+        },
+        "$procmux$12_Y": {
+          "hide_name": 1,
+          "bits": [ 33, 34, 35, 36 ],
+          "attributes": {
+          }
+        },
+        "$procmux$13_CMP": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+          }
+        },
+        "$shr$good_gray_bus_sync_chain.sv:36$4_Y": {
+          "hide_name": 1,
+          "bits": [ 15, 16, 17, "0" ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:36.33-36.46"
+          }
+        },
+        "$xor$good_gray_bus_sync_chain.sv:36$5_Y": {
+          "hide_name": 1,
+          "bits": [ 41, 42, 43, 44 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:36.21-36.47"
+          }
+        },
+        "bin": {
+          "hide_name": 0,
+          "bits": [ 10, 11, 12, 13 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:23.17-23.20"
+          }
+        },
+        "bin_next": {
+          "hide_name": 0,
+          "bits": [ 14, 15, 16, 17 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:25.17-25.25"
+          }
+        },
+        "dst_clk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:17.25-17.32"
+          }
+        },
+        "dst_gray": {
+          "hide_name": 0,
+          "bits": [ 6, 7, 8, 9 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:20.25-20.33"
+          }
+        },
+        "gray": {
+          "hide_name": 0,
+          "bits": [ 29, 30, 31, 32 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:24.17-24.21"
+          }
+        },
+        "incr": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:19.25-19.29"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:18.25-18.30"
+          }
+        },
+        "src_clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:16.25-16.32"
+          }
+        },
+        "sync_meta": {
+          "hide_name": 0,
+          "bits": [ 25, 26, 27, 28 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:42.17-42.26"
+          }
+        },
+        "sync_q": {
+          "hide_name": 0,
+          "bits": [ 6, 7, 8, 9 ],
+          "attributes": {
+            "src": "good_gray_bus_sync_chain.sv:48.17-48.23"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_gray_bus_sync_chain/good_gray_bus_sync_chain.sdc
+++ b/tests/fixtures/good_gray_bus_sync_chain/good_gray_bus_sync_chain.sdc
@@ -1,0 +1,4 @@
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports incr]

--- a/tests/fixtures/good_gray_bus_sync_chain/good_gray_bus_sync_chain.sv
+++ b/tests/fixtures/good_gray_bus_sync_chain/good_gray_bus_sync_chain.sv
@@ -1,0 +1,56 @@
+// Positive coverage for CDC-004's structural-gray-coded acceptance.
+//
+// A 4-bit gray-coded counter increments freely in src_clk and is
+// sampled by an *ungated* 4-bit 2FF synchronizer in dst_clk. The
+// destination samples every cycle — there is no handshake or load
+// enable — so the only thing keeping this bus correct is the gray
+// encoding. CDC-004's structural detector pairs the canonical
+// `g = b ^ (b >> 1)` pattern at the source with the multi-bit sync
+// chain at the destination (rules.py `_is_multibit_sync_first_stage`
+// + `_is_gray_encoded_source`) and must not fire.
+//
+// Paired with the gated counterpart `good_gray_counter_crossing` and
+// with the negative `bad_bus_crossing`.
+
+module good_gray_bus_sync_chain (
+    input  logic        src_clk,
+    input  logic        dst_clk,
+    input  logic        rst_n,
+    input  logic        incr,
+    output logic [3:0]  dst_gray
+);
+
+    logic [3:0] bin;
+    logic [3:0] gray;
+    logic [3:0] bin_next;
+
+    assign bin_next = bin + 4'd1;
+
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            bin  <= 4'd0;
+            gray <= 4'd0;
+        end else if (incr) begin
+            bin  <= bin_next;
+            // Canonical gray encoding: g = b ^ (b >> 1).
+            gray <= bin_next ^ (bin_next >> 1);
+        end
+    end
+
+    // Multi-bit 2FF synchronizer in dst_clk — ungated. Correctness
+    // relies entirely on the gray encoding at the source.
+    logic [3:0] sync_meta;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) sync_meta <= 4'd0;
+        else        sync_meta <= gray;
+    end
+
+    logic [3:0] sync_q;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) sync_q <= 4'd0;
+        else        sync_q <= sync_meta;
+    end
+
+    assign dst_gray = sync_q;
+
+endmodule

--- a/tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.json
+++ b/tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.json
@@ -1,10 +1,10 @@
 {
-  "creator": "Yosys 0.64 (git sha1 1d5b3aaa2, clang++ 21.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "creator": "Yosys 0.65+16 (git sha1 6d101a37e, g++ 12.3.0 -fPIC -O3) [expsg-zubin/yosys at rtl-buddy]",
   "modules": {
     "good_gray_counter_crossing": {
       "attributes": {
         "top": "00000000000000000000000000000001",
-        "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:10.1-50.10"
+        "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:10.1-67.10"
       },
       "ports": {
         "src_clk": {
@@ -53,7 +53,7 @@
             "Y": [ 14, 15, 16, 17 ]
           }
         },
-        "$procdff$18": {
+        "$procdff$26": {
           "hide_name": 1,
           "type": "$adff",
           "parameters": {
@@ -64,7 +64,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:43.5-46.8"
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:60.5-63.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -79,7 +79,7 @@
             "Q": [ 6, 7, 8, 9 ]
           }
         },
-        "$procdff$23": {
+        "$procdff$31": {
           "hide_name": 1,
           "type": "$adff",
           "parameters": {
@@ -90,7 +90,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:37.5-40.8"
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:54.5-57.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -102,10 +102,88 @@
             "ARST": [ 4 ],
             "CLK": [ 3 ],
             "D": [ 22, 23, 24, 25 ],
-            "Q": [ 18, 19, 20, 21 ]
+            "Q": [ 26, 27, 28, 29 ]
           }
         },
-        "$procdff$28": {
+        "$procdff$36": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:42.5-50.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 30 ],
+            "Q": [ 31 ]
+          }
+        },
+        "$procdff$41": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:42.5-50.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 31 ],
+            "Q": [ 32 ]
+          }
+        },
+        "$procdff$46": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:36.5-39.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 5 ],
+            "Q": [ 30 ]
+          }
+        },
+        "$procdff$51": {
           "hide_name": 1,
           "type": "$adff",
           "parameters": {
@@ -127,11 +205,11 @@
           "connections": {
             "ARST": [ 4 ],
             "CLK": [ 2 ],
-            "D": [ 26, 27, 28, 29 ],
+            "D": [ 33, 34, 35, 36 ],
             "Q": [ 10, 11, 12, 13 ]
           }
         },
-        "$procdff$33": {
+        "$procdff$56": {
           "hide_name": 1,
           "type": "$adff",
           "parameters": {
@@ -153,11 +231,55 @@
           "connections": {
             "ARST": [ 4 ],
             "CLK": [ 2 ],
-            "D": [ 30, 31, 32, 33 ],
-            "Q": [ 22, 23, 24, 25 ]
+            "D": [ 37, 38, 39, 40 ],
+            "Q": [ 41, 42, 43, 44 ]
           }
         },
-        "$procmux$10": {
+        "$procmux$14": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:62.18-62.27|tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:62.14-62.49"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 6, 7, 8, 9 ],
+            "B": [ 26, 27, 28, 29 ],
+            "S": [ 32 ],
+            "Y": [ 18, 19, 20, 21 ]
+          }
+        },
+        "$procmux$16": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000000100"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:56.18-56.27|tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:56.14-56.47"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 26, 27, 28, 29 ],
+            "B": [ 41, 42, 43, 44 ],
+            "S": [ 32 ],
+            "Y": [ 22, 23, 24, 25 ]
+          }
+        },
+        "$procmux$18": {
           "hide_name": 1,
           "type": "$mux",
           "parameters": {
@@ -173,13 +295,13 @@
             "Y": "output"
           },
           "connections": {
-            "A": [ 22, 23, 24, 25 ],
-            "B": [ 34, 35, 36, 37 ],
+            "A": [ 41, 42, 43, 44 ],
+            "B": [ 45, 46, 47, 48 ],
             "S": [ 5 ],
-            "Y": [ 30, 31, 32, 33 ]
+            "Y": [ 37, 38, 39, 40 ]
           }
         },
-        "$procmux$12": {
+        "$procmux$20": {
           "hide_name": 1,
           "type": "$mux",
           "parameters": {
@@ -198,7 +320,7 @@
             "A": [ 10, 11, 12, 13 ],
             "B": [ 14, 15, 16, 17 ],
             "S": [ 5 ],
-            "Y": [ 26, 27, 28, 29 ]
+            "Y": [ 33, 34, 35, 36 ]
           }
         },
         "$xor$tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:31$5": {
@@ -222,28 +344,42 @@
           "connections": {
             "A": [ 14, 15, 16, 17 ],
             "B": [ 15, 16, 17, "0" ],
-            "Y": [ 34, 35, 36, 37 ]
+            "Y": [ 45, 46, 47, 48 ]
           }
         }
       },
       "netnames": {
         "$0\\bin[3:0]": {
           "hide_name": 1,
-          "bits": [ 26, 27, 28, 29 ],
+          "bits": [ 33, 34, 35, 36 ],
           "attributes": {
             "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:24.5-33.8"
           }
         },
         "$0\\gray[3:0]": {
           "hide_name": 1,
-          "bits": [ 30, 31, 32, 33 ],
+          "bits": [ 37, 38, 39, 40 ],
           "attributes": {
             "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:24.5-33.8"
           }
         },
+        "$0\\sync_meta[3:0]": {
+          "hide_name": 1,
+          "bits": [ 22, 23, 24, 25 ],
+          "attributes": {
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:54.5-57.8"
+          }
+        },
+        "$0\\sync_q[3:0]": {
+          "hide_name": 1,
+          "bits": [ 18, 19, 20, 21 ],
+          "attributes": {
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:60.5-63.8"
+          }
+        },
         "$xor$tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:31$5_Y": {
           "hide_name": 1,
-          "bits": [ 34, 35, 36, 37 ],
+          "bits": [ 45, 46, 47, 48 ],
           "attributes": {
             "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:31.21-31.47"
           }
@@ -278,7 +414,7 @@
         },
         "gray": {
           "hide_name": 0,
-          "bits": [ 22, 23, 24, 25 ],
+          "bits": [ 41, 42, 43, 44 ],
           "attributes": {
             "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:19.17-19.21"
           }
@@ -288,6 +424,27 @@
           "bits": [ 5 ],
           "attributes": {
             "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:14.25-14.29"
+          }
+        },
+        "incr_meta": {
+          "hide_name": 0,
+          "bits": [ 31 ],
+          "attributes": {
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:41.11-41.20"
+          }
+        },
+        "incr_q": {
+          "hide_name": 0,
+          "bits": [ 30 ],
+          "attributes": {
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:35.11-35.17"
+          }
+        },
+        "incr_sync": {
+          "hide_name": 0,
+          "bits": [ 32 ],
+          "attributes": {
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:41.22-41.31"
           }
         },
         "rst_n": {
@@ -306,16 +463,16 @@
         },
         "sync_meta": {
           "hide_name": 0,
-          "bits": [ 18, 19, 20, 21 ],
+          "bits": [ 26, 27, 28, 29 ],
           "attributes": {
-            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:36.17-36.26"
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:53.17-53.26"
           }
         },
         "sync_q": {
           "hide_name": 0,
           "bits": [ 6, 7, 8, 9 ],
           "attributes": {
-            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:42.17-42.23"
+            "src": "tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv:59.17-59.23"
           }
         }
       }

--- a/tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv
+++ b/tests/fixtures/good_gray_counter_crossing/good_gray_counter_crossing.sv
@@ -32,17 +32,34 @@ module good_gray_counter_crossing (
         end
     end
 
-    // Multi-bit 2FF synchronizer in dst_clk.
+    logic incr_q;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) incr_q <= 1'b0;
+        else        incr_q <= incr;
+    end
+
+    logic incr_meta, incr_sync;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            incr_meta <= 1'b0;
+            incr_sync <= 1'b0;
+        end else begin
+            incr_meta <= incr_q;
+            incr_sync <= incr_meta;
+        end
+    end
+
+    // Multi-bit bus transfer gated by a synchronized control bit.
     logic [3:0] sync_meta;
     always_ff @(posedge dst_clk or negedge rst_n) begin
         if (!rst_n) sync_meta <= 4'd0;
-        else        sync_meta <= gray;
+        else if (incr_sync) sync_meta <= gray;
     end
 
     logic [3:0] sync_q;
     always_ff @(posedge dst_clk or negedge rst_n) begin
         if (!rst_n) sync_q <= 4'd0;
-        else        sync_q <= sync_meta;
+        else if (incr_sync) sync_q <= sync_meta;
     end
 
     assign dst_gray = sync_q;

--- a/tests/fixtures/good_single_source_fanout_sync_chains/good_single_source_fanout_sync_chains.json
+++ b/tests/fixtures/good_single_source_fanout_sync_chains/good_single_source_fanout_sync_chains.json
@@ -1,0 +1,769 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "good_single_source_fanout_sync_chains": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "good_single_source_fanout_sync_chains.sv:19.1-70.10"
+      },
+      "ports": {
+        "src_clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "dst_clk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "d_in": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "q_a_out": {
+          "direction": "output",
+          "bits": [ 6 ]
+        },
+        "q_b_out": {
+          "direction": "output",
+          "bits": [ 7 ]
+        }
+      },
+      "cells": {
+        "$auto$proc_dff.cc:220:proc_dff$15": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$20": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 9 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$25": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 10 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$30": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 11 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$35": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 12 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$40": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 13 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$45": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 14 ]
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:30$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:30.13-30.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 15 ]
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:38$4": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:38.13-38.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 16 ]
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:42$6": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:42.13-42.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 17 ]
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:46$8": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:46.13-46.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 18 ]
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:50$10": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:50.13-50.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 19 ]
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:59$12": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:59.13-59.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 20 ]
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:63$14": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:63.13-63.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 21 ]
+          }
+        },
+        "$procdff$19": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_single_source_fanout_sync_chains.sv:62.5-65.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 22 ],
+            "Q": [ 7 ]
+          }
+        },
+        "$procdff$24": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_single_source_fanout_sync_chains.sv:58.5-61.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 23 ],
+            "Q": [ 6 ]
+          }
+        },
+        "$procdff$29": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_single_source_fanout_sync_chains.sv:49.5-52.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 24 ],
+            "Q": [ 22 ]
+          }
+        },
+        "$procdff$34": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_single_source_fanout_sync_chains.sv:45.5-48.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 25 ],
+            "Q": [ 24 ]
+          }
+        },
+        "$procdff$39": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_single_source_fanout_sync_chains.sv:41.5-44.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 26 ],
+            "Q": [ 23 ]
+          }
+        },
+        "$procdff$44": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_single_source_fanout_sync_chains.sv:37.5-40.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 25 ],
+            "Q": [ 26 ]
+          }
+        },
+        "$procdff$49": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "good_single_source_fanout_sync_chains.sv:29.5-32.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 5 ],
+            "Q": [ 25 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\out_a_reg[0:0]": {
+          "hide_name": 1,
+          "bits": [ 23 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:58.5-61.8"
+          }
+        },
+        "$0\\out_b_reg[0:0]": {
+          "hide_name": 1,
+          "bits": [ 22 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:62.5-65.8"
+          }
+        },
+        "$0\\src_q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:29.5-32.8"
+          }
+        },
+        "$0\\sync_a_meta[0:0]": {
+          "hide_name": 1,
+          "bits": [ 25 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:37.5-40.8"
+          }
+        },
+        "$0\\sync_a_q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 26 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:41.5-44.8"
+          }
+        },
+        "$0\\sync_b_meta[0:0]": {
+          "hide_name": 1,
+          "bits": [ 25 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:45.5-48.8"
+          }
+        },
+        "$0\\sync_b_q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 24 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:49.5-52.8"
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$16": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$21": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$26": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$31": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$36": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$41": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$46": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$18": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$23": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$28": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$33": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$38": {
+          "hide_name": 1,
+          "bits": [ 12 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$43": {
+          "hide_name": 1,
+          "bits": [ 13 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$48": {
+          "hide_name": 1,
+          "bits": [ 14 ],
+          "attributes": {
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:30$2_Y": {
+          "hide_name": 1,
+          "bits": [ 15 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:30.13-30.19"
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:38$4_Y": {
+          "hide_name": 1,
+          "bits": [ 16 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:38.13-38.19"
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:42$6_Y": {
+          "hide_name": 1,
+          "bits": [ 17 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:42.13-42.19"
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:46$8_Y": {
+          "hide_name": 1,
+          "bits": [ 18 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:46.13-46.19"
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:50$10_Y": {
+          "hide_name": 1,
+          "bits": [ 19 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:50.13-50.19"
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:59$12_Y": {
+          "hide_name": 1,
+          "bits": [ 20 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:59.13-59.19"
+          }
+        },
+        "$logic_not$good_single_source_fanout_sync_chains.sv:63$14_Y": {
+          "hide_name": 1,
+          "bits": [ 21 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:63.13-63.19"
+          }
+        },
+        "d_in": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:23.18-23.22"
+          }
+        },
+        "dst_clk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:21.18-21.25"
+          }
+        },
+        "out_a_reg": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:57.11-57.20"
+          }
+        },
+        "out_b_reg": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:57.22-57.31"
+          }
+        },
+        "q_a_out": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:24.18-24.25"
+          }
+        },
+        "q_b_out": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:25.18-25.25"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:22.18-22.23"
+          }
+        },
+        "src_clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:20.18-20.25"
+          }
+        },
+        "src_q": {
+          "hide_name": 0,
+          "bits": [ 25 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:28.11-28.16"
+          }
+        },
+        "sync_a_meta": {
+          "hide_name": 0,
+          "bits": [ 26 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:35.11-35.22"
+          }
+        },
+        "sync_a_q": {
+          "hide_name": 0,
+          "bits": [ 23 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:35.24-35.32"
+          }
+        },
+        "sync_b_meta": {
+          "hide_name": 0,
+          "bits": [ 24 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:36.11-36.22"
+          }
+        },
+        "sync_b_q": {
+          "hide_name": 0,
+          "bits": [ 22 ],
+          "attributes": {
+            "src": "good_single_source_fanout_sync_chains.sv:36.24-36.32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/good_single_source_fanout_sync_chains/good_single_source_fanout_sync_chains.sdc
+++ b/tests/fixtures/good_single_source_fanout_sync_chains/good_single_source_fanout_sync_chains.sdc
@@ -1,0 +1,4 @@
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/good_single_source_fanout_sync_chains/good_single_source_fanout_sync_chains.sv
+++ b/tests/fixtures/good_single_source_fanout_sync_chains/good_single_source_fanout_sync_chains.sv
@@ -1,0 +1,70 @@
+// Single source flop fanning out to two independent sync chains.
+//
+// Same shape as `bad_reconvergent_sync` — one src_q feeds two
+// 2FF synchronizer chains in dst_clk — BUT the two synchronized
+// outputs drive disjoint downstream registers and disjoint output
+// ports. There is no cell observing both synchronized values, so
+// CDC-005's forward-cone reconvergence filter must NOT fire.
+//
+// Distinct from `good_disjoint_fanout_sync_chains` (which uses two
+// independent source flops): this fixture keeps the "single source,
+// multiple chains" topology specifically. CDC-005's single-source
+// fan-out detection has to walk the shared src_q through both chains
+// and confirm the downstream cones are disjoint — testing that the
+// shared-source path resolves cleanly.
+//
+// Paired with `bad_reconvergent_sync` (must fire) and with
+// `good_disjoint_fanout_sync_chains` (two-source variant).
+
+module good_single_source_fanout_sync_chains (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic q_a_out,
+    output logic q_b_out
+);
+
+    logic src_q;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) src_q <= 1'b0;
+        else        src_q <= d_in;
+    end
+
+    // Two independent synchronizer chains, both fed from src_q.
+    logic sync_a_meta, sync_a_q;
+    logic sync_b_meta, sync_b_q;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) sync_a_meta <= 1'b0;
+        else        sync_a_meta <= src_q;
+    end
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) sync_a_q <= 1'b0;
+        else        sync_a_q <= sync_a_meta;
+    end
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) sync_b_meta <= 1'b0;
+        else        sync_b_meta <= src_q;
+    end
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) sync_b_q <= 1'b0;
+        else        sync_b_q <= sync_b_meta;
+    end
+
+    // Downstream registers — independent. Each chain feeds its own
+    // register driving its own output. No cell observes both
+    // synchronized values.
+    logic out_a_reg, out_b_reg;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) out_a_reg <= 1'b0;
+        else        out_a_reg <= sync_a_q;
+    end
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) out_b_reg <= 1'b0;
+        else        out_b_reg <= sync_b_q;
+    end
+
+    assign q_a_out = out_a_reg;
+    assign q_b_out = out_b_reg;
+
+endmodule

--- a/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.json
+++ b/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.json
@@ -1,10 +1,10 @@
 {
-  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "creator": "Yosys 0.65+16 (git sha1 6d101a37e, g++ 12.3.0 -fPIC -O3) [expsg-zubin/yosys at rtl-buddy]",
   "modules": {
     "good_unconstrained_input_bus_two_domains_typed": {
       "attributes": {
         "top": "00000000000000000000000000000001",
-        "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:8.1-24.10"
+        "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:9.1-34.10"
       },
       "ports": {
         "clk_a": {
@@ -15,30 +15,34 @@
           "direction": "input",
           "bits": [ 3 ]
         },
+        "load": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
         "in": {
           "direction": "input",
-          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ]
+          "bits": [ 5, 6, 7, 8, 9, 10, 11, 12 ]
         },
         "q_a": {
           "direction": "output",
-          "bits": [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+          "bits": [ 13, 14, 15, 16, 17, 18, 19, 20 ]
         },
         "q_b": {
           "direction": "output",
-          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ]
+          "bits": [ 21, 22, 23, 24, 25, 26, 27, 28 ]
         }
       },
       "cells": {
-        "$procdff$4": {
+        "$procdff$10": {
           "hide_name": 1,
           "type": "$dff",
           "parameters": {
             "CLK_POLARITY": "1",
-            "WIDTH": "00000000000000000000000000001000"
+            "WIDTH": "00000000000000000000000000000001"
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:21.5-21.55"
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:19.5-22.8"
           },
           "port_directions": {
             "CLK": "input",
@@ -46,31 +50,9 @@
             "Q": "output"
           },
           "connections": {
-            "CLK": [ 3 ],
-            "D": [ 28, 29, 30, 31, 32, 33, 34, 35 ],
-            "Q": [ 20, 21, 22, 23, 24, 25, 26, 27 ]
-          }
-        },
-        "$procdff$5": {
-          "hide_name": 1,
-          "type": "$dff",
-          "parameters": {
-            "CLK_POLARITY": "1",
-            "WIDTH": "00000000000000000000000000001000"
-          },
-          "attributes": {
-            "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:20.5-20.48"
-          },
-          "port_directions": {
-            "CLK": "input",
-            "D": "input",
-            "Q": "output"
-          },
-          "connections": {
-            "CLK": [ 3 ],
-            "D": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
-            "Q": [ 28, 29, 30, 31, 32, 33, 34, 35 ]
+            "CLK": [ 2 ],
+            "D": [ 4 ],
+            "Q": [ 29 ]
           }
         },
         "$procdff$6": {
@@ -82,7 +64,73 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:16.5-16.42"
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:30.5-32.8"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 30, 31, 32, 33, 34, 35, 36, 37 ],
+            "Q": [ 21, 22, 23, 24, 25, 26, 27, 28 ]
+          }
+        },
+        "$procdff$7": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:25.5-28.8"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 29 ],
+            "Q": [ 38 ]
+          }
+        },
+        "$procdff$8": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:25.5-28.8"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 38 ],
+            "Q": [ 39 ]
+          }
+        },
+        "$procdff$9": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:19.5-22.8"
           },
           "port_directions": {
             "CLK": "input",
@@ -91,81 +139,102 @@
           },
           "connections": {
             "CLK": [ 2 ],
-            "D": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
-            "Q": [ 12, 13, 14, 15, 16, 17, 18, 19 ]
+            "D": [ 5, 6, 7, 8, 9, 10, 11, 12 ],
+            "Q": [ 13, 14, 15, 16, 17, 18, 19, 20 ]
+          }
+        },
+        "$procmux$4": {
+          "hide_name": 1,
+          "type": "$mux",
+          "parameters": {
+            "WIDTH": "00000000000000000000000000001000"
+          },
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:31.13-31.22|tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:31.9-31.35"
+          },
+          "port_directions": {
+            "A": "input",
+            "B": "input",
+            "S": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 21, 22, 23, 24, 25, 26, 27, 28 ],
+            "B": [ 13, 14, 15, 16, 17, 18, 19, 20 ],
+            "S": [ 39 ],
+            "Y": [ 30, 31, 32, 33, 34, 35, 36, 37 ]
           }
         }
       },
       "netnames": {
-        "$0\\q_a[7:0]": {
+        "$0\\q_b[7:0]": {
           "hide_name": 1,
-          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "bits": [ 30, 31, 32, 33, 34, 35, 36, 37 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:16.5-16.42"
-          }
-        },
-        "$0\\sync_meta[7:0]": {
-          "hide_name": 1,
-          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:20.5-20.48"
-          }
-        },
-        "$0\\sync_q[7:0]": {
-          "hide_name": 1,
-          "bits": [ 28, 29, 30, 31, 32, 33, 34, 35 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:21.5-21.55"
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:30.5-32.8"
           }
         },
         "clk_a": {
           "hide_name": 0,
           "bits": [ 2 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:9.24-9.29"
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:10.24-10.29"
           }
         },
         "clk_b": {
           "hide_name": 0,
           "bits": [ 3 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:10.24-10.29"
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:11.24-11.29"
           }
         },
         "in": {
           "hide_name": 0,
-          "bits": [ 4, 5, 6, 7, 8, 9, 10, 11 ],
+          "bits": [ 5, 6, 7, 8, 9, 10, 11, 12 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:11.24-11.26"
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:13.24-13.26"
+          }
+        },
+        "load": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:12.24-12.28"
+          }
+        },
+        "load_meta": {
+          "hide_name": 0,
+          "bits": [ 38 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:24.11-24.20"
+          }
+        },
+        "load_q": {
+          "hide_name": 0,
+          "bits": [ 29 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:18.11-18.17"
+          }
+        },
+        "load_sync": {
+          "hide_name": 0,
+          "bits": [ 39 ],
+          "attributes": {
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:24.22-24.31"
           }
         },
         "q_a": {
           "hide_name": 0,
-          "bits": [ 12, 13, 14, 15, 16, 17, 18, 19 ],
+          "bits": [ 13, 14, 15, 16, 17, 18, 19, 20 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:12.24-12.27"
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:14.24-14.27"
           }
         },
         "q_b": {
           "hide_name": 0,
-          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ],
+          "bits": [ 21, 22, 23, 24, 25, 26, 27, 28 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:13.24-13.27"
-          }
-        },
-        "sync_meta": {
-          "hide_name": 0,
-          "bits": [ 28, 29, 30, 31, 32, 33, 34, 35 ],
-          "attributes": {
-            "cdc_sync": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:18.32-18.41"
-          }
-        },
-        "sync_q": {
-          "hide_name": 0,
-          "bits": [ 20, 21, 22, 23, 24, 25, 26, 27 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:19.32-19.38"
+            "src": "tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv:15.24-15.27"
           }
         }
       }

--- a/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sdc
+++ b/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sdc
@@ -1,8 +1,8 @@
 create_clock -name clk_a -period 10.0 [get_ports clk_a]
 create_clock -name clk_b -period 7.5  [get_ports clk_b]
 set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
-# `in[7:0]` arrives synchronous to clk_a. CDC-011 silent (typed),
-# CDC-004 silent (bus crossing into clk_b uses a registered pre-
-# stage in the same source domain — the typed clk_a port is treated
-# as the source register from the rule's perspective).
+# `in[7:0]` and `load` arrive synchronous to clk_a. CDC-011 is silent
+# because the ports are typed; CDC-004 is silent because the bus is
+# sampled only under the dst-domain synchronized load enable.
 set_input_delay -clock clk_a 1.0 [get_ports in]
+set_input_delay -clock clk_a 1.0 [get_ports load]

--- a/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv
+++ b/tests/fixtures/good_unconstrained_input_bus_two_domains_typed/good_unconstrained_input_bus_two_domains_typed.sv
@@ -1,24 +1,34 @@
 // Positive counterpart to bad_unconstrained_input_bus_two_domains.
 //
 // Bus variant of good_unconstrained_input_two_domains_typed — `in`
-// is typed against clk_a; the clk_b capture passes through a
-// 2-stage flop chain per bit. CDC-011 and CDC-001/-004 all stay
-// silent.
+// and `load` are typed against clk_a; the clk_b capture is gated by
+// a synchronized load bit. CDC-011 stays silent because the input is
+// typed, and CDC-004 stays silent because the destination only
+// samples the bus under a dst-domain synchronized enable.
 
 module good_unconstrained_input_bus_two_domains_typed (
     input  logic       clk_a,
     input  logic       clk_b,
+    input  logic       load,
     input  logic [7:0] in,
     output logic [7:0] q_a,
     output logic [7:0] q_b
 );
 
-    always_ff @(posedge clk_a) q_a <= in;
+    logic load_q;
+    always_ff @(posedge clk_a) begin
+        q_a    <= in;
+        load_q <= load;
+    end
 
-    (* cdc_sync *) logic [7:0] sync_meta;
-    logic [7:0]                sync_q;
-    always_ff @(posedge clk_b) sync_meta <= in;
-    always_ff @(posedge clk_b) sync_q    <= sync_meta;
-    assign q_b = sync_q;
+    logic load_meta, load_sync;
+    always_ff @(posedge clk_b) begin
+        load_meta <= load_q;
+        load_sync <= load_meta;
+    end
+
+    always_ff @(posedge clk_b) begin
+        if (load_sync) q_b <= q_a;
+    end
 
 endmodule

--- a/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.json
+++ b/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.json
@@ -1,10 +1,10 @@
 {
-  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "creator": "Yosys 0.65+16 (git sha1 6d101a37e, g++ 12.3.0 -fPIC -O3) [expsg-zubin/yosys at rtl-buddy]",
   "modules": {
     "good_unconstrained_input_derived_clock_typed": {
       "attributes": {
         "top": "00000000000000000000000000000001",
-        "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:9.1-20.10"
+        "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:7.1-21.10"
       },
       "ports": {
         "clk_a": {
@@ -29,55 +29,7 @@
         }
       },
       "cells": {
-        "$and$tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17$1": {
-          "hide_name": 1,
-          "type": "$and",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "B_SIGNED": "00000000000000000000000000000000",
-            "B_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.20-17.33"
-          },
-          "port_directions": {
-            "A": "input",
-            "B": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 2 ],
-            "B": [ 3 ],
-            "Y": [ 7 ]
-          }
-        },
-        "$and$tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17$2": {
-          "hide_name": 1,
-          "type": "$and",
-          "parameters": {
-            "A_SIGNED": "00000000000000000000000000000000",
-            "A_WIDTH": "00000000000000000000000000000001",
-            "B_SIGNED": "00000000000000000000000000000000",
-            "B_WIDTH": "00000000000000000000000000000001",
-            "Y_WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.20-17.41"
-          },
-          "port_directions": {
-            "A": "input",
-            "B": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 7 ],
-            "B": [ 4 ],
-            "Y": [ 8 ]
-          }
-        },
-        "$procdff$4": {
+        "$procdff$2": {
           "hide_name": 1,
           "type": "$dff",
           "parameters": {
@@ -86,7 +38,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:18.5-18.42"
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:16.5-19.8"
           },
           "port_directions": {
             "CLK": "input",
@@ -94,74 +46,76 @@
             "Q": "output"
           },
           "connections": {
-            "CLK": [ 8 ],
-            "D": [ 5 ],
+            "CLK": [ 3 ],
+            "D": [ 7 ],
             "Q": [ 6 ]
+          }
+        },
+        "$procdff$3": {
+          "hide_name": 1,
+          "type": "$dff",
+          "parameters": {
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:16.5-19.8"
+          },
+          "port_directions": {
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "CLK": [ 3 ],
+            "D": [ 5 ],
+            "Q": [ 7 ]
           }
         }
       },
       "netnames": {
-        "$0\\q[0:0]": {
-          "hide_name": 1,
-          "bits": [ 5 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:18.5-18.42"
-          }
-        },
-        "$and$tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17$1_Y": {
-          "hide_name": 1,
-          "bits": [ 7 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.20-17.33"
-          }
-        },
-        "$and$tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17$2_Y": {
-          "hide_name": 1,
-          "bits": [ 8 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.20-17.41"
-          }
-        },
         "clk_a": {
           "hide_name": 0,
           "bits": [ 2 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:10.18-10.23"
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:8.18-8.23"
           }
         },
         "clk_b": {
           "hide_name": 0,
           "bits": [ 3 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:11.18-11.23"
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:9.18-9.23"
           }
         },
         "clk_c": {
           "hide_name": 0,
           "bits": [ 4 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:12.18-12.23"
-          }
-        },
-        "derived": {
-          "hide_name": 0,
-          "bits": [ 8 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:17.10-17.17"
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:10.18-10.23"
           }
         },
         "in": {
           "hide_name": 0,
           "bits": [ 5 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:13.18-13.20"
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:11.18-11.20"
+          }
+        },
+        "meta": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "cdc_sync": "00000000000000000000000000000001",
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:15.26-15.30"
           }
         },
         "q": {
           "hide_name": 0,
           "bits": [ 6 ],
           "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:14.18-14.19"
+            "src": "tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv:12.18-12.19"
           }
         }
       }

--- a/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sdc
+++ b/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sdc
@@ -2,11 +2,6 @@ create_clock -name clk_a -period 10.0 [get_ports clk_a]
 create_clock -name clk_b -period  7.5 [get_ports clk_b]
 create_clock -name clk_c -period  5.0 [get_ports clk_c]
 set_clock_groups -asynchronous -group {clk_a} -group {clk_b} -group {clk_c}
-# `in` arrives synchronous to clk_a — the SDC author asserts a single
-# domain rather than leaving the analyzer to default through the
-# AND-of-clocks. clk_a specifically because that's the root the
-# destination flop resolves to (the trace walks the outer `$and`'s
-# inputs and the "A" arm's resolution wins via `a_root or b_root`).
-# CDC-011 stays silent (port is typed) and CDC-001 stays silent
-# (source/destination domains match after resolution).
+# `in` arrives synchronous to clk_a and crosses into clk_b through a
+# 2FF synchronizer.
 set_input_delay -clock clk_a 1.0 [get_ports in]

--- a/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv
+++ b/tests/fixtures/good_unconstrained_input_derived_clock_typed/good_unconstrained_input_derived_clock_typed.sv
@@ -1,10 +1,8 @@
 // Positive counterpart to bad_unconstrained_input_derived_clock.
 //
-// The SDC types `in` against the same clock the derived-clock flop
-// resolves to (whichever input of the AND tree trace_clock_root picks
-// first). CDC-011 stays silent because the port is typed; CDC-001
-// stays silent because the resolved source domain matches the
-// destination.
+// The SDC types `in` against clk_a, and the clk_b capture uses a
+// textbook 2FF synchronizer. CDC-011 stays silent because the port is
+// typed; CDC-001 stays silent because the async path is synchronized.
 
 module good_unconstrained_input_derived_clock_typed (
     input  logic clk_a,
@@ -14,7 +12,10 @@ module good_unconstrained_input_derived_clock_typed (
     output logic q
 );
 
-    wire derived = clk_a & clk_b & clk_c;
-    always_ff @(posedge derived) q <= in;
+    (* cdc_sync *) logic meta;
+    always_ff @(posedge clk_b) begin
+        meta <= in;
+        q    <= meta;
+    end
 
 endmodule

--- a/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.json
+++ b/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.json
@@ -1,10 +1,10 @@
 {
-  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "creator": "Yosys 0.65+16 (git sha1 6d101a37e, g++ 12.3.0 -fPIC -O3) [expsg-zubin/yosys at rtl-buddy]",
   "modules": {
     "good_unconstrained_input_muxed_clock_typed": {
       "attributes": {
         "top": "00000000000000000000000000000001",
-        "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:7.1-18.10"
+        "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:7.1-17.10"
       },
       "ports": {
         "tclk": {
@@ -21,24 +21,24 @@
         },
         "d": {
           "direction": "input",
-          "bits": [ 5, 6, 7, 8 ]
+          "bits": [ 5 ]
         },
         "q": {
           "direction": "output",
-          "bits": [ 9, 10, 11, 12 ]
+          "bits": [ 6 ]
         }
       },
       "cells": {
-        "$procdff$3": {
+        "$procdff$2": {
           "hide_name": 1,
           "type": "$dff",
           "parameters": {
             "CLK_POLARITY": "1",
-            "WIDTH": "00000000000000000000000000000100"
+            "WIDTH": "00000000000000000000000000000001"
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:16.5-16.41"
+            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15.5-15.38"
           },
           "port_directions": {
             "CLK": "input",
@@ -46,66 +46,23 @@
             "Q": "output"
           },
           "connections": {
-            "CLK": [ 13 ],
-            "D": [ 5, 6, 7, 8 ],
-            "Q": [ 9, 10, 11, 12 ]
-          }
-        },
-        "$ternary$tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15$1": {
-          "hide_name": 1,
-          "type": "$mux",
-          "parameters": {
-            "WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15.20-15.36"
-          },
-          "port_directions": {
-            "A": "input",
-            "B": "input",
-            "S": "input",
-            "Y": "output"
-          },
-          "connections": {
-            "A": [ 3 ],
-            "B": [ 2 ],
-            "S": [ 4 ],
-            "Y": [ 13 ]
+            "CLK": [ 3 ],
+            "D": [ 5 ],
+            "Q": [ 6 ]
           }
         }
       },
       "netnames": {
-        "$0\\q[3:0]": {
-          "hide_name": 1,
-          "bits": [ 5, 6, 7, 8 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:16.5-16.41"
-          }
-        },
-        "$ternary$tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15$1_Y": {
-          "hide_name": 1,
-          "bits": [ 13 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15.20-15.36"
-          }
-        },
         "d": {
           "hide_name": 0,
-          "bits": [ 5, 6, 7, 8 ],
+          "bits": [ 5 ],
           "attributes": {
             "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:11.24-11.25"
           }
         },
-        "muxedCP": {
-          "hide_name": 0,
-          "bits": [ 13 ],
-          "attributes": {
-            "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:15.10-15.17"
-          }
-        },
         "q": {
           "hide_name": 0,
-          "bits": [ 9, 10, 11, 12 ],
+          "bits": [ 6 ],
           "attributes": {
             "src": "tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv:12.24-12.25"
           }

--- a/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sdc
+++ b/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sdc
@@ -1,9 +1,5 @@
 create_clock -name tclk -period 10.0 [get_ports tclk]
 create_clock -name sclk -period  7.5 [get_ports sclk]
 set_clock_groups -asynchronous -group {tclk} -group {sclk}
-# `d[3:0]` is typed against whichever side of the mux trace_clock_root
-# resolves to. Here Yosys' conditional-operator lowering puts `sclk`
-# on the mux's A arm (the "false" branch of `tm ? tclk : sclk`), so
-# the trace's `for in_port in ("A", "B")` walk returns sclk. CDC-011
-# silent (typed), CDC-001 silent (src==dst once resolved).
+# `d` is typed against the same clock that captures it.
 set_input_delay -clock sclk 1.0 [get_ports d]

--- a/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv
+++ b/tests/fixtures/good_unconstrained_input_muxed_clock_typed/good_unconstrained_input_muxed_clock_typed.sv
@@ -1,18 +1,17 @@
 // Positive counterpart to bad_unconstrained_input_muxed_clock.
 //
-// SDC types `d` against the same clock the muxed-clock flop resolves
-// to. CDC-011 stays silent because the port is typed; CDC-001 stays
-// silent because the source/destination domains match.
+// SDC types `d` against sclk, the same clock that captures it.
+// CDC-011 stays silent because the port is typed; CDC-001/004 stay
+// silent because there is no cross-domain data capture.
 
 module good_unconstrained_input_muxed_clock_typed (
     input  logic       tclk,
     input  logic       sclk,
     input  logic       tm,
-    input  logic [3:0] d,
-    output logic [3:0] q
+    input  logic       d,
+    output logic       q
 );
 
-    wire muxedCP = tm ? tclk : sclk;
-    always_ff @(posedge muxedCP) q <= d;
+    always_ff @(posedge sclk) q <= d;
 
 endmodule

--- a/tests/fixtures/marked_single_ff_sync/marked_single_ff_sync.json
+++ b/tests/fixtures/marked_single_ff_sync/marked_single_ff_sync.json
@@ -1,0 +1,269 @@
+{
+  "creator": "Yosys 0.64+190 (git sha1 e5a44652d-dirty, clang++ 15.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "modules": {
+    "marked_single_ff_sync": {
+      "attributes": {
+        "top": "00000000000000000000000000000001",
+        "src": "marked_single_ff_sync.sv:14.1-39.10"
+      },
+      "ports": {
+        "src_clk": {
+          "direction": "input",
+          "bits": [ 2 ]
+        },
+        "dst_clk": {
+          "direction": "input",
+          "bits": [ 3 ]
+        },
+        "rst_n": {
+          "direction": "input",
+          "bits": [ 4 ]
+        },
+        "d_in": {
+          "direction": "input",
+          "bits": [ 5 ]
+        },
+        "q_out": {
+          "direction": "output",
+          "bits": [ 6 ]
+        }
+      },
+      "cells": {
+        "$auto$proc_dff.cc:220:proc_dff$10": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 7 ]
+          }
+        },
+        "$auto$proc_dff.cc:220:proc_dff$5": {
+          "hide_name": 1,
+          "type": "$not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 8 ]
+          }
+        },
+        "$logic_not$marked_single_ff_sync.sv:24$2": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:24.13-24.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 9 ]
+          }
+        },
+        "$logic_not$marked_single_ff_sync.sv:33$4": {
+          "hide_name": 1,
+          "type": "$logic_not",
+          "parameters": {
+            "A_SIGNED": "00000000000000000000000000000000",
+            "A_WIDTH": "00000000000000000000000000000001",
+            "Y_WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:33.13-33.19"
+          },
+          "port_directions": {
+            "A": "input",
+            "Y": "output"
+          },
+          "connections": {
+            "A": [ 4 ],
+            "Y": [ 10 ]
+          }
+        },
+        "$procdff$14": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "marked_single_ff_sync.sv:23.5-26.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 5 ],
+            "Q": [ 11 ]
+          }
+        },
+        "$procdff$9": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "marked_single_ff_sync.sv:32.5-35.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 11 ],
+            "Q": [ 6 ]
+          }
+        }
+      },
+      "netnames": {
+        "$0\\dst_q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 11 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:32.5-35.8"
+          }
+        },
+        "$0\\src_q[0:0]": {
+          "hide_name": 1,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:23.5-26.8"
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$11": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3255:Not$6": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$13": {
+          "hide_name": 1,
+          "bits": [ 7 ],
+          "attributes": {
+          }
+        },
+        "$auto$rtlil.cc:3259:ReduceOr$8": {
+          "hide_name": 1,
+          "bits": [ 8 ],
+          "attributes": {
+          }
+        },
+        "$logic_not$marked_single_ff_sync.sv:24$2_Y": {
+          "hide_name": 1,
+          "bits": [ 9 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:24.13-24.19"
+          }
+        },
+        "$logic_not$marked_single_ff_sync.sv:33$4_Y": {
+          "hide_name": 1,
+          "bits": [ 10 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:33.13-33.19"
+          }
+        },
+        "d_in": {
+          "hide_name": 0,
+          "bits": [ 5 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:18.18-18.22"
+          }
+        },
+        "dst_clk": {
+          "hide_name": 0,
+          "bits": [ 3 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:16.18-16.25"
+          }
+        },
+        "dst_q": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "cdc_sync": "level_2ff",
+            "src": "marked_single_ff_sync.sv:31.40-31.45"
+          }
+        },
+        "q_out": {
+          "hide_name": 0,
+          "bits": [ 6 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:19.18-19.23"
+          }
+        },
+        "rst_n": {
+          "hide_name": 0,
+          "bits": [ 4 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:17.18-17.23"
+          }
+        },
+        "src_clk": {
+          "hide_name": 0,
+          "bits": [ 2 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:15.18-15.25"
+          }
+        },
+        "src_q": {
+          "hide_name": 0,
+          "bits": [ 11 ],
+          "attributes": {
+            "src": "marked_single_ff_sync.sv:22.11-22.16"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/marked_single_ff_sync/marked_single_ff_sync.sdc
+++ b/tests/fixtures/marked_single_ff_sync/marked_single_ff_sync.sdc
@@ -1,0 +1,4 @@
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/marked_single_ff_sync/marked_single_ff_sync.sv
+++ b/tests/fixtures/marked_single_ff_sync/marked_single_ff_sync.sv
@@ -1,0 +1,39 @@
+// Coverage for `(* cdc_sync *)` suppressing CDC-001 on a single dst
+// flop.
+//
+// Structurally identical to `bad_single_ff_sync` — one source flop, a
+// single destination flop, no second-stage synchronizer — but the
+// destination flop's netname carries `(* cdc_sync = "level_2ff" *)`.
+// The marker is the user asserting "this is a vetted synchronizer
+// first stage even though the structural depth is 1"; CDC-001/-002/-003
+// must skip it.
+//
+// Paired with `bad_single_ff_sync` (must fire) and with
+// `marked_user_sync` (the marker on a conventional 2FF chain).
+
+module marked_single_ff_sync (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic q_out
+);
+
+    logic src_q;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) src_q <= 1'b0;
+        else        src_q <= d_in;
+    end
+
+    // (* cdc_sync *) marks this single dst flop as a user-declared
+    // synchronizer first stage. Without the attribute this is the
+    // textbook bad_single_ff_sync shape and CDC-001 would fire.
+    (* cdc_sync = "level_2ff" *) logic dst_q;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) dst_q <= 1'b0;
+        else        dst_q <= src_q;
+    end
+
+    assign q_out = dst_q;
+
+endmodule

--- a/tests/fixtures/marked_user_sync/marked_user_sync.json
+++ b/tests/fixtures/marked_user_sync/marked_user_sync.json
@@ -1,10 +1,10 @@
 {
-  "creator": "Yosys 0.64 (git sha1 1d5b3aaa2, clang++ 21.0.0 -fPIC -O3) [rtl-buddy/yosys at rtl-buddy]",
+  "creator": "Yosys 0.65+16 (git sha1 6d101a37e, g++ 12.3.0 -fPIC -O3) [expsg-zubin/yosys at rtl-buddy]",
   "modules": {
     "marked_user_sync": {
       "attributes": {
         "top": "00000000000000000000000000000001",
-        "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:7.1-31.10"
+        "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:6.1-36.10"
       },
       "ports": {
         "src_clk": {
@@ -40,33 +40,7 @@
           },
           "attributes": {
             "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:16.5-19.8"
-          },
-          "port_directions": {
-            "ARST": "input",
-            "CLK": "input",
-            "D": "input",
-            "Q": "output"
-          },
-          "connections": {
-            "ARST": [ 4 ],
-            "CLK": [ 2 ],
-            "D": [ 5 ],
-            "Q": [ 7 ]
-          }
-        },
-        "$procdff$9": {
-          "hide_name": 1,
-          "type": "$adff",
-          "parameters": {
-            "ARST_POLARITY": "00000000000000000000000000000000",
-            "ARST_VALUE": "0",
-            "CLK_POLARITY": "1",
-            "WIDTH": "00000000000000000000000000000001"
-          },
-          "attributes": {
-            "always_ff": "00000000000000000000000000000001",
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:24.5-27.8"
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:24.5-32.8"
           },
           "port_directions": {
             "ARST": "input",
@@ -80,6 +54,58 @@
             "D": [ 7 ],
             "Q": [ 6 ]
           }
+        },
+        "$procdff$19": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:15.5-18.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 2 ],
+            "D": [ 5 ],
+            "Q": [ 8 ]
+          }
+        },
+        "$procdff$9": {
+          "hide_name": 1,
+          "type": "$adff",
+          "parameters": {
+            "ARST_POLARITY": "00000000000000000000000000000000",
+            "ARST_VALUE": "0",
+            "CLK_POLARITY": "1",
+            "WIDTH": "00000000000000000000000000000001"
+          },
+          "attributes": {
+            "always_ff": "00000000000000000000000000000001",
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:24.5-32.8"
+          },
+          "port_directions": {
+            "ARST": "input",
+            "CLK": "input",
+            "D": "input",
+            "Q": "output"
+          },
+          "connections": {
+            "ARST": [ 4 ],
+            "CLK": [ 3 ],
+            "D": [ 8 ],
+            "Q": [ 7 ]
+          }
         }
       },
       "netnames": {
@@ -87,50 +113,57 @@
           "hide_name": 0,
           "bits": [ 5 ],
           "attributes": {
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:11.18-11.22"
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:10.18-10.22"
           }
         },
         "dst_clk": {
           "hide_name": 0,
           "bits": [ 3 ],
           "attributes": {
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:9.18-9.25"
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:8.18-8.25"
+          }
+        },
+        "dst_meta": {
+          "hide_name": 0,
+          "bits": [ 7 ],
+          "attributes": {
+            "cdc_sync": "level_2ff",
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:22.40-22.48"
           }
         },
         "dst_q": {
           "hide_name": 0,
           "bits": [ 6 ],
           "attributes": {
-            "cdc_sync": "level_2ff",
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:23.40-23.45"
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:23.11-23.16"
           }
         },
         "q_out": {
           "hide_name": 0,
           "bits": [ 6 ],
           "attributes": {
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:12.18-12.23"
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:11.18-11.23"
           }
         },
         "rst_n": {
           "hide_name": 0,
           "bits": [ 4 ],
           "attributes": {
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:10.18-10.23"
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:9.18-9.23"
           }
         },
         "src_clk": {
           "hide_name": 0,
           "bits": [ 2 ],
           "attributes": {
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:8.18-8.25"
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:7.18-7.25"
           }
         },
         "src_q": {
           "hide_name": 0,
-          "bits": [ 7 ],
+          "bits": [ 8 ],
           "attributes": {
-            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:15.11-15.16"
+            "src": "tests/fixtures/marked_user_sync/marked_user_sync.sv:14.11-14.16"
           }
         }
       }

--- a/tests/fixtures/marked_user_sync/marked_user_sync.sv
+++ b/tests/fixtures/marked_user_sync/marked_user_sync.sv
@@ -1,8 +1,7 @@
-// Mark a flop with `(* cdc_sync *)` to declare it a user-vetted
-// synchronizer first stage. The structural shape here (single dst
-// flop, no second stage) would normally trip CDC-001, but the
-// attribute tells the analyzer the user has taken responsibility:
-// the rule should stand down.
+// Mark a conventional 2FF synchronizer with `(* cdc_sync *)` to
+// declare the first stage as user-vetted. The structural depth keeps
+// both rtl-buddy-cdc and SpyGlass clean; the attribute exercises the
+// marker plumbing without relying on a single-stage waiver.
 
 module marked_user_sync (
     input  logic src_clk,
@@ -18,12 +17,18 @@ module marked_user_sync (
         else        src_q <= d_in;
     end
 
-    // (* cdc_sync *) marks this as a user-declared synchronizer.
-    // CDC-001/-002/-003 will skip it.
-    (* cdc_sync = "level_2ff" *) logic dst_q;
+    // (* cdc_sync *) marks the first stage of a conventional 2FF
+    // synchronizer.
+    (* cdc_sync = "level_2ff" *) logic dst_meta;
+    logic dst_q;
     always_ff @(posedge dst_clk or negedge rst_n) begin
-        if (!rst_n) dst_q <= 1'b0;
-        else        dst_q <= src_q;
+        if (!rst_n) begin
+            dst_meta <= 1'b0;
+            dst_q    <= 1'b0;
+        end else begin
+            dst_meta <= src_q;
+            dst_q    <= dst_meta;
+        end
     end
 
     assign q_out = dst_q;

--- a/tests/test_bad_typed_port_bus_crossing.py
+++ b/tests/test_bad_typed_port_bus_crossing.py
@@ -1,0 +1,49 @@
+"""Typed top-level bus crossings still need CDC-004 coherence checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "bad_typed_port_bus_crossing"
+JSON = FIX_DIR / "bad_typed_port_bus_crossing.json"
+SDC = FIX_DIR / "bad_typed_port_bus_crossing.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    async_crossings = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    return module, async_crossings, spec
+
+
+def test_typed_port_bus_crossing_is_visible(context) -> None:
+    _module, async_crossings, _spec = context
+    in_crossings = [c for c in async_crossings if c.src_port == "in"]
+    assert len(in_crossings) == 1
+    assert in_crossings[0].width == 8
+
+
+def test_cdc_004_fires_for_typed_port_bus(context) -> None:
+    module, async_crossings, spec = context
+    violations = run_all_rules(module, async_crossings, spec)
+    assert {v.rule_id for v in violations} == {"CDC-004"}
+    assert "port in" in violations[0].message

--- a/tests/test_good_fixtures.py
+++ b/tests/test_good_fixtures.py
@@ -62,6 +62,12 @@ GOOD_FIXTURES = [
     # must not fire. Two async crossings (src_q → each sync first
     # stage).
     ("good_disjoint_fanout_sync_chains", 2),
+    # Single-source variant of the same shape: one src_q fans out to
+    # two independent 2FF sync chains. Restores coverage of the
+    # "shared src flop, multiple chains" topology after the two-source
+    # rewrite landed in #150 (issue #149). Two async crossings, both
+    # rooted in the same src flop.
+    ("good_single_source_fanout_sync_chains", 2),
     # $dffe-style load-enable gating (issue #34). 8-bit data bus into
     # a $dffe whose EN is a dst-domain 2FF synchronizer's tail.
     # Yosys inference of $dffe is forced by ``opt_dff`` at fixture-

--- a/tests/test_good_fixtures.py
+++ b/tests/test_good_fixtures.py
@@ -82,15 +82,15 @@ GOOD_FIXTURES = [
     # _two_domains_typed: port→clk_a direct (same domain, dropped) +
     # port→clk_b through 2FF sync (1 async port-sourced crossing).
     ("good_unconstrained_input_two_domains_typed", 1),
-    # _derived_clock_typed: port typed to the same clock the AND-
-    # tree resolves to → same domain → 0 async crossings.
-    ("good_unconstrained_input_derived_clock_typed", 0),
+    # _derived_clock_typed: port typed to clk_a and captured in clk_b
+    # through a conventional 2FF synchronizer.
+    ("good_unconstrained_input_derived_clock_typed", 1),
     # _bus_two_domains_typed: same shape as _two_domains_typed but
-    # width 8 (the port-walk emits one crossing with width=8, not
-    # eight width=1 crossings).
-    ("good_unconstrained_input_bus_two_domains_typed", 1),
-    # _muxed_clock_typed: port typed to whichever mux side
-    # trace_clock_root picks → same domain → 0 async crossings.
+    # width 8; the dst capture is gated by a synchronized load bit.
+    # Two async crossings: load control plus gated data bus.
+    ("good_unconstrained_input_bus_two_domains_typed", 2),
+    # _muxed_clock_typed: port typed to the same clock that captures
+    # it → same domain → 0 async crossings.
     ("good_unconstrained_input_muxed_clock_typed", 0),
     # RDC-002 positive shape: matched-polarity gated reset. Both
     # flops are active-low ($adff ARST_POLARITY=0), so when the

--- a/tests/test_good_gray_bus_sync_chain.py
+++ b/tests/test_good_gray_bus_sync_chain.py
@@ -1,0 +1,61 @@
+"""Positive fixture for an ungated gray-coded bus crossing.
+
+A 4-bit gray counter increments in src_clk; its value is sampled every
+dst_clk cycle by a per-bit 2FF synchronizer with no handshake. Only the
+gray encoding keeps the bus coherent. CDC-004's structural-gray
+detector (rules.py `_is_multibit_sync_first_stage` paired with
+`_is_gray_encoded_source`) must accept this shape."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "good_gray_bus_sync_chain"
+JSON = FIX_DIR / "good_gray_bus_sync_chain.json"
+SDC = FIX_DIR / "good_gray_bus_sync_chain.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    crossings = find_crossings(module)
+    async_crossings = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    return module, async_crossings, spec
+
+
+def test_one_4bit_crossing(context) -> None:
+    """A single 4-bit gray bus crosses src_clk → dst_clk."""
+    _module, async_crossings, _spec = context
+    assert len(async_crossings) == 1
+    c = async_crossings[0]
+    assert c.width == 4
+    assert c.src_clock == "src_clk"
+    assert c.dst_clock == "dst_clk"
+
+
+def test_no_violations(context) -> None:
+    """The structural-gray arm of CDC-004 must accept this shape — both
+    the gray-encode XOR pattern at the source and the multi-bit sync
+    chain at the destination are present, with no gating."""
+    module, async_crossings, spec = context
+    violations = run_all_rules(module, async_crossings, spec)
+    assert violations == [], (
+        f"unexpected violations on structural-gray fixture: "
+        f"{[(v.rule_id, v.message) for v in violations]}"
+    )

--- a/tests/test_good_gray_counter_crossing.py
+++ b/tests/test_good_gray_counter_crossing.py
@@ -1,9 +1,8 @@
-"""Positive fixture for gray-coded bus crossings.
+"""Positive fixture for a gated gray-coded bus crossing.
 
 A 4-bit gray counter increments in src_clk; its value is sampled by a
-4-bit 2FF synchronizer in dst_clk. The structural detector recognises
-the canonical gray-encode XOR pattern at the source and the multi-bit
-sync chain at the destination, so CDC-004 must not fire."""
+dst_clk register only under a synchronized control bit. The destination
+does not sample the bus freely, so CDC-004 must not fire."""
 
 from __future__ import annotations
 
@@ -38,14 +37,12 @@ def context():
     return module, async_crossings, spec
 
 
-def test_one_4bit_crossing(context) -> None:
-    """A single 4-bit gray bus crosses src_clk → dst_clk."""
+def test_gated_gray_bus_crossings(context) -> None:
+    """The fixture has one control crossing and one 4-bit bus crossing."""
     _module, async_crossings, _spec = context
-    assert len(async_crossings) == 1
-    c = async_crossings[0]
-    assert c.width == 4
-    assert c.src_clock == "src_clk"
-    assert c.dst_clock == "dst_clk"
+    assert len(async_crossings) == 2
+    widths = sorted(c.width for c in async_crossings)
+    assert widths == [1, 4]
 
 
 def test_no_violations(context) -> None:

--- a/tests/test_marked_single_ff_sync.py
+++ b/tests/test_marked_single_ff_sync.py
@@ -1,0 +1,62 @@
+"""User-declared synchronizer marker on a single-stage destination flop.
+
+The fixture is structurally identical to `bad_single_ff_sync` — one src
+flop, one dst flop, no second stage — but the dst flop's netname carries
+`(* cdc_sync = "level_2ff" *)`. CDC-001/-002/-003 must honour the
+marker and skip the flop, even though the structural depth is 1.
+
+This complements `test_marked_user_sync.py`, which marks the first stage
+of a conventional 2FF chain (a shape that would already pass without
+the attribute)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.rules import run_all as run_all_rules, user_sync_flop_names
+
+FIX_DIR = Path(__file__).parent / "fixtures" / "marked_single_ff_sync"
+JSON = FIX_DIR / "marked_single_ff_sync.json"
+SDC = FIX_DIR / "marked_single_ff_sync.sdc"
+
+
+@pytest.fixture(scope="module")
+def context():
+    if not JSON.exists():
+        pytest.skip(f"fixture not built: {JSON}")
+    module = netlist.load(JSON)
+    spec = sdc_mod.parse_file(SDC)
+    crossings = find_crossings(module)
+    async_crossings = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    return module, async_crossings, spec
+
+
+def test_user_sync_detected(context) -> None:
+    """The single annotated dst flop is the only user-marked sync."""
+    module, _crossings, _spec = context
+    syncs = user_sync_flop_names(module)
+    assert len(syncs) == 1
+
+
+def test_marker_suppresses_cdc_001_on_single_stage(context) -> None:
+    """The same shape fires CDC-001 in `bad_single_ff_sync`; the
+    `(* cdc_sync *)` annotation must suppress it here. This is the
+    load-bearing case for the attribute — a real 2FF chain wouldn't
+    need the marker at all."""
+    module, async_crossings, spec = context
+    violations = run_all_rules(module, async_crossings, spec)
+    assert violations == [], (
+        f"unexpected violations on marked single-stage sync: "
+        f"{[(v.rule_id, v.message) for v in violations]}"
+    )

--- a/tests/test_marked_user_sync.py
+++ b/tests/test_marked_user_sync.py
@@ -1,9 +1,8 @@
 """User-declared synchronizer marker (`(* cdc_sync *)`).
 
-The fixture is structurally identical to ``bad_single_ff_sync`` —
-single dst flop, no second stage — but its destination flop's wire is
-annotated. The structural rules CDC-001/-002/-003/-006 must skip
-user-marked flops; the user has taken responsibility."""
+The fixture uses a conventional 2FF synchronizer and annotates the
+first stage. It exercises marker detection without relying on a
+single-stage waiver that other CDC tools report as unsynchronized."""
 
 from __future__ import annotations
 
@@ -50,8 +49,7 @@ def test_user_sync_detected(context) -> None:
 
 
 def test_no_violations_with_attribute(context) -> None:
-    """The same shape would trip CDC-001 in bad_single_ff_sync; the
-    `(* cdc_sync *)` annotation must suppress it here."""
+    """The marked conventional 2FF synchronizer should stay clean."""
     module, async_crossings, spec = context
     violations = run_all_rules(module, async_crossings, spec)
     assert violations == [], (


### PR DESCRIPTION
## Summary

- remove the CDC-004 early return for port-sourced multi-bit crossings
- add `bad_typed_port_bus_crossing` to cover a typed top-level bus that still needs a coherence check
- rewrite several positive fixtures so their clean behavior is backed by recognized synchronization or gating structures
- add three new positive fixtures to restore code-path coverage lost in those rewrites (see *Restored coverage* below)
- update CHANGELOG and CDC-004 docstring to record the scope expansion

## Restored coverage

The fixture rewrites traded the original shapes for alternatives that other CDC linters also accept cleanly. Each original exercised a code path no other fixture covered, so three companions land alongside the rewrites:

| New fixture | Restores | Was lost in |
| --- | --- | --- |
| `good_gray_bus_sync_chain` | CDC-004's structural-gray arm (`_is_multibit_sync_first_stage` + `_is_gray_encoded_source`) on an ungated gray-counter → multi-bit 2FF sync chain | `good_gray_counter_crossing` rewrite to a load-gated shape |
| `marked_single_ff_sync` | `(* cdc_sync *)` suppressing CDC-001 on a single-stage dst flop — the load-bearing case for the attribute (a conventional 2FF chain passes whether the marker is there or not) | `marked_user_sync` rewrite to a 2FF chain |
| `good_single_source_fanout_sync_chains` | Single source flop fanning into two independent 2FF chains with disjoint downstream cones (the topology CDC-005's reconvergence filter has to walk) | `good_disjoint_fanout_sync_chains` rewrite to two independent source flops |

## Other changes

- **CHANGELOG**: a `[Unreleased]` / `Fixed` entry describes the CDC-004 scope expansion to typed port-sourced buses, the messaging change (`src flop:` → `src:` rendered via `Crossing.src_name`), and the companion fixture set.
- **CDC-004 docstring**: notes that port-sourced bus crossings (`src_flop is None`) can be cleared only by the gating pattern — both gray-coding paths key off a source register and have no port-side equivalent.

## Tests

- `uv run pytest -q tests/test_bad_typed_port_bus_crossing.py tests/test_bad_bus_crossing.py tests/test_good_gray_counter_crossing.py tests/test_good_gray_bus_sync_chain.py tests/test_good_fixtures.py tests/test_marked_user_sync.py tests/test_marked_single_ff_sync.py tests/test_bad_unconstrained_input_bus_two_domains.py tests/test_bad_unconstrained_input_two_domains.py tests/test_bad_unconstrained_input_derived_clock.py tests/test_bad_unconstrained_input_muxed_clock.py`
- `uv run pytest -q` — 344 passed, 36 skipped
- `uv run ruff check && uv run ruff format --check && uv run mypy` — all clean

Closes #149