### PR TITLE
test(fuzz): close stage 2 coverage gap — corpus now 22/22 rules

### DIFF
--- a/tests/fuzz/templates/__init__.py
+++ b/tests/fuzz/templates/__init__.py
@@ -5,32 +5,50 @@ from .cdc001 import UnsyncedSingleBit
 from .cdc002 import ShortChain
 from .cdc003 import CombBeforeSync
 from .cdc004 import UncodedBus
+from .cdc005 import ReconvergentSync
 from .cdc006 import CombSource
 from .cdc008 import ClockAsData
+from .cdc009 import PulseWidthFastToSlow
+from .cdc010 import AsyncClockMux
 from .cdc011 import UnconstrainedInput
+from .cdc012 import FunctionalDataHoldEnable
+from .cdc013 import ToggleNoXorTail
 from .cdc014 import CombBetweenStages
+from .cdc015 import SyncChainForeignReset
 from .cdc016 import OppositeEdgeChain
 from .gap_g1 import GapG1LatchInSyncChain
 from .gap_g3 import GapG3PulseSyncFalsePositive
 from .gap_g12 import GapG12GateLevelSilent
 from .good import GoodTwoFF
 from .rdc001 import AsyncResetCrossing
+from .rdc002 import ResetPolarityMismatch
+from .rdc003 import SyncResetCrossing
 from .rdc004 import CombDrivenReset
 from .rdc005 import MultiSourceReset
+from .rdc006 import DerivedAsyncResetUnsync
 
 ALL_TEMPLATES: list[type[Template]] = [
     UnsyncedSingleBit,
     ShortChain,
     CombBeforeSync,
     UncodedBus,
+    ReconvergentSync,
     CombSource,
     ClockAsData,
+    PulseWidthFastToSlow,
+    AsyncClockMux,
     UnconstrainedInput,
+    FunctionalDataHoldEnable,
+    ToggleNoXorTail,
     CombBetweenStages,
+    SyncChainForeignReset,
     OppositeEdgeChain,
     AsyncResetCrossing,
+    ResetPolarityMismatch,
+    SyncResetCrossing,
     CombDrivenReset,
     MultiSourceReset,
+    DerivedAsyncResetUnsync,
     GapG1LatchInSyncChain,
     GapG3PulseSyncFalsePositive,
     GapG12GateLevelSilent,
@@ -39,24 +57,33 @@ ALL_TEMPLATES: list[type[Template]] = [
 
 __all__ = [
     "ALL_TEMPLATES",
-    "ExpectedFinding",
-    "Op",
-    "RenderedCase",
-    "Template",
-    "UnsyncedSingleBit",
-    "ShortChain",
-    "CombBeforeSync",
-    "UncodedBus",
-    "CombSource",
-    "ClockAsData",
-    "UnconstrainedInput",
-    "CombBetweenStages",
-    "OppositeEdgeChain",
+    "AsyncClockMux",
     "AsyncResetCrossing",
+    "ClockAsData",
+    "CombBeforeSync",
+    "CombBetweenStages",
     "CombDrivenReset",
-    "MultiSourceReset",
+    "CombSource",
+    "DerivedAsyncResetUnsync",
+    "ExpectedFinding",
+    "FunctionalDataHoldEnable",
     "GapG1LatchInSyncChain",
-    "GapG3PulseSyncFalsePositive",
     "GapG12GateLevelSilent",
+    "GapG3PulseSyncFalsePositive",
     "GoodTwoFF",
+    "MultiSourceReset",
+    "Op",
+    "OppositeEdgeChain",
+    "PulseWidthFastToSlow",
+    "ReconvergentSync",
+    "RenderedCase",
+    "ResetPolarityMismatch",
+    "ShortChain",
+    "SyncChainForeignReset",
+    "SyncResetCrossing",
+    "Template",
+    "ToggleNoXorTail",
+    "UnconstrainedInput",
+    "UncodedBus",
+    "UnsyncedSingleBit",
 ]

--- a/tests/fuzz/templates/cdc005.py
+++ b/tests/fuzz/templates/cdc005.py
@@ -1,0 +1,81 @@
+"""CDC-005 — reconvergent synchronisers.
+
+One source-domain flop fans out to two independent 2FF synchroniser
+chains in the destination domain, then the chains' outputs are
+recombined combinationally. Each chain individually filters
+metastability, but variable resolution times can give different
+synced values for one or two dst cycles — the AND/OR of the chains
+can observe a transient state that never existed at the source.
+
+CDC-005 must fire once (one finding per offending recombination).
+CDC-001 / CDC-002 stay silent — each chain is structurally a valid
+2FF synchroniser.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic q_out
+);
+    logic src_q;
+    always_ff @(posedge src_clk or negedge rst_n)
+        if (!rst_n) src_q <= 1'b0;
+        else        src_q <= d_in;
+
+    logic sync_a_meta, sync_a_q;
+    logic sync_b_meta, sync_b_q;
+    always_ff @(posedge dst_clk or negedge rst_n)
+        if (!rst_n) sync_a_meta <= 1'b0;
+        else        sync_a_meta <= src_q;
+    always_ff @(posedge dst_clk or negedge rst_n)
+        if (!rst_n) sync_a_q <= 1'b0;
+        else        sync_a_q <= sync_a_meta;
+    always_ff @(posedge dst_clk or negedge rst_n)
+        if (!rst_n) sync_b_meta <= 1'b0;
+        else        sync_b_meta <= src_q;
+    always_ff @(posedge dst_clk or negedge rst_n)
+        if (!rst_n) sync_b_q <= 1'b0;
+        else        sync_b_q <= sync_b_meta;
+
+    assign q_out = sync_a_q & ~sync_b_q;
+endmodule
+"""
+
+_SDC = """\
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports d_in]
+"""
+
+
+class ReconvergentSync:
+    """One src flop, two parallel 2FF chains, recombined downstream."""
+
+    name = "cdc005_reconvergent_sync"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("CDC-005", Op.GE, 1),),
+            forbidden=(
+                ExpectedFinding("CDC-001", Op.ZERO),
+                ExpectedFinding("CDC-002", Op.ZERO),
+            ),
+        )

--- a/tests/fuzz/templates/cdc009.py
+++ b/tests/fuzz/templates/cdc009.py
@@ -1,0 +1,83 @@
+"""CDC-009 — fast-to-slow pulse-width loss.
+
+A 1-cycle src pulse encoded as ``event_q & ~event_d`` (edge detector)
+is captured by a much slower dst clock. The pulse can land entirely
+between two dst rising edges and be dropped — data lost without
+metastability ever entering the picture. CDC-001/-002 stay silent
+because the dst-side capture is a textbook 2FF; the failure is
+pulse-width, not synchroniser depth.
+
+See rtl-buddy-cdc#47 for the rule's framing. The good counterpart
+either width-stretches the strobe or replaces the edge-detector
+source with a held request/ack handshake.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic event_in,
+    output logic captured
+);
+    logic event_q, event_d, event_strobe;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            event_q      <= 1'b0;
+            event_d      <= 1'b0;
+            event_strobe <= 1'b0;
+        end else begin
+            event_q      <= event_in;
+            event_d      <= event_q;
+            event_strobe <= event_q & ~event_d;
+        end
+    end
+
+    logic captured_meta;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            captured_meta <= 1'b0;
+            captured      <= 1'b0;
+        end else begin
+            captured_meta <= event_strobe;
+            captured      <= captured_meta;
+        end
+    end
+endmodule
+"""
+
+_SDC = """\
+create_clock -name src_clk -period 2.0  [get_ports src_clk]
+create_clock -name dst_clk -period 20.0 [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 0.5 [get_ports event_in]
+"""
+
+
+class PulseWidthFastToSlow:
+    """10x clock ratio + edge-detector source = pulse-loss risk."""
+
+    name = "cdc009_pulse_width_fast_to_slow"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("CDC-009", Op.GE, 1),),
+            forbidden=(
+                ExpectedFinding("CDC-001", Op.ZERO),
+                ExpectedFinding("CDC-002", Op.ZERO),
+            ),
+        )

--- a/tests/fuzz/templates/cdc010.py
+++ b/tests/fuzz/templates/cdc010.py
@@ -1,0 +1,70 @@
+"""CDC-010 — clock mux with foreign-domain select.
+
+A 2-to-1 mux selects between two legitimate ck0-domain clocks; its
+select pin is driven by a flop in the async ck1 domain. Every ck1
+edge that toggles the select can chop the muxed output mid-period,
+producing a sub-period runt the downstream flop will sample as a
+real edge. The fix is to synchronise the select into ck0 before it
+reaches the mux.
+
+The two mux inputs are declared as the *same* clock in the SDC so
+the mux output's clock-input-domain set collapses to ``{ck0}``; the
+foreign-domain select is what trips the rule structurally.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic ck0_a,
+    input  logic ck0_b,
+    input  logic ck1,
+    input  logic rst_n,
+    input  logic sel_d,
+    input  logic d_in,
+    output logic q_out
+);
+    logic sel_q;
+    always_ff @(posedge ck1 or negedge rst_n)
+        if (!rst_n) sel_q <= 1'b0;
+        else        sel_q <= sel_d;
+
+    logic ck_out;
+    assign ck_out = sel_q ? ck0_a : ck0_b;
+
+    always_ff @(posedge ck_out or negedge rst_n)
+        if (!rst_n) q_out <= 1'b0;
+        else        q_out <= d_in;
+endmodule
+"""
+
+_SDC = """\
+create_clock -name ck0 -period 10.0  [get_ports {ck0_a ck0_b}]
+create_clock -name ck1 -period 13.3  [get_ports ck1]
+set_clock_groups -asynchronous -group {ck0} -group {ck1}
+set_input_delay -clock ck1 0.0 [get_ports sel_d]
+set_input_delay -clock ck0 0.0 [get_ports d_in]
+"""
+
+
+class AsyncClockMux:
+    """Async select on a 2-to-1 clock mux."""
+
+    name = "cdc010_async_clock_mux"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("CDC-010", Op.GE, 1),),
+        )

--- a/tests/fuzz/templates/cdc012.py
+++ b/tests/fuzz/templates/cdc012.py
@@ -1,0 +1,86 @@
+"""CDC-012 — functional data-hold violation on a gated bus.
+
+A 1-bit ``src_req`` is synchronised into ``dst_clk`` and gates the
+destination's bus capture, so the crossing looks structurally
+correct (CDC-004 stays silent — the bus is gated by a synced
+control). The functional bug: ``src_payload`` keeps changing every
+``src_clk`` cycle while the request travels through the sync chain,
+so the dst sample can observe a payload from a *different*
+transaction than the one that armed the request.
+
+The textbook fix is a req/ack handshake — hold the payload stable
+from req-assert through ack-return — captured in the
+``good_functional_datahold_handshake`` fixture.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic        src_clk,
+    input  logic        dst_clk,
+    input  logic        rst_n,
+    input  logic        src_req,
+    input  logic [7:0]  src_data,
+    output logic [7:0]  dst_data
+);
+    logic [7:0] src_payload;
+    logic       src_req_q;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            src_payload <= 8'h00;
+            src_req_q   <= 1'b0;
+        end else begin
+            src_payload <= src_data;
+            src_req_q   <= src_req;
+        end
+    end
+
+    logic req_meta, req_sync;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            req_meta <= 1'b0;
+            req_sync <= 1'b0;
+        end else begin
+            req_meta <= src_req_q;
+            req_sync <= req_meta;
+        end
+    end
+
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n)        dst_data <= 8'h00;
+        else if (req_sync) dst_data <= src_payload;
+    end
+endmodule
+"""
+
+_SDC = """\
+create_clock -name src_clk -period 4.0  [get_ports src_clk]
+create_clock -name dst_clk -period 10.0 [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 0.5 [get_ports src_req]
+set_input_delay -clock src_clk 0.5 [get_ports src_data[*]]
+"""
+
+
+class FunctionalDataHoldEnable:
+    """Synced gate + freely changing payload = data-hold violation."""
+
+    name = "cdc012_functional_datahold_enable"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("CDC-012", Op.GE, 1),),
+        )

--- a/tests/fuzz/templates/cdc013.py
+++ b/tests/fuzz/templates/cdc013.py
@@ -1,0 +1,76 @@
+"""CDC-013 — toggle synchroniser without XOR-tail pulse recovery.
+
+Source-side toggle flop encodes events as level changes
+(``D = en ? ~Q : Q``); the destination 2FF chain hands its tail's Q
+to the consumer directly, without reconstructing the pulse via
+``Q ^ Q_delayed``. The output therefore tracks the toggle level
+instead of emitting one pulse per source event — closely-spaced
+events that toggle twice between two destination samples are lost.
+
+This template pins the *genuine* failure mode. The companion
+``gap_g3`` sentinel (added in rtl-buddy-cdc#196 and now a positive
+regression for the XOR-tail recogniser) covers the textbook-correct
+shape that must stay silent. Together they bracket CDC-013's
+acceptance shape from both sides.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic event_in,
+    output logic event_seen
+);
+    logic src_toggle;
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n)        src_toggle <= 1'b0;
+        else if (event_in) src_toggle <= ~src_toggle;
+    end
+
+    logic toggle_meta, toggle_sync;
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) begin
+            toggle_meta <= 1'b0;
+            toggle_sync <= 1'b0;
+        end else begin
+            toggle_meta <= src_toggle;
+            toggle_sync <= toggle_meta;
+        end
+    end
+
+    assign event_seen = toggle_sync;
+endmodule
+"""
+
+_SDC = """\
+create_clock -name src_clk -period 2.0  [get_ports src_clk]
+create_clock -name dst_clk -period 20.0 [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 0.5 [get_ports event_in]
+"""
+
+
+class ToggleNoXorTail:
+    """Toggle src + 2FF dst with no XOR-tail = pulse-rate loss."""
+
+    name = "cdc013_toggle_no_xor_tail"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("CDC-013", Op.GE, 1),),
+        )

--- a/tests/fuzz/templates/cdc015.py
+++ b/tests/fuzz/templates/cdc015.py
@@ -1,0 +1,82 @@
+"""CDC-015 — sync chain asynchronously reset from a foreign clock domain.
+
+A 2FF synchroniser in ``dst_clk`` whose resolving flops have their
+``ARST`` driven by a reset *registered in ``src_clk``*. The chain
+cannot reach steady state on its own clock — every foreign-domain
+reset deassertion races the dst-clk edge, restoring the flops at an
+arbitrary point in pointer-value space.
+
+The data-path CDC rules (CDC-001 / CDC-002) see a structurally valid
+depth-2 chain and stay silent. The bug is in the reset path. RDC-001
+also fires by construction on the same physical structure with
+reset-tree framing — the two findings coexist, so we don't forbid
+RDC-001 here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic global_rst_n,
+    input  logic async_signal,
+    output logic dst_q
+);
+    logic src_rst_q;
+    always_ff @(posedge src_clk or negedge global_rst_n)
+        if (!global_rst_n) src_rst_q <= 1'b0;
+        else               src_rst_q <= 1'b1;
+
+    logic src_q;
+    always_ff @(posedge src_clk or negedge global_rst_n)
+        if (!global_rst_n) src_q <= 1'b0;
+        else               src_q <= async_signal;
+
+    logic sync_1;
+    always_ff @(posedge dst_clk or negedge src_rst_q)
+        if (!src_rst_q) sync_1 <= 1'b0;
+        else            sync_1 <= src_q;
+
+    logic sync_2;
+    always_ff @(posedge dst_clk or negedge src_rst_q)
+        if (!src_rst_q) sync_2 <= 1'b0;
+        else            sync_2 <= sync_1;
+
+    assign dst_q = sync_2;
+endmodule
+"""
+
+_SDC = """\
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports async_signal]
+"""
+
+
+class SyncChainForeignReset:
+    """2FF sync chain whose ARST comes from a foreign-domain flop."""
+
+    name = "cdc015_sync_chain_foreign_reset"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("CDC-015", Op.GE, 1),),
+            forbidden=(
+                ExpectedFinding("CDC-001", Op.ZERO),
+                ExpectedFinding("CDC-002", Op.ZERO),
+            ),
+        )

--- a/tests/fuzz/templates/rdc002.py
+++ b/tests/fuzz/templates/rdc002.py
@@ -1,0 +1,60 @@
+"""RDC-002 — reset polarity mismatch on a direct flop→flop reset.
+
+Producer flop ``gated_rst`` is ``$adff`` with active-low reset
+(``ARST_POLARITY=0``, ``ARST_VALUE=0``) — so during system reset its
+Q sits at 0. Consumer flop ``q_out`` takes that Q as its async reset
+on a *posedge*, inferring ``$adff`` with ``ARST_POLARITY=1``. The
+polarities disagree: during a system reset the producer drives 0
+into the consumer's ARST, which the consumer reads as "reset
+deasserted" — the consumer never enters reset on a system reset
+event.
+
+Single-clock design, so no CDC rules fire. RDC-002 owns the finding.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic clk,
+    input  logic raw_rst_n,
+    output logic q_out
+);
+    logic gated_rst;
+    always_ff @(posedge clk or negedge raw_rst_n)
+        if (!raw_rst_n) gated_rst <= 1'b0;
+        else            gated_rst <= 1'b1;
+
+    always_ff @(posedge clk or posedge gated_rst)
+        if (gated_rst) q_out <= 1'b0;
+        else           q_out <= 1'b1;
+endmodule
+"""
+
+_SDC = """\
+create_clock -name clk -period 10.0 [get_ports clk]
+set_input_delay -clock clk 1.0 [get_ports raw_rst_n]
+"""
+
+
+class ResetPolarityMismatch:
+    """Active-low producer → active-high consumer ARST."""
+
+    name = "rdc002_polarity_mismatch"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("RDC-002", Op.GE, 1),),
+        )

--- a/tests/fuzz/templates/rdc003.py
+++ b/tests/fuzz/templates/rdc003.py
@@ -1,0 +1,73 @@
+"""RDC-003 — sync-reset crossing without a reset synchroniser.
+
+A reset signal registered in ``src_clk`` directly drives the
+synchronous reset pin (``SRST``) of a flop in ``dst_clk``. Sync
+resets are sampled on the dst clock edge, so a foreign-domain
+source can be metastable on the cycle the src flop changes. The
+textbook fix is a 2FF reset synchroniser in ``dst_clk`` between the
+foreign reset and the consuming ``$sdff``.
+
+Requires Yosys ``opt_dff`` so the mux-on-D pattern folds into
+``$sdff``; without it the consumer is a plain ``$dff`` + ``$mux``
+and the rule (which keys on the ``SRST`` pin) can't see it. The
+default fuzz pipeline applies ``proc; opt_dff; flatten`` so this
+just works.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic global_rst_n,
+    input  logic kill_req,
+    input  logic d_in,
+    output logic q_out
+);
+    logic src_rst;
+    always_ff @(posedge src_clk or negedge global_rst_n)
+        if (!global_rst_n) src_rst <= 1'b0;
+        else               src_rst <= kill_req;
+
+    logic q_dst;
+    always_ff @(posedge dst_clk)
+        if (src_rst) q_dst <= 1'b0;
+        else         q_dst <= d_in;
+
+    assign q_out = q_dst;
+endmodule
+"""
+
+_SDC = """\
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports kill_req]
+set_input_delay -clock dst_clk 1.0 [get_ports d_in]
+"""
+
+
+class SyncResetCrossing:
+    """Foreign-domain src_rst driving dst_clk $sdff's SRST."""
+
+    name = "rdc003_sync_reset_crossing"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("RDC-003", Op.GE, 1),),
+            # opt_dff folds the if/else into $sdff so SRST is exposed.
+            extra_yosys_passes="opt_dff;",
+        )

--- a/tests/fuzz/templates/rdc006.py
+++ b/tests/fuzz/templates/rdc006.py
@@ -1,0 +1,59 @@
+"""RDC-006 — derived async reset feeding a flop's ARST unsynchronised.
+
+A mux selects between two reset ports; the selected reset goes
+directly to a flop's async clear pin. The consumer clock has no
+local reset synchroniser, so the deassertion edge of whichever
+reset is currently selected is asynchronous to ``clk`` — recovery/
+removal timing on ``q_out`` is violated and the flop can come out
+of reset partway through a clock cycle.
+
+Single-clock design — no CDC findings. RDC-006 owns it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from .base import ExpectedFinding, Op, RenderedCase
+
+_TEMPLATE = """\
+module {top} (
+    input  logic clk,
+    input  logic global_rst_n,
+    input  logic block_rst_n,
+    input  logic use_block_rst,
+    input  logic d_in,
+    output logic q_out
+);
+    logic selected_rst_n;
+    assign selected_rst_n = use_block_rst ? block_rst_n : global_rst_n;
+
+    always_ff @(posedge clk or negedge selected_rst_n)
+        if (!selected_rst_n) q_out <= 1'b0;
+        else                 q_out <= d_in;
+endmodule
+"""
+
+_SDC = """\
+create_clock -name clk -period 10.0 [get_ports clk]
+set_input_delay -clock clk 0.5 [get_ports d_in]
+"""
+
+
+class DerivedAsyncResetUnsync:
+    """Muxed reset directly driving ARST with no dst-side sync."""
+
+    name = "rdc006_derived_async_reset_unsync"
+
+    @classmethod
+    def cases(cls) -> Iterator[RenderedCase]:
+        top = f"fuzz_{cls.name}"
+        yield RenderedCase(
+            template_name=cls.name,
+            case_id=top,
+            sv=_TEMPLATE.format(top=top),
+            sdc=_SDC,
+            top=top,
+            params={},
+            expected=(ExpectedFinding("RDC-006", Op.GE, 1),),
+        )


### PR DESCRIPTION
## Summary

Closes the eight zero-coverage rules flagged in rtl-buddy-cdc#190's
Stage 2 status table, plus the CDC-013 hole that opened after
PR #197 (gap_g3 flipped from positive- to negative-CDC-013 sentinel).

| Rule | Template file | Bad-shape source |
|---|---|---|
| CDC-005 | `cdc005.py` | mirrors `bad_reconvergent_sync` |
| CDC-009 | `cdc009.py` | mirrors `bad_pulse_width_fast_to_slow` |
| CDC-010 | `cdc010.py` | mirrors `bad_async_clock_mux` |
| CDC-012 | `cdc012.py` | mirrors `bad_functional_datahold_enable` |
| CDC-013 | `cdc013.py` | mirrors `bad_toggle_no_xor_tail` |
| CDC-015 | `cdc015.py` | mirrors `bad_sync_chain_foreign_reset` |
| RDC-002 | `rdc002.py` | mirrors `bad_rdc_002_polarity_mismatch` |
| RDC-003 | `rdc003.py` | mirrors `bad_rdc_003_sync_reset_crossing` |
| RDC-006 | `rdc006.py` | mirrors `bad_derived_async_reset_unsync` |

Each template's expected/forbidden encoding matches the per-fixture
hand-authored test's "only this rule fires" assertion. CDC-015 is
the exception — it shares its underlying structure with RDC-001, so
both fire by construction and the template doesn't forbid RDC-001.
RDC-003 needs `extra_yosys_passes="opt_dff;"` so the mux-on-D shape
folds into ``$sdff`` for the SRST-pin walk.

## Coverage

Before:
```
Corpus: 26 cases — 13/21 rules fired, 8 never fired
```

After:
```
Corpus: 35 cases — 22/22 rules fired
```

## Test plan

- [x] `uv run pytest -m fuzz -q` → 35 passed
- [x] `uv run pytest -q` (default) → 552 passed, 24 skipped
- [x] `uv run pytest -m sim -q` → 6 passed
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check tests/fuzz/` → clean
- [x] `uv run mypy` → clean
- [x] `uv run python -m tests.fuzz.coverage` → 22/22 rules covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)