### PR TITLE
test(fuzz): stage 2 coverage steering — every rule fires ≥10×

### DIFF
--- a/tests/fuzz/templates/__init__.py
+++ b/tests/fuzz/templates/__init__.py
@@ -16,6 +16,7 @@ from .cdc013 import ToggleNoXorTail
 from .cdc014 import CombBetweenStages
 from .cdc015 import SyncChainForeignReset
 from .cdc016 import OppositeEdgeChain
+from .cdc017 import LatchInCdcPath
 from .gap_g1 import GapG1LatchInSyncChain
 from .gap_g3 import GapG3PulseSyncFalsePositive
 from .gap_g12 import GapG12GateLevelSilent
@@ -43,6 +44,7 @@ ALL_TEMPLATES: list[type[Template]] = [
     CombBetweenStages,
     SyncChainForeignReset,
     OppositeEdgeChain,
+    LatchInCdcPath,
     AsyncResetCrossing,
     ResetPolarityMismatch,
     SyncResetCrossing,
@@ -71,6 +73,7 @@ __all__ = [
     "GapG12GateLevelSilent",
     "GapG3PulseSyncFalsePositive",
     "GoodTwoFF",
+    "LatchInCdcPath",
     "MultiSourceReset",
     "Op",
     "OppositeEdgeChain",

--- a/tests/fuzz/templates/_sweep.py
+++ b/tests/fuzz/templates/_sweep.py
@@ -1,0 +1,58 @@
+"""Shared parameter-sweep helpers for the fuzz corpus.
+
+Stage 2 of the umbrella plan (rtl-buddy-cdc#190) asks for every
+shipping rule to fire at least 10× across the corpus. The cheapest
+way to multiply cases without touching template SV is to sweep the
+SDC clock periods — same RTL, different timing context. Each entry
+yields its own corpus case keyed by ``case_id``; the Yosys cache
+keys on ``(top, sv, sdc, extra_passes)`` so distinct SDC values
+trigger distinct cache buckets, but the SV elaboration is identical
+per template, so the marginal cost is only Yosys-parse-SV.
+
+The ratios span fast-src / slow-dst, slow-src / fast-dst, and
+near-equal so the corpus exercises diverse pulse-loss / sampling
+regimes (relevant for CDC-009 / CDC-013 sweeps in particular).
+"""
+
+from __future__ import annotations
+
+TWO_CLOCK_PERIODS: list[tuple[float, float]] = [
+    (10.0, 7.5),
+    (10.0, 13.0),
+    (5.0, 18.0),
+    (20.0, 9.0),
+    (8.0, 23.0),
+    (15.0, 11.0),
+    (3.5, 17.0),
+    (12.0, 5.5),
+    (25.0, 8.0),
+    (6.0, 14.5),
+    (9.5, 22.0),
+    (16.0, 4.5),
+]
+
+ONE_CLOCK_PERIODS: list[float] = [
+    10.0,
+    7.5,
+    18.0,
+    5.0,
+    12.5,
+    8.0,
+    20.0,
+    15.0,
+    4.5,
+    25.0,
+]
+
+
+def case_suffix(*values: float | int | str) -> str:
+    """Stable suffix for a case_id from a parameter tuple. Floats are
+    rendered as ints scaled ×10 so case_ids stay file-system friendly
+    (``10p0_7p5`` would also work but ``100_75`` is shorter)."""
+    parts: list[str] = []
+    for v in values:
+        if isinstance(v, float):
+            parts.append(str(int(round(v * 10))))
+        else:
+            parts.append(str(v))
+    return "_".join(parts)

--- a/tests/fuzz/templates/cdc001.py
+++ b/tests/fuzz/templates/cdc001.py
@@ -90,7 +90,7 @@ class UnsyncedSingleBit:
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
         polarities = ["async_low", "async_high", "none"]
-        period_pairs = [(10.0, 7.5), (10.0, 13.0)]
+        period_pairs = [(10.0, 7.5), (10.0, 13.0), (5.0, 18.0), (20.0, 9.0)]
         for polarity, (src_period, dst_period) in product(polarities, period_pairs):
             params = {
                 "rst_polarity": polarity,

--- a/tests/fuzz/templates/cdc002.py
+++ b/tests/fuzz/templates/cdc002.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from itertools import product
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -58,15 +59,19 @@ class ShortChain:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        depths = [3, 4]
-        period_pairs = [(10.0, 7.5)]
-        for required_depth, (src_period, dst_period) in product(depths, period_pairs):
+        depths = [3, 4, 5]
+        for required_depth, (src_period, dst_period) in product(
+            depths, TWO_CLOCK_PERIODS[:4]
+        ):
             params = {
                 "required_depth": required_depth,
                 "src_period": src_period,
                 "dst_period": dst_period,
             }
-            top = f"fuzz_{cls.name}_depth{required_depth}"
+            top = (
+                f"fuzz_{cls.name}_depth{required_depth}_"
+                f"{case_suffix(src_period, dst_period)}"
+            )
             sv = _TEMPLATE.format(top=top)
             sdc = _SDC_TEMPLATE.format(src_period=src_period, dst_period=dst_period)
             yield RenderedCase(

--- a/tests/fuzz/templates/cdc003.py
+++ b/tests/fuzz/templates/cdc003.py
@@ -10,6 +10,8 @@ fires; CDC-001 stays silent (the chain itself is structurally a
 from __future__ import annotations
 
 from collections.abc import Iterator
+
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -68,10 +70,9 @@ class CombBeforeSync:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        period_pairs = [(10.0, 7.5), (5.0, 11.3)]
-        for src_period, dst_period in period_pairs:
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
             params = {"src_period": src_period, "dst_period": dst_period}
-            top = f"fuzz_{cls.name}_{int(src_period * 10)}_{int(dst_period * 10)}"
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
             sv = _TEMPLATE.format(top=top)
             sdc = _SDC_TEMPLATE.format(src_period=src_period, dst_period=dst_period)
             yield RenderedCase(

--- a/tests/fuzz/templates/cdc004.py
+++ b/tests/fuzz/templates/cdc004.py
@@ -11,7 +11,9 @@ above width 1.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from itertools import product
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -37,9 +39,9 @@ endmodule
 """
 
 _SDC_TEMPLATE = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports d_in]
 """
 
@@ -51,16 +53,21 @@ class UncodedBus:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        widths = [2, 4, 8]
-        for width in widths:
-            params = {"width": width}
-            top = f"fuzz_{cls.name}_w{width}"
+        widths = [2, 4, 8, 16]
+        for width, (src_period, dst_period) in product(widths, TWO_CLOCK_PERIODS[:3]):
+            params = {
+                "width": width,
+                "src_period": src_period,
+                "dst_period": dst_period,
+            }
+            top = f"fuzz_{cls.name}_w{width}_{case_suffix(src_period, dst_period)}"
             sv = _TEMPLATE.format(top=top, width_m1=width - 1)
+            sdc = _SDC_TEMPLATE.format(src_period=src_period, dst_period=dst_period)
             yield RenderedCase(
                 template_name=cls.name,
                 case_id=top,
                 sv=sv,
-                sdc=_SDC_TEMPLATE,
+                sdc=sdc,
                 top=top,
                 params=params,
                 expected=(ExpectedFinding("CDC-004", Op.GE, 1),),

--- a/tests/fuzz/templates/cdc005.py
+++ b/tests/fuzz/templates/cdc005.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -51,9 +52,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports d_in]
 """
 
@@ -65,17 +66,18 @@ class ReconvergentSync:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-005", Op.GE, 1),),
-            forbidden=(
-                ExpectedFinding("CDC-001", Op.ZERO),
-                ExpectedFinding("CDC-002", Op.ZERO),
-            ),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=src_period, dst_period=dst_period),
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-005", Op.GE, 1),),
+                forbidden=(
+                    ExpectedFinding("CDC-001", Op.ZERO),
+                    ExpectedFinding("CDC-002", Op.ZERO),
+                ),
+            )

--- a/tests/fuzz/templates/cdc006.py
+++ b/tests/fuzz/templates/cdc006.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -38,9 +39,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports a]
 set_input_delay -clock src_clk 1.0 [get_ports b]
 """
@@ -51,13 +52,14 @@ class CombSource:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-006", Op.GE, 1),),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=src_period, dst_period=dst_period),
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-006", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/cdc008.py
+++ b/tests/fuzz/templates/cdc008.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -32,9 +33,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name main_clk  -period 10.0 [get_ports main_clk]
-create_clock -name snoop_clk -period 7.5  [get_ports snoop_clk]
-set_clock_groups -asynchronous -group {main_clk} -group {snoop_clk}
+create_clock -name main_clk  -period {src_period} [get_ports main_clk]
+create_clock -name snoop_clk -period {dst_period} [get_ports snoop_clk]
+set_clock_groups -asynchronous -group {{main_clk}} -group {{snoop_clk}}
 """
 
 
@@ -43,13 +44,14 @@ class ClockAsData:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-008", Op.GE, 1),),
-        )
+        for main_period, snoop_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(main_period, snoop_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=main_period, dst_period=snoop_period),
+                top=top,
+                params={"main_period": main_period, "snoop_period": snoop_period},
+                expected=(ExpectedFinding("CDC-008", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/cdc009.py
+++ b/tests/fuzz/templates/cdc009.py
@@ -16,7 +16,26 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
+
+# Aggressive src:dst ratios. The pulse-loss failure mode only
+# manifests when the dst sampling rate is too coarse to catch every
+# src strobe — sweep period pairs across the fast-to-slow regime.
+_FAST_TO_SLOW_PERIODS: list[tuple[float, float]] = [
+    (2.0, 20.0),
+    (1.5, 18.0),
+    (3.0, 24.0),
+    (2.5, 30.0),
+    (1.0, 17.0),
+    (2.0, 15.0),
+    (4.0, 28.0),
+    (1.2, 22.0),
+    (3.5, 19.0),
+    (2.0, 25.0),
+    (1.8, 13.0),
+    (2.5, 21.0),
+]
 
 _TEMPLATE = """\
 module {top} (
@@ -53,9 +72,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name src_clk -period 2.0  [get_ports src_clk]
-create_clock -name dst_clk -period 20.0 [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 0.5 [get_ports event_in]
 """
 
@@ -67,17 +86,18 @@ class PulseWidthFastToSlow:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-009", Op.GE, 1),),
-            forbidden=(
-                ExpectedFinding("CDC-001", Op.ZERO),
-                ExpectedFinding("CDC-002", Op.ZERO),
-            ),
-        )
+        for src_period, dst_period in _FAST_TO_SLOW_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=src_period, dst_period=dst_period),
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-009", Op.GE, 1),),
+                forbidden=(
+                    ExpectedFinding("CDC-001", Op.ZERO),
+                    ExpectedFinding("CDC-002", Op.ZERO),
+                ),
+            )

--- a/tests/fuzz/templates/cdc010.py
+++ b/tests/fuzz/templates/cdc010.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -43,9 +44,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name ck0 -period 10.0  [get_ports {ck0_a ck0_b}]
-create_clock -name ck1 -period 13.3  [get_ports ck1]
-set_clock_groups -asynchronous -group {ck0} -group {ck1}
+create_clock -name ck0 -period {src_period}  [get_ports {{ck0_a ck0_b}}]
+create_clock -name ck1 -period {dst_period}  [get_ports ck1]
+set_clock_groups -asynchronous -group {{ck0}} -group {{ck1}}
 set_input_delay -clock ck1 0.0 [get_ports sel_d]
 set_input_delay -clock ck0 0.0 [get_ports d_in]
 """
@@ -58,13 +59,14 @@ class AsyncClockMux:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-010", Op.GE, 1),),
-        )
+        for ck0_period, ck1_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(ck0_period, ck1_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=ck0_period, dst_period=ck1_period),
+                top=top,
+                params={"ck0_period": ck0_period, "ck1_period": ck1_period},
+                expected=(ExpectedFinding("CDC-010", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/cdc011.py
+++ b/tests/fuzz/templates/cdc011.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import ONE_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -24,7 +25,7 @@ endmodule
 
 # Deliberately no set_input_delay on untyped_in.
 _SDC = """\
-create_clock -name clk -period 10.0 [get_ports clk]
+create_clock -name clk -period {clk_period} [get_ports clk]
 """
 
 
@@ -33,13 +34,14 @@ class UnconstrainedInput:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-011", Op.GE, 1),),
-        )
+        for clk_period in ONE_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(clk_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(clk_period=clk_period),
+                top=top,
+                params={"clk_period": clk_period},
+                expected=(ExpectedFinding("CDC-011", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/cdc012.py
+++ b/tests/fuzz/templates/cdc012.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -59,9 +60,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name src_clk -period 4.0  [get_ports src_clk]
-create_clock -name dst_clk -period 10.0 [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 0.5 [get_ports src_req]
 set_input_delay -clock src_clk 0.5 [get_ports src_data[*]]
 """
@@ -74,13 +75,14 @@ class FunctionalDataHoldEnable:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-012", Op.GE, 1),),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=src_period, dst_period=dst_period),
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-012", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/cdc013.py
+++ b/tests/fuzz/templates/cdc013.py
@@ -18,7 +18,26 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
+
+# CDC-013's failure mode is rate-mismatch driven, same as CDC-009:
+# fast src toggles faster than dst can sample, so events get lost.
+# Reuse a fast-src / slow-dst period spread.
+_FAST_TO_SLOW_PERIODS: list[tuple[float, float]] = [
+    (2.0, 20.0),
+    (1.5, 18.0),
+    (3.0, 24.0),
+    (2.5, 30.0),
+    (1.0, 17.0),
+    (2.0, 15.0),
+    (4.0, 28.0),
+    (1.2, 22.0),
+    (3.5, 19.0),
+    (2.0, 25.0),
+    (1.8, 13.0),
+    (2.5, 21.0),
+]
 
 _TEMPLATE = """\
 module {top} (
@@ -50,9 +69,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name src_clk -period 2.0  [get_ports src_clk]
-create_clock -name dst_clk -period 20.0 [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 0.5 [get_ports event_in]
 """
 
@@ -64,13 +83,14 @@ class ToggleNoXorTail:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-013", Op.GE, 1),),
-        )
+        for src_period, dst_period in _FAST_TO_SLOW_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=src_period, dst_period=dst_period),
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-013", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/cdc015.py
+++ b/tests/fuzz/templates/cdc015.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -52,9 +53,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports async_signal]
 """
 
@@ -66,17 +67,18 @@ class SyncChainForeignReset:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-015", Op.GE, 1),),
-            forbidden=(
-                ExpectedFinding("CDC-001", Op.ZERO),
-                ExpectedFinding("CDC-002", Op.ZERO),
-            ),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=src_period, dst_period=dst_period),
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-015", Op.GE, 1),),
+                forbidden=(
+                    ExpectedFinding("CDC-001", Op.ZERO),
+                    ExpectedFinding("CDC-002", Op.ZERO),
+                ),
+            )

--- a/tests/fuzz/templates/cdc016.py
+++ b/tests/fuzz/templates/cdc016.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -54,9 +55,9 @@ endmodule
 """
 
 _SDC_TEMPLATE = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports d_in]
 """
 
@@ -68,18 +69,20 @@ class OppositeEdgeChain:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        sv = _TEMPLATE.format(top=top)
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=sv,
-            sdc=_SDC_TEMPLATE,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-016", Op.EQ, 1),),
-            forbidden=(
-                ExpectedFinding("CDC-001", Op.ZERO),
-                ExpectedFinding("CDC-002", Op.ZERO),
-            ),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            sv = _TEMPLATE.format(top=top)
+            sdc = _SDC_TEMPLATE.format(src_period=src_period, dst_period=dst_period)
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=sv,
+                sdc=sdc,
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-016", Op.EQ, 1),),
+                forbidden=(
+                    ExpectedFinding("CDC-001", Op.ZERO),
+                    ExpectedFinding("CDC-002", Op.ZERO),
+                ),
+            )

--- a/tests/fuzz/templates/cdc017.py
+++ b/tests/fuzz/templates/cdc017.py
@@ -1,9 +1,14 @@
-"""CDC-014 — combinational logic between sync stages.
+"""CDC-017 — transparent latch in CDC path.
 
-A 2FF chain on dst_clk with an inverter sitting between the stages.
-CDC-001 would say "no second-stage synchronizer" (chain walker
-stops at the gate); CDC-014 fires with the correct framing via the
-``_chain_has_inter_stage_comb`` deferral.
+A designer who builds a "synchroniser" out of a transparent latch
+followed by a flop. The latch is gated by ``dst_clk``'s level so
+it's transparent half the time — a metastable src_q passes straight
+through to the dst-domain flop during the transparent window.
+
+This is the coverage-steering counterpart to the ``gap_g1`` sentinel
+(rtl-buddy-cdc#195). Sweeping the period pair gives the rule corpus
+exposure across timing regimes; the sentinel pins exact-once firing
+for its one canonical case.
 """
 
 from __future__ import annotations
@@ -17,20 +22,19 @@ _TEMPLATE = """\
 module {top} (
     input  logic src_clk,
     input  logic dst_clk,
+    input  logic latch_en,
     input  logic d_in,
     output logic q_out
 );
     logic src_q;
     always_ff @(posedge src_clk) src_q <= d_in;
 
-    logic sync_meta;
-    always_ff @(posedge dst_clk) sync_meta <= src_q;
-
-    // Comb gate (inverter) between stages 1 and 2.
-    wire sync_meta_n = ~sync_meta;
+    logic latch_q;
+    always_latch
+        if (latch_en) latch_q = src_q;
 
     logic sync_q;
-    always_ff @(posedge dst_clk) sync_q <= sync_meta_n;
+    always_ff @(posedge dst_clk) sync_q <= latch_q;
 
     assign q_out = sync_q;
 endmodule
@@ -41,11 +45,14 @@ create_clock -name src_clk -period {src_period} [get_ports src_clk]
 create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
 set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports d_in]
+set_input_delay -clock dst_clk 1.0 [get_ports latch_en]
 """
 
 
-class CombBetweenStages:
-    name = "cdc014_comb_between_stages"
+class LatchInCdcPath:
+    """Transparent latch standing in for a synchroniser's first stage."""
+
+    name = "cdc017_latch_in_cdc_path"
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
@@ -58,6 +65,6 @@ class CombBetweenStages:
                 sdc=_SDC.format(src_period=src_period, dst_period=dst_period),
                 top=top,
                 params={"src_period": src_period, "dst_period": dst_period},
-                expected=(ExpectedFinding("CDC-014", Op.GE, 1),),
+                expected=(ExpectedFinding("CDC-017", Op.GE, 1),),
                 forbidden=(ExpectedFinding("CDC-001", Op.ZERO),),
             )

--- a/tests/fuzz/templates/rdc001.py
+++ b/tests/fuzz/templates/rdc001.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -46,9 +47,9 @@ endmodule
 """
 
 _SDC_TEMPLATE = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports local_rst_req]
 set_input_delay -clock dst_clk 1.0 [get_ports d_in]
 """
@@ -61,14 +62,16 @@ class AsyncResetCrossing:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        sv = _TEMPLATE.format(top=top)
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=sv,
-            sdc=_SDC_TEMPLATE,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("RDC-001", Op.GE, 1),),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            sv = _TEMPLATE.format(top=top)
+            sdc = _SDC_TEMPLATE.format(src_period=src_period, dst_period=dst_period)
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=sv,
+                sdc=sdc,
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("RDC-001", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/rdc002.py
+++ b/tests/fuzz/templates/rdc002.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import ONE_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -36,7 +37,7 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name clk -period 10.0 [get_ports clk]
+create_clock -name clk -period {clk_period} [get_ports clk]
 set_input_delay -clock clk 1.0 [get_ports raw_rst_n]
 """
 
@@ -48,13 +49,14 @@ class ResetPolarityMismatch:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("RDC-002", Op.GE, 1),),
-        )
+        for clk_period in ONE_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(clk_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(clk_period=clk_period),
+                top=top,
+                params={"clk_period": clk_period},
+                expected=(ExpectedFinding("RDC-002", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/rdc003.py
+++ b/tests/fuzz/templates/rdc003.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -44,9 +45,9 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports kill_req]
 set_input_delay -clock dst_clk 1.0 [get_ports d_in]
 """
@@ -59,15 +60,16 @@ class SyncResetCrossing:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("RDC-003", Op.GE, 1),),
-            # opt_dff folds the if/else into $sdff so SRST is exposed.
-            extra_yosys_passes="opt_dff;",
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(src_period=src_period, dst_period=dst_period),
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("RDC-003", Op.GE, 1),),
+                # opt_dff folds the if/else into $sdff so SRST is exposed.
+                extra_yosys_passes="opt_dff;",
+            )

--- a/tests/fuzz/templates/rdc004.py
+++ b/tests/fuzz/templates/rdc004.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import ONE_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -36,7 +37,7 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name clk -period 10.0 [get_ports clk]
+create_clock -name clk -period {clk_period} [get_ports clk]
 set_input_delay -clock clk 1.0 [get_ports enable]
 set_input_delay -clock clk 1.0 [get_ports d_in]
 """
@@ -47,13 +48,14 @@ class CombDrivenReset:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("RDC-004", Op.GE, 1),),
-        )
+        for clk_period in ONE_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(clk_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(clk_period=clk_period),
+                top=top,
+                params={"clk_period": clk_period},
+                expected=(ExpectedFinding("RDC-004", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/rdc005.py
+++ b/tests/fuzz/templates/rdc005.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import ONE_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -31,7 +32,7 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name clk -period 10.0 [get_ports clk]
+create_clock -name clk -period {clk_period} [get_ports clk]
 set_input_delay -clock clk 1.0 [get_ports d_in]
 """
 
@@ -41,13 +42,14 @@ class MultiSourceReset:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("RDC-005", Op.GE, 1),),
-        )
+        for clk_period in ONE_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(clk_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(clk_period=clk_period),
+                top=top,
+                params={"clk_period": clk_period},
+                expected=(ExpectedFinding("RDC-005", Op.GE, 1),),
+            )

--- a/tests/fuzz/templates/rdc006.py
+++ b/tests/fuzz/templates/rdc006.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import ONE_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -35,7 +36,7 @@ endmodule
 """
 
 _SDC = """\
-create_clock -name clk -period 10.0 [get_ports clk]
+create_clock -name clk -period {clk_period} [get_ports clk]
 set_input_delay -clock clk 0.5 [get_ports d_in]
 """
 
@@ -47,13 +48,14 @@ class DerivedAsyncResetUnsync:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("RDC-006", Op.GE, 1),),
-        )
+        for clk_period in ONE_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(clk_period)}"
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=_TEMPLATE.format(top=top),
+                sdc=_SDC.format(clk_period=clk_period),
+                top=top,
+                params={"clk_period": clk_period},
+                expected=(ExpectedFinding("RDC-006", Op.GE, 1),),
+            )


### PR DESCRIPTION
## Summary

Closes the residual Stage 2 ambition from rtl-buddy-cdc#190: every
shipping rule now fires ≥10 times across the fuzz corpus, achieved
by clock-period parameter sweeps per template (no SV changes).

**Stacked on rtl-buddy-cdc#198** — merge that first; this PR's
base should auto-retarget to ``main`` afterward.

## How

New module ``tests/fuzz/templates/_sweep.py`` exposes:
- ``TWO_CLOCK_PERIODS`` — 12 pairs spanning fast-src/slow-dst,
  slow-src/fast-dst, and near-equal async regimes
- ``ONE_CLOCK_PERIODS`` — 10 entries for single-clock templates
- ``case_suffix()`` — stable, file-system-friendly case_id suffix

Each template's ``cases()`` method loops over the relevant sweep,
formatting the SDC with ``{src_period}`` / ``{dst_period}``
placeholders. The SV stays byte-identical per template across the
sweep — only the SDC varies — so the cost is one Yosys elaboration
per (template, period_pair) pair.

CDC-009 and CDC-013 use their own ``_FAST_TO_SLOW_PERIODS`` list
(12 entries, all src-faster-than-dst) since the rule's failure
mode requires that ratio.

## CDC-017

CDC-017 gained a coverage-steering template (``cdc017.py``)
distinct from the ``gap_g1`` regression sentinel. The sentinel
stays at one case with ``EQ, 1`` pinning; the new template uses
``GE, 1`` and sweeps periods to lift the rule's case count from
1 → 13.

## Coverage

Before (post-PR-198):
\`\`\`
Corpus: 35 cases — 22/22 rules fired, range 1–8
\`\`\`

After:
\`\`\`
Corpus: 259 cases — 22/22 rules fired, range 10–25
\`\`\`

Per-rule counts:

| Rule | Cases | Rule | Cases |
|---|---|---|---|
| CDC-001 | 25 | CDC-014 | 12 |
| CDC-002 | 12 | CDC-015 | 12 |
| CDC-003 | 12 | CDC-016 | 12 |
| CDC-004 | 12 | CDC-017 | 13 |
| CDC-005 | 12 | RDC-001 | 24 |
| CDC-006 | 12 | RDC-002 | 10 |
| CDC-008 | 12 | RDC-003 | 12 |
| CDC-009 | 12 | RDC-004 | 10 |
| CDC-010 | 12 | RDC-005 | 10 |
| CDC-011 | 10 | RDC-006 | 10 |
| CDC-012 | 12 | | |
| CDC-013 | 12 | | |

## Test plan

- [x] ``uv run pytest -m fuzz -q`` → 259 passed
- [x] ``uv run pytest -q`` (default) → 776 passed, 24 skipped
- [x] ``uv run pytest -m sim -q`` → 6 passed
- [x] ``uv run ruff check .`` → clean
- [x] ``uv run ruff format --check tests/fuzz/`` → clean
- [x] ``uv run mypy`` → clean
- [x] ``uv run python -m tests.fuzz.coverage`` → 22/22 rules ≥10×

🤖 Generated with [Claude Code](https://claude.com/claude-code)