### PR TITLE
feat(domain-map): clock_network_crossings list + renderer hook (schema 1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Domain-map schema 1.1: `clock_network_crossings[]`** (#168). New
+  top-level list capturing flop→flop relationships that travel via
+  the clock network — a foreign-domain flop driving a clock-mux
+  select or ICG enable whose output reaches another flop's CLK pin.
+  Same hazard CDC-010 already detects, exposed as a structural
+  parallel to `crossings[]` so consumers can render the edge that
+  the data-fanout walker can't see. Each entry carries
+  `src_flop` / `dst_flop` (hier paths), `src_clock` / `dst_clock`,
+  the gating cell triple (`control_cell`, `control_cell_type`,
+  `control_pin`), and `control_kind` ∈ {`mux-select`,
+  `gate-enable`}. `async_per_sdc` is always `true` — the walker
+  only emits pairs where the source domain is async to *every*
+  clock-input domain of the controlled cell, mirroring CDC-010's
+  firing condition. Lives in a new module
+  `src/rtl_buddy_cdc/clock_network.py` (function
+  `find_clock_network_crossings`) so it stays separate from the
+  rule pack's `Violation` surface while reusing the same
+  structural helpers via import from `rules.py`. Schema bump is
+  additive — v1.0 consumers ignore the field, and the renderer
+  treats absence as empty. The mermaid renderer in
+  `rtl_buddy_cdc.render` draws each entry with a thick arrow and
+  a `⚡ clk-ctrl (mux S)` / `(gate EN)` label so the CDC-010
+  hazard is visible at a glance.
+
 ### Fixed
 
 - **Domain-map: flop and crossing clock names canonicalise through

--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -19,6 +19,7 @@ from rtl_buddy_cdc import (
     waivers as waivers_mod,
 )
 from rtl_buddy_cdc.domain import Crossing, assign_domains, find_crossings
+from rtl_buddy_cdc.clock_network import find_clock_network_crossings
 from rtl_buddy_cdc.domain_map import build_domain_map
 from rtl_buddy_cdc.frontend import Frontend, elaborate, resolve_auto
 from rtl_buddy_cdc.frontends.slang import SlangFrontendUnavailable
@@ -642,12 +643,19 @@ def _analyze_module_and_report(
     # failure surfaces deterministically as an OSError rather than being
     # masked by the report's own I/O path.
     if emit_domain_map is not None:
+        clock_net_crossings = find_clock_network_crossings(
+            module,
+            spec,
+            clock_for_port=spec.clock_for_port if spec is not None else None,
+            use_heuristic=not cdc_010_no_heuristic,
+        )
         payload = build_domain_map(
             module,
             domains,
             crossings,
             spec,
             async_crossings=async_crossings,
+            clock_network_crossings=clock_net_crossings,
         )
         with emit_domain_map.open("w") as fh:
             json.dump(payload, fh, indent=2)

--- a/src/rtl_buddy_cdc/clock_network.py
+++ b/src/rtl_buddy_cdc/clock_network.py
@@ -1,0 +1,326 @@
+"""Structural surface for clock-network-driven flop→flop relationships.
+
+CDC-010 detects a hazard the data-fanout walk in
+:func:`rtl_buddy_cdc.domain.find_crossings` is blind to: a flop in one
+clock domain drives the *control* pin of a clock-network cell (a mux's
+``S``, an ICG's ``EN``) whose output clocks flops in another domain.
+The async control transition chops the downstream clock into runt
+pulses; no synchroniser at the sink can recover.
+
+The rule pack already detects this and emits a :class:`Violation` per
+``(cell, control_pin, src_flop)`` triple. This module exposes the same
+facts as a parallel structural surface — one record per ``(src_flop,
+dst_flop)`` pair where the relationship goes through the clock network —
+so consumers like the domain-map emitter and the mermaid renderer can
+draw the edge that ``find_crossings`` couldn't.
+
+See issue #168 for the design discussion.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from rtl_buddy_cdc.domain import assign_domains
+from rtl_buddy_cdc.flops import Flop, find_flops
+from rtl_buddy_cdc.netlist import Bit, Module
+from rtl_buddy_cdc.rules import (
+    _backward_flop_fanin,
+    _clock_network_cells,
+    _control_pins_for,
+    _OUTPUT_PINS,
+)
+from rtl_buddy_cdc.sdc import ClockSpec
+
+ControlKind = Literal["mux-select", "gate-enable"]
+
+
+@dataclass(frozen=True)
+class ClockNetworkCrossing:
+    """A flop drives a control pin whose host cell's output reaches another
+    flop's CLK pin, and the two flops sit in async clock domains.
+
+    Mirrors :class:`rtl_buddy_cdc.domain.Crossing` for the clock-network
+    axis. ``src_flop`` is the control-pin driver; ``dst_flop`` is one of
+    the flops whose CLK pin traces back through ``control_cell``.
+    ``dst_clock`` is the clock-input domain of the controlled cell that
+    ``src_clock`` is async to (a cell can have multiple clock-input
+    domains; we record the first one we encounter — the rule that the
+    source must be async to *every* one of them has already fired by
+    the time the record is emitted, so any choice is correct).
+    """
+
+    src_flop: Flop
+    src_clock: str
+    dst_flop: Flop
+    dst_clock: str
+    control_cell: str
+    control_cell_type: str
+    control_pin: str
+    control_kind: ControlKind
+
+
+def find_clock_network_crossings(
+    module: Module,
+    clock_spec: ClockSpec | None = None,
+    *,
+    clock_for_port: Callable[[str], str | None] | None = None,
+    use_heuristic: bool = True,
+) -> list[ClockNetworkCrossing]:
+    """Enumerate every clock-network-driven async flop→flop pair.
+
+    The walk is the same structural shape as
+    :func:`rtl_buddy_cdc.rules.check_cdc_010`: for each cell on the
+    clock-distribution network, pull the control pins via
+    :func:`_control_pins_for`, walk the control bits back to source
+    flops via :func:`_backward_flop_fanin`, and compare each source
+    flop's clock domain against the cell's own clock-input domains.
+    The new bit — the part the rule pack doesn't need — is the
+    forward mapping from controlled cell to the downstream flops it
+    clocks, computed once up front via
+    :func:`_cell_to_downstream_flops`. Records are emitted per
+    ``(src_flop, dst_flop)`` pair rather than per cell so consumers
+    can draw the relationship as an edge.
+
+    Determinism: every emitted list (per (cell, ctrl_port) source
+    flops, per cell downstream flops, the final crossings list) is
+    sorted by name so two runs on the same input produce the same
+    sequence.
+    """
+    pin_clocks = clock_spec.pin_clocks if clock_spec is not None else None
+    flop_domains = assign_domains(
+        module, pin_clocks=pin_clocks, clock_for_port=clock_for_port
+    )
+    flop_by_name = {fd.flop.cell.name: fd.flop for fd in flop_domains}
+    domain_by_name = {fd.flop.cell.name: fd.clock for fd in flop_domains}
+
+    drivers = _bit_drivers_with_idx(module)
+    clock_net_cells = _clock_network_cells(module, drivers)
+    if not clock_net_cells:
+        return []
+    cell_to_dst_flops = _cell_to_downstream_flops(module, drivers)
+
+    def _resolve(name: str) -> str:
+        if clock_for_port is None:
+            return name
+        return clock_for_port(name) or name
+
+    def _async(a: str, b: str) -> bool:
+        if clock_spec is None:
+            return a != b
+        return clock_spec.are_async(_resolve(a), _resolve(b))
+
+    crossings: list[ClockNetworkCrossing] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    for cell_name in sorted(clock_net_cells):
+        cell = module.cells[cell_name]
+        control_ports = _control_pins_for(cell, use_heuristic=use_heuristic)
+        if not control_ports:
+            continue
+        dst_flop_names = sorted(cell_to_dst_flops.get(cell_name, ()))
+        if not dst_flop_names:
+            continue
+        cell_clock_domains: set[str] | None = None
+        for ctrl_port in sorted(control_ports):
+            ctrl_bits = cell.connections.get(ctrl_port, ())
+            if not ctrl_bits:
+                continue
+            ctrl_fanin = _backward_flop_fanin(module, ctrl_bits, drivers)
+            if not ctrl_fanin:
+                continue
+            if cell_clock_domains is None:
+                cell_clock_domains = _cell_clock_input_domains(
+                    module,
+                    cell,
+                    drivers,
+                    domain_by_name,
+                    clock_spec,
+                    control_ports,
+                )
+            if not cell_clock_domains:
+                continue
+            kind = _control_kind_for(ctrl_port, cell.type)
+            for src_flop_name in sorted(ctrl_fanin):
+                src_clk = domain_by_name.get(src_flop_name)
+                if src_clk is None:
+                    continue
+                if src_clk in cell_clock_domains:
+                    continue
+                if not all(_async(src_clk, d) for d in cell_clock_domains):
+                    continue
+                # Pick a deterministic representative for the cell's
+                # gated-clock domain — sorted so the choice is stable
+                # across runs. CDC-010 already enforced that src_clk
+                # is async to every member of the set.
+                dst_clk = sorted(cell_clock_domains)[0]
+                src_flop = flop_by_name.get(src_flop_name)
+                if src_flop is None:
+                    continue
+                for dst_flop_name in dst_flop_names:
+                    dst_flop = flop_by_name.get(dst_flop_name)
+                    if dst_flop is None or dst_flop is src_flop:
+                        continue
+                    key = (src_flop_name, dst_flop_name, cell_name)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    crossings.append(
+                        ClockNetworkCrossing(
+                            src_flop=src_flop,
+                            src_clock=src_clk,
+                            dst_flop=dst_flop,
+                            dst_clock=dst_clk,
+                            control_cell=cell_name,
+                            control_cell_type=cell.type,
+                            control_pin=ctrl_port,
+                            control_kind=kind,
+                        )
+                    )
+
+    crossings.sort(
+        key=lambda c: (
+            c.src_flop.cell.name,
+            c.dst_flop.cell.name,
+            c.control_cell,
+            c.control_pin,
+        )
+    )
+    return crossings
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _bit_drivers_with_idx(
+    module: Module,
+) -> dict[Bit, tuple[str, str, int]]:
+    """Like :func:`rtl_buddy_cdc.domain._bit_drivers` but with the bit
+    index — the schema the rules.py helpers consume."""
+    out: dict[Bit, tuple[str, str, int]] = {}
+    for cell in module.cells.values():
+        for port_name in ("Y", "Q"):
+            for idx, b in enumerate(cell.connections.get(port_name, ())):
+                if isinstance(b, int):
+                    out[b] = (cell.name, port_name, idx)
+    return out
+
+
+def _cell_to_downstream_flops(
+    module: Module,
+    drivers: dict[Bit, tuple[str, str, int]],
+) -> dict[str, set[str]]:
+    """Inverse of :func:`_clock_network_cells`: for each clock-network
+    cell, the set of flop cell-names whose CLK pin is reached when
+    walking back from the flop through that cell."""
+    out: dict[str, set[str]] = defaultdict(set)
+    for f in find_flops(module):
+        if not isinstance(f.clk, int):
+            continue
+        seen_bits: set[Bit] = set()
+        frontier: list[Bit] = [f.clk]
+        while frontier:
+            nxt: list[Bit] = []
+            for bit in frontier:
+                if bit in seen_bits:
+                    continue
+                seen_bits.add(bit)
+                drv = drivers.get(bit)
+                if drv is None:
+                    continue
+                cell_name = drv[0]
+                out[cell_name].add(f.cell.name)
+                cell = module.cells[cell_name]
+                for in_port, in_bits in cell.connections.items():
+                    if in_port in _OUTPUT_PINS:
+                        continue
+                    for b in in_bits:
+                        if isinstance(b, int):
+                            nxt.append(b)
+            frontier = nxt
+    return dict(out)
+
+
+def _cell_clock_input_domains(
+    module: Module,
+    cell,
+    drivers: dict[Bit, tuple[str, str, int]],
+    domain_by_name: dict[str, str | None],
+    clock_spec: ClockSpec | None,
+    control_ports: frozenset[str],
+    max_depth: int = 12,
+) -> set[str]:
+    """Set of clock-domain names driving ``cell``'s non-control inputs.
+
+    Self-contained mirror of :func:`rtl_buddy_cdc.rules._clock_input_domains_for`
+    — takes the precomputed drivers + domain map directly rather than a
+    :class:`_RuleContext`, so this module doesn't need to instantiate
+    rule-pack-specific state.
+    """
+    domains: set[str] = set()
+    seen: set[Bit] = set()
+    frontier: list[tuple[Bit, int]] = []
+    for port_name, bits in cell.connections.items():
+        if port_name in _OUTPUT_PINS or port_name in control_ports:
+            continue
+        for b in bits:
+            if isinstance(b, int):
+                frontier.append((b, 0))
+
+    while frontier:
+        nxt: list[tuple[Bit, int]] = []
+        for bit, depth in frontier:
+            if bit in seen:
+                continue
+            seen.add(bit)
+            drv = drivers.get(bit)
+            if drv is None:
+                if clock_spec is None:
+                    continue
+                port = module.port_of_bit(bit)
+                if port is None:
+                    continue
+                clk = clock_spec.clock_for_port(port.name)
+                if clk is not None:
+                    domains.add(clk)
+                continue
+            src_cell_name, out_port, _idx = drv
+            if out_port == "Q":
+                src_clk = domain_by_name.get(src_cell_name)
+                if src_clk is not None:
+                    domains.add(src_clk)
+                continue
+            if depth >= max_depth:
+                continue
+            src_cell = module.cells[src_cell_name]
+            for in_port, in_bits in src_cell.connections.items():
+                if in_port in _OUTPUT_PINS:
+                    continue
+                for b in in_bits:
+                    if isinstance(b, int):
+                        nxt.append((b, depth + 1))
+        frontier = nxt
+    return domains
+
+
+_GATE_ENABLE_PINS: frozenset[str] = frozenset({"E", "EN", "CE", "GATE", "SE"})
+
+
+def _control_kind_for(control_pin: str, cell_type: str) -> ControlKind:
+    """Classify a control pin as mux-select or gate-enable.
+
+    Cell-type-driven first (mux families have ``S``/``T``/``U``/``V``
+    selects; everything else with a control pin is treated as a gate
+    enable). The pin-name list is the same heuristic the rule pack uses
+    in :data:`rtl_buddy_cdc.rules._CDC_010_HEURISTIC_PINS`.
+    """
+    if cell_type in {"$mux", "$pmux", "$_MUX_", "$_MUX4_", "$_MUX8_", "$_MUX16_"}:
+        return "mux-select"
+    if control_pin.upper() in _GATE_ENABLE_PINS:
+        return "gate-enable"
+    # Fallback — anything else with a select-shaped name (rare in
+    # practice). Treat as mux-select for visual differentiation.
+    return "mux-select"

--- a/src/rtl_buddy_cdc/domain_map.py
+++ b/src/rtl_buddy_cdc/domain_map.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from rtl_buddy_cdc.clock_network import ClockNetworkCrossing
 from rtl_buddy_cdc.domain import Crossing, FlopDomain
 from rtl_buddy_cdc.netlist import Module
 from rtl_buddy_cdc.reporter import (
@@ -29,7 +30,10 @@ from rtl_buddy_cdc.reporter import (
 )
 from rtl_buddy_cdc.sdc import UNCONSTRAINED_SENTINEL, ClockSpec
 
-SCHEMA_VERSION = "1.0"
+# v1.1 adds the additive optional ``clock_network_crossings`` list
+# (#168). v1.0 consumers ignore unknown keys, so the bump is
+# backward-compatible — old maps without the field still validate.
+SCHEMA_VERSION = "1.1"
 # Yosys is the only frontend whose ``Module`` we serialize today (the
 # slang frontend lowers to the same shape, so it lands here unchanged).
 _FRONTEND = "yosys"
@@ -42,8 +46,9 @@ def build_domain_map(
     spec: ClockSpec | None,
     *,
     async_crossings: list[Crossing] | None = None,
+    clock_network_crossings: list[ClockNetworkCrossing] | None = None,
 ) -> dict[str, Any]:
-    """Build the v1.0 domain-map payload.
+    """Build the v1.1 domain-map payload.
 
     ``async_crossings`` is the SDC-aware subset of ``crossings`` that
     the rule pack would receive. Each emitted crossing is tagged with
@@ -51,6 +56,11 @@ def build_domain_map(
     supplied — every entry then carries ``async_per_sdc: false``,
     matching the convention that no-SDC runs have nothing to compare
     against.
+
+    ``clock_network_crossings`` is the parallel surface for flop→flop
+    relationships that travel through the clock network (a foreign-
+    domain flop driving a clock-mux select or ICG enable). Empty list
+    when omitted — consumers always see the key. See issue #168.
     """
     async_keys = _crossing_keys(async_crossings or [])
     return {
@@ -64,6 +74,9 @@ def build_domain_map(
         "flop_domains": _serialize_flop_domains(module, domains),
         "port_domains": _serialize_port_domains(module, spec),
         "crossings": _serialize_crossings(module, crossings, async_keys),
+        "clock_network_crossings": _serialize_clock_network_crossings(
+            module, clock_network_crossings or []
+        ),
     }
 
 
@@ -229,6 +242,54 @@ def _serialize_crossings(
             str(e["dst_clock"]),
             str(e["dst_flop"]),
             str(e.get("src_flop") or e.get("src_port") or ""),
+        )
+    )
+    return out
+
+
+def _serialize_clock_network_crossings(
+    module: Module,
+    crossings: list[ClockNetworkCrossing],
+) -> list[dict[str, Any]]:
+    """Per-cell flop→flop relationships routed via the clock network.
+
+    Each entry carries the source flop (control-pin driver), the
+    destination flop (whose CLK pin the controlled cell feeds), the
+    two clock domains, and metadata describing the gating cell
+    (``control_cell``, ``control_cell_type``, ``control_pin``,
+    ``control_kind`` ∈ {``"mux-select"``, ``"gate-enable"``}). Always
+    ``async_per_sdc: true`` here — the upstream walker only emits
+    pairs where the source domain is async to every clock-input
+    domain of the controlled cell, mirroring CDC-010's firing
+    condition.
+    """
+    out: list[dict[str, Any]] = []
+    for c in crossings:
+        out.append(
+            {
+                "src_clock": c.src_clock,
+                "dst_clock": c.dst_clock,
+                "src_flop": _hier_path(module, c.src_flop.cell.name),
+                "src_source_instance_path": _source_instance_path(
+                    module, c.src_flop.cell.name
+                ),
+                "dst_flop": _hier_path(module, c.dst_flop.cell.name),
+                "dst_source_instance_path": _source_instance_path(
+                    module, c.dst_flop.cell.name
+                ),
+                "control_cell": c.control_cell,
+                "control_cell_type": c.control_cell_type,
+                "control_pin": c.control_pin,
+                "control_kind": c.control_kind,
+                "async_per_sdc": True,
+            }
+        )
+    out.sort(
+        key=lambda e: (
+            str(e["src_flop"]),
+            str(e["dst_flop"]),
+            str(e["control_cell"]),
+            str(e["control_pin"]),
         )
     )
     return out

--- a/src/rtl_buddy_cdc/render.py
+++ b/src/rtl_buddy_cdc/render.py
@@ -120,6 +120,32 @@ def render_mermaid(map_data: dict[str, Any]) -> str:
         else:
             buf.write(f"  {src_id} --- {dst_id}\n")
 
+    # Clock-network crossings (schema 1.1+). A foreign-domain flop
+    # driving a clock-mux select or ICG enable whose output reaches
+    # the destination flop's CLK pin — the CDC-010 hazard. Drawn
+    # with a thick arrow so it stands apart from data crossings.
+    clock_net_crossings = sorted(
+        map_data.get("clock_network_crossings", []),
+        key=lambda c: (
+            c.get("src_flop", ""),
+            c.get("dst_flop", ""),
+            c.get("control_cell", ""),
+        ),
+    )
+    for x in clock_net_crossings:
+        src = x.get("src_flop")
+        dst = x.get("dst_flop")
+        if not src or not dst:
+            continue
+        src_id = _flop_node_id(src)
+        dst_id = _flop_node_id(dst)
+        kind = x.get("control_kind", "mux-select")
+        pin = x.get("control_pin", "?")
+        # ``mux S`` / ``gate EN`` reads more naturally than the raw
+        # enum value.
+        kind_word = "mux" if kind == "mux-select" else "gate"
+        buf.write(f'  {src_id} ==> |"⚡ clk-ctrl ({kind_word} {pin})"| {dst_id}\n')
+
     buf.write("  classDef port fill:#f4f4f5,stroke:#71717a\n")
     buf.write("```\n")
     return buf.getvalue()

--- a/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
+++ b/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "1.1",
   "generator": {
     "name": "rtl-buddy-cdc",
     "version": "0.2.0"
@@ -211,5 +211,6 @@
       "src_flop": "ip_cdc_handshake.$procdff$62",
       "src_source_instance_path": "ip_cdc_handshake"
     }
-  ]
+  ],
+  "clock_network_crossings": []
 }

--- a/tests/test_bad_async_clock_mux.py
+++ b/tests/test_bad_async_clock_mux.py
@@ -142,6 +142,39 @@ def test_find_crossings_canonicalises_dst_clock_into_same_domain_pair(
     )
 
 
+def test_clock_network_crossings_surface_sel_q_to_q_out_pair(context) -> None:
+    """rtl-buddy-cdc#168: ``find_clock_network_crossings`` exposes the
+    sel_q → q_out_flop relationship that travels through the clock
+    mux. CDC-010 fires structurally on the ``(cell, control_pin,
+    src_flop)`` triple but doesn't enumerate the downstream flops —
+    this surface records the flop-pair so a renderer can draw the
+    edge.
+    """
+    from rtl_buddy_cdc.clock_network import find_clock_network_crossings
+
+    module, _crossings, _async_crossings, spec = context
+    cn_crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=spec.clock_for_port
+    )
+    assert len(cn_crossings) == 1, (
+        f"expected one clock-network crossing (sel_q→q_out_flop via "
+        f"the clock mux), got {len(cn_crossings)}: "
+        f"{[(c.src_flop.cell.name, c.dst_flop.cell.name) for c in cn_crossings]}"
+    )
+    cnc = cn_crossings[0]
+    assert cnc.src_clock == "ck1"
+    assert cnc.dst_clock == "ck0"
+    assert cnc.control_pin == "S"
+    assert cnc.control_kind == "mux-select"
+    assert cnc.control_cell_type == "$mux"
+    # Identify src/dst by the netname they own — Yosys auto-names
+    # ($procdff$N) are not stable across regenerations.
+    sel_q_bits = module.netnames["sel_q"].bits
+    q_out_bits = module.netnames["q_out"].bits
+    assert cnc.src_flop.cell.connections.get("Q", ()) == sel_q_bits
+    assert cnc.dst_flop.cell.connections.get("Q", ()) == q_out_bits
+
+
 def test_no_other_rule_fires(context) -> None:
     """CDC-001 / -004 can't see a select-on-$mux shape (it's not a
     flop D); CDC-008 must stay silent here (no clock signal sits on

--- a/tests/test_domain_map.py
+++ b/tests/test_domain_map.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.clock_network import find_clock_network_crossings
 from rtl_buddy_cdc.domain import assign_domains, find_crossings
 from rtl_buddy_cdc.domain_map import SCHEMA_VERSION, build_domain_map
 
@@ -53,7 +54,17 @@ def _build(sdc_path: Path | None) -> dict:
                 continue
             if spec.are_async(a, b):
                 async_cs.append(c)
-    return build_domain_map(module, domains, crossings, spec, async_crossings=async_cs)
+    clock_net_crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=clock_for_port
+    )
+    return build_domain_map(
+        module,
+        domains,
+        crossings,
+        spec,
+        async_crossings=async_cs,
+        clock_network_crossings=clock_net_crossings,
+    )
 
 
 def test_golden_matches() -> None:
@@ -81,7 +92,7 @@ def test_schema_version_is_string_and_pinned() -> None:
 
 
 def test_top_level_keys() -> None:
-    """The v1.0 schema's top-level keys are PUBLIC API."""
+    """The schema's top-level keys are PUBLIC API."""
     payload = _build(SDC)
     expected = {
         "schema_version",
@@ -94,6 +105,7 @@ def test_top_level_keys() -> None:
         "flop_domains",
         "port_domains",
         "crossings",
+        "clock_network_crossings",
     }
     assert set(payload.keys()) == expected
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -135,6 +135,62 @@ def test_render_accepts_minor_version_drift() -> None:
     assert "flowchart" in out
 
 
+def test_render_draws_clock_network_crossing_edges() -> None:
+    """rtl-buddy-cdc#168: ``clock_network_crossings[]`` (schema 1.1+)
+    is drawn with a thick arrow + ⚡ clk-ctrl label so the CDC-010
+    flop→flop relationship is visible alongside the data crossings."""
+    out = render_mermaid(
+        {
+            "schema_version": "1.1",
+            "design": {"top": "t"},
+            "clocks": [
+                {"name": "ck0", "period": 10.0},
+                {"name": "ck1", "period": 13.3},
+            ],
+            "generated_clocks": [],
+            "flop_domains": [
+                {"instance_path": "t.fa", "clock": "ck1"},
+                {"instance_path": "t.fb", "clock": "ck0"},
+            ],
+            "port_domains": [],
+            "crossings": [],
+            "clock_network_crossings": [
+                {
+                    "src_clock": "ck1",
+                    "dst_clock": "ck0",
+                    "src_flop": "t.fa",
+                    "dst_flop": "t.fb",
+                    "control_cell": "$mux$12",
+                    "control_cell_type": "$mux",
+                    "control_pin": "S",
+                    "control_kind": "mux-select",
+                    "async_per_sdc": True,
+                }
+            ],
+        }
+    )
+    assert "==>" in out, "expected a thick arrow for the clock-network crossing"
+    assert "⚡ clk-ctrl (mux S)" in out
+
+
+def test_render_omits_clock_network_section_when_field_absent() -> None:
+    """v1.0 maps don't carry the field; the renderer must treat it as
+    an empty list rather than raising."""
+    out = render_mermaid(
+        {
+            "schema_version": "1.0",
+            "design": {"top": "t"},
+            "clocks": [],
+            "generated_clocks": [],
+            "flop_domains": [],
+            "port_domains": [],
+            "crossings": [],
+        }
+    )
+    assert "==>" not in out
+    assert "clk-ctrl" not in out
+
+
 def test_render_surfaces_undeclared_clocks() -> None:
     """If a flop references a clock that's not in ``clocks`` or
     ``generated_clocks`` (e.g. malformed map), we still draw it under


### PR DESCRIPTION
Closes rtl-buddy-cdc#168.

## Summary

- New module `src/rtl_buddy_cdc/clock_network.py` exposes `find_clock_network_crossings(module, spec, *, clock_for_port=None, use_heuristic=True) -> list[ClockNetworkCrossing]` enumerating CDC-010-style flop→flop relationships per (src_flop, dst_flop) pair. Reuses CDC-010's structural primitives (`_clock_network_cells`, `_control_pins_for`, `_backward_flop_fanin`) imported from `rules.py`; the new bit is the cell→downstream-flops inverse map.
- Domain-map schema bumps to **v1.1** (additive — v1.0 consumers ignore unknown keys). New top-level `clock_network_crossings[]` with `src_flop` / `dst_flop` / `src_clock` / `dst_clock` / `control_cell` / `control_cell_type` / `control_pin` / `control_kind` (`mux-select` / `gate-enable`) / `async_per_sdc` (always `true`).
- `rtl_buddy_cdc.render` draws each entry with a thick mermaid arrow + `⚡ clk-ctrl (mux S)` / `(gate EN)` label so the CDC-010 hazard reads at a glance.

## Why

`find_crossings` walks data fanout and doesn't see the relationship between sel_q and q_out_flop in `bad_async_clock_mux` — it goes through the clock network, not the data network. CDC-010 detects the hazard structurally but emits per-`(cell, control_pin, src_flop)` Violations without enumerating the downstream flops, so there was nothing in the JSON for an external consumer (chiefly the per-fixture README mermaid generator in rtl-buddy-cdc#165) to join into an edge. The new list is the missing structural surface.

## End-to-end

`bad_async_clock_mux` (`create_clock -name ck0 [get_ports {ck0_a ck0_b}]` + `create_clock -name ck1 [get_ports ck1]`):

```
clock_network_crossings (1):
  bad_async_clock_mux.$procdff$15 (ck1) → bad_async_clock_mux.$procdff$10 (ck0)
    via $mux S (mux-select), async_per_sdc=true
```

Renders as:
```
f_fc18e771 ==> |"⚡ clk-ctrl (mux S)"| f_92c88a19
```

Sister fixture `bad_techmap_async_clock_mux` lands the same shape with `control_cell_type: $_MUX_`.

## Schema migration

- `schema_version` bumps `"1.0"` → `"1.1"`.
- New required key `clock_network_crossings` (always present, possibly empty).
- Renderer is forward+backward compatible: a v1.0 map without the field renders cleanly with no clk-ctrl artefacts; a v1.1 map draws the new edges.
- Golden file (`ip_cdc_handshake.domain-map.json`) refreshed — diff is the schema bump + an empty `clock_network_crossings: []` (the fixture has no clock muxes / gates).

## Test plan

- [x] `uv run ruff check` + `uv run ruff format` clean
- [x] `uv run mypy` — Success: no issues found in 20 source files (was 19; the new module picks up)
- [x] `uv run pytest -q` — 478 passed, 24 skipped (3 more than post-#167 baseline = the new tests)
- [x] New regression in `test_bad_async_clock_mux.py` asserts the sel_q→q_out_flop pair surfaces with `control_kind: mux-select`, identified by netname (Yosys auto-names are unstable).
- [x] `test_render.py` covers both directions: a v1.1 map with a crossing draws the new edge; a v1.0 map without the field renders cleanly.
- [x] `test_domain_map.py::test_top_level_keys` updated to expect the new key (public-API pin).
- [x] End-to-end sanity-checked on `bad_async_clock_mux` + `bad_techmap_async_clock_mux`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)