### PR TITLE
test(sim): stage 4 clock-glitch oracle for CDC-008 / CDC-010

### DIFF
--- a/tests/sim/dut_clock_as_data.sv
+++ b/tests/sim/dut_clock_as_data.sv
@@ -1,0 +1,28 @@
+// CDC-008 sim DUT: a flop in main_clk's domain samples another clock
+// (snoop_clk) as data. The standard meta_flop methodology applies —
+// every time snoop_clk transitions, the main_clk sample of it can
+// be metastable. Over a long run with no synchroniser, the captured
+// value diverges from a "golden" sample (a one-cycle-delayed copy)
+// far more often than for a clean dst-synchronous signal.
+
+`include "meta_flop_lib.sv"
+
+module dut_clock_as_data (
+    input  logic src_clk,   // main_clk in CDC-008 terms
+    input  logic dst_clk,   // snoop_clk — the foreign clock being used as data
+    input  logic d_in,      // unused (TB drives it but the DUT samples a clock)
+    output logic q_out
+);
+    // The bug: sample dst_clk (a foreign-domain clock) as data on
+    // src_clk. The cell-level inference is a $dff whose D pin is
+    // the snoop_clk net — exactly what CDC-008's clock-network walk
+    // catches structurally.
+    meta_flop #(.RATE_PCT(80), .SEED(32'h0FF1_CE_42))
+        u_dst (.clk(src_clk), .d(dst_clk), .q(q_out));
+
+    // Tie d_in to a no-op so the TB's stimulus doesn't get optimised
+    // away (Icarus is OK either way but keep the port active).
+    /* verilator lint_off UNUSED */
+    wire _unused_d_in = d_in;
+    /* verilator lint_on UNUSED */
+endmodule

--- a/tests/sim/dut_clock_mux_glitch.sv
+++ b/tests/sim/dut_clock_mux_glitch.sv
@@ -1,0 +1,51 @@
+// CDC-010 sim DUT: clock mux with foreign-domain select.
+//
+// Two same-domain clocks (ck0_a / ck0_b) feed a 2-to-1 mux whose
+// select is driven by a flop in a foreign clock domain (ck1).
+// Because the mux output is `sel_q ? ck0_a : ck0_b`, any sel
+// transition that lands during a window where the two inputs
+// disagree (in our TB they're 180° out of phase) tears the muxed
+// clock — Icarus simulates this faithfully: clk_mux goes high→low→
+// high or vice-versa within a sub-cycle window, producing a runt
+// pulse the downstream flop will sample as a real edge.
+//
+// The TB counts posedges of clk_mux and compares against the
+// edge count of a *safe* reference (sel pre-synchronised into the
+// ck0 domain before reaching the mux). Glitchy mux output → extra
+// edges → over-count vs. reference.
+//
+// No metastability injection on the downstream flop — the failure
+// here is structural (runt clock pulse), not setup-hold.
+//
+// Why there's no paired "safe" RTL DUT: a combinational mux on
+// async-disagreeing inputs *will* glitch on every sel transition
+// regardless of whether sel is synchronised — a 2FF sync into the
+// ck0 domain doesn't help, because the mux still tears whenever
+// the two ck0 inputs disagree at the moment of switching. The
+// actual fix is a glitch-free clock-mux primitive (vendor cell
+// like BUFGMUX, or a phase-aware latch + AND-OR structure) that's
+// outside what plain RTL can express. The analyzer's `cdc_sync`
+// attribute on a synced sel is the user *promising* such a cell
+// exists downstream; sim has no way to model that promise.
+
+`timescale 1ns/1ps
+
+module dut_clock_mux_glitch (
+    input  logic ck0_a,
+    input  logic ck0_b,
+    input  logic ck1,
+    input  logic sel_d,
+    output logic [31:0] edge_count
+);
+    // Foreign-domain select flop.
+    logic sel_q;
+    always_ff @(posedge ck1) sel_q <= sel_d;
+
+    // The bad shape: mux on a foreign-domain select.
+    logic clk_mux;
+    assign clk_mux = sel_q ? ck0_a : ck0_b;
+
+    // Counter clocked by the muxed clock. Every posedge increments.
+    initial edge_count = '0;
+    always_ff @(posedge clk_mux) edge_count <= edge_count + 1;
+endmodule

--- a/tests/sim/runner.py
+++ b/tests/sim/runner.py
@@ -44,10 +44,27 @@ def iverilog_available() -> bool:
     return shutil.which("iverilog") is not None and shutil.which("vvp") is not None
 
 
+def _tb_for(dut_sv: Path) -> str:
+    """Pick the testbench file matching the DUT's port shape.
+
+    - ``*_rdc*`` / ``*_reset*`` DUTs: ``tb_reset_crossing.sv``
+      (ports include global_rst_n + local_rst_req).
+    - ``*clock_mux*`` DUTs: ``tb_clock_glitch.sv`` (ports include
+      ck0_a / ck0_b / ck1 / sel_d / edge_count, no d_in/q_out pair).
+    - Everything else: ``tb_crossing.sv``.
+    """
+    stem = dut_sv.stem.lower()
+    if "rdc" in stem:
+        return "tb_reset_crossing.sv"
+    if "clock_mux" in stem:
+        return "tb_clock_glitch.sv"
+    return "tb_crossing.sv"
+
+
 def _digest(dut_sv: Path, macros: dict[str, str | int]) -> str:
     h = hashlib.sha256()
     for src in sorted(
-        [dut_sv, SIM_DIR / "tb_crossing.sv", SIM_DIR / "meta_flop_lib.sv"]
+        [dut_sv, SIM_DIR / _tb_for(dut_sv), SIM_DIR / "meta_flop_lib.sv"]
     ):
         h.update(src.read_bytes())
         h.update(b"\0")
@@ -69,14 +86,7 @@ def compile_dut(dut_sv: Path, macros: dict[str, str | int]) -> Path:
     cmd = ["iverilog", "-g2012", "-o", str(vvp_path), "-I", str(SIM_DIR)]
     for k, v in macros.items():
         cmd.extend(["-D", f"{k}={v}"])
-    # Route DUTs to their matching testbench. The reset-aware DUTs
-    # have a different port list (global_rst_n + local_rst_req) so
-    # they pair with tb_reset_crossing.sv; everything else uses the
-    # plain tb_crossing.sv.
-    tb_name = (
-        "tb_reset_crossing.sv" if "rdc" in dut_sv.stem.lower() else "tb_crossing.sv"
-    )
-    cmd.extend([str(dut_sv), str(SIM_DIR / tb_name)])
+    cmd.extend([str(dut_sv), str(SIM_DIR / _tb_for(dut_sv))])
     proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if proc.returncode != 0:
         raise RuntimeError(

--- a/tests/sim/tb_clock_glitch.sv
+++ b/tests/sim/tb_clock_glitch.sv
@@ -1,0 +1,77 @@
+// Testbench for the clock-glitch DUTs.
+//
+// Drives two ck0-domain clocks (ck0_a, ck0_b) at the same period
+// but 180° out of phase, plus a foreign ck1 of incommensurate
+// period. The TB toggles `sel_d` at ck1 edges so sel transitions
+// land at arbitrary phases of the ck0 inputs — exactly the regime
+// that produces runt pulses on the mux output.
+//
+// The "expected" baseline is the edge count the muxed clock would
+// produce if sel never changed (i.e. the count of either ck0_a or
+// ck0_b's posedges over the run). Glitchy mux → over-count.
+//
+// Emits a single `SIM_RESULT errors=N total=M` line:
+// - errors = excess_edges = observed_count - expected_baseline
+// - total  = expected_baseline
+//
+// The Python runner parses this line; tests assert errors > 0 on
+// the bad DUT and errors == 0 on the safe DUT.
+
+`timescale 1ns/1ps
+
+`ifndef DUT_MODULE
+`define DUT_MODULE dut_clock_mux_glitch
+`endif
+
+`ifndef RUN_CYCLES
+`define RUN_CYCLES 5000
+`endif
+
+module tb;
+    logic ck0_a = 0;
+    logic ck0_b = 1;   // 180° out of phase with ck0_a
+    logic ck1   = 0;
+    logic sel_d = 0;
+    logic [31:0] edge_count;
+
+    // ck0 family: 10 ns full period (5 ns half), 180° offset.
+    always #5.0 ck0_a = ~ck0_a;
+    always #5.0 ck0_b = ~ck0_b;
+
+    // ck1: incommensurate period to ck0 — sel transitions land in
+    // random ck0 phases.
+    always #6.7 ck1 = ~ck1;
+
+    // Toggle sel_d at ~30% of ck1 edges.
+    int seed = 32'hC0DE_F00D;
+    always_ff @(posedge ck1) begin
+        if (($dist_uniform(seed, 0, 9)) < 3) sel_d <= ~sel_d;
+    end
+
+    `DUT_MODULE u_dut (
+        .ck0_a     (ck0_a),
+        .ck0_b     (ck0_b),
+        .ck1       (ck1),
+        .sel_d     (sel_d),
+        .edge_count(edge_count)
+    );
+
+    // Baseline: count ck0_a posedges over the same run window.
+    int baseline = 0;
+    always_ff @(posedge ck0_a) baseline <= baseline + 1;
+
+    initial begin
+        #1;
+        repeat (`RUN_CYCLES) @(posedge ck0_a);
+        // Allow a few extra ck0 edges to settle.
+        #50;
+        // errors = excess edges on the muxed clock vs. baseline.
+        // A clean mux emits exactly one edge per ck0 period; a
+        // glitching mux emits more on cycles where sel transitioned
+        // mid-period.
+        $display("SIM_RESULT errors=%0d total=%0d",
+                 (edge_count > baseline) ? (edge_count - baseline) : 0,
+                 baseline);
+        $finish;
+    end
+endmodule

--- a/tests/sim/test_glitch_oracle.py
+++ b/tests/sim/test_glitch_oracle.py
@@ -1,0 +1,80 @@
+"""Stage 4 clock-glitch oracle (rtl-buddy-cdc#190).
+
+Two sim probes that pair with the analyzer's CDC-010 and CDC-008
+rules:
+
+- ``test_clock_mux_emits_glitches`` — drives the combinational
+  clock-mux DUT and asserts the muxed output emits *more* posedges
+  than its baseline ck0_a would, evidence of runt pulses on sel
+  transitions. Pairs with the analyzer's CDC-010 firing on the
+  same shape: ``tests/fuzz/templates/cdc010.py`` and the
+  ``bad_async_clock_mux`` hand-authored fixture.
+
+- ``test_clock_as_data_fails_like_unsynced`` — a flop sampling a
+  foreign clock as data must produce a non-trivial error rate
+  under metastability injection. Pairs with CDC-008 firing on the
+  same shape.
+
+These don't replace the gap-mining oracle (``test_oracle.py``);
+they add structural-failure coverage for two rules whose failure
+modes aren't dominantly stochastic-flip but clock-network shape.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .runner import iverilog_available, run
+
+SIM_DIR = Path(__file__).parent
+
+
+pytestmark = pytest.mark.sim
+
+
+@pytest.mark.skipif(not iverilog_available(), reason="iverilog/vvp not on PATH")
+def test_clock_mux_emits_glitches() -> None:
+    """CDC-010 oracle: a combinational mux on a foreign-domain
+    select emits runt pulses on every sel transition that lands
+    during a window where the two muxed clocks disagree. The TB
+    counts posedges of the muxed clock vs. its ck0_a baseline; the
+    bad DUT's excess is non-zero.
+
+    The CI threshold of 50 excess edges across ~5000 cycles is well
+    above noise (zero) but well below the typical observed value
+    (~500–600); regressions that quietly stop producing glitches
+    (e.g., Icarus's mux-output settle behaviour changing across
+    versions) will trip this."""
+    result = run(
+        SIM_DIR / "dut_clock_mux_glitch.sv",
+        {"DUT_MODULE": "dut_clock_mux_glitch"},
+    )
+    assert result.errors > 50, (
+        f"clock-mux DUT produced only {result.errors} excess edges "
+        f"over {result.total} baseline cycles — oracle has regressed "
+        f"or Icarus's glitch behaviour has changed"
+    )
+
+
+@pytest.mark.skipif(not iverilog_available(), reason="iverilog/vvp not on PATH")
+def test_clock_as_data_fails_like_unsynced() -> None:
+    """CDC-008 oracle: a flop in main_clk's domain that samples a
+    foreign clock as data must show a non-trivial divergence from
+    a 1-cycle-delayed reference. Reuses ``tb_crossing.sv``'s golden
+    model with LATENCY_CYCLES=1 — the same comparison shape as the
+    unsynced data DUT in ``test_oracle.py``.
+
+    A clock-as-data crossing is metastability-prone exactly like a
+    plain unsynced data crossing — every transition of snoop_clk
+    has a chance of landing in main_clk's setup/hold window."""
+    result = run(
+        SIM_DIR / "dut_clock_as_data.sv",
+        {"DUT_MODULE": "dut_clock_as_data", "LATENCY_CYCLES": 1},
+    )
+    assert result.errors > 100, (
+        f"clock-as-data DUT produced only {result.errors} errors "
+        f"over {result.total} cycles — oracle should see hundreds "
+        f"under 80% injection; injection setup may have regressed"
+    )


### PR DESCRIPTION
## Summary

Closes the Stage 4 work from rtl-buddy-cdc#190: clock-glitch
injection for CDC-008 / CDC-010. Two new sim probes that add
structural-failure coverage to rules whose failure mode isn't
dominantly stochastic-flip but clock-network shape.

Independent of PR #198 / PR #199 — this PR can land at any time.

## What's new

| File | Purpose |
|---|---|
| ``dut_clock_mux_glitch.sv`` | CDC-010 bad DUT: combinational mux on foreign-domain sel; Icarus naturally simulates runt pulses on sel transitions |
| ``dut_clock_as_data.sv`` | CDC-008 bad DUT: flop sampling a foreign clock as data; uses existing ``meta_flop`` for the metastability side |
| ``tb_clock_glitch.sv`` | Drives ck0_a / ck0_b 180° out of phase + foreign ck1; counts muxed-clock posedges vs. ck0_a baseline; reports excess as ``errors`` |
| ``test_glitch_oracle.py`` | Two pytest cases asserting non-trivial failure rates |
| ``runner.py`` refactor | ``_tb_for(dut_sv)`` helper picks between three TBs (data / reset / clock-glitch) instead of an inline conditional |

## Sample run

```
$ vvp dut_clock_mux_glitch.vvp
SIM_RESULT errors=565 total=5004

$ vvp dut_clock_as_data.vvp
SIM_RESULT errors=1784 total=4995
```

CDC-010: 565 excess clock edges over 5000 baseline cycles — runt
pulses from the combinational mux being torn by every sel
transition.

CDC-008: 1784 / 4995 ≈ 36% error rate against a 1-cycle-delayed
golden — clock-as-data is fundamentally unstable.

## No paired safe RTL DUT for CDC-010

A combinational mux on async-disagreeing inputs is structurally
glitch-prone regardless of whether sel is synchronised — a 2FF
sync into the ck0 domain doesn't help (the mux still tears
whenever the two ck0 inputs disagree at the moment of switching).
The textbook fix is a glitch-free clock-mux primitive (BUFGMUX
or similar vendor cell, or a phase-aware latch + AND-OR structure)
which is outside what plain RTL can express. The analyzer's
``cdc_sync`` attribute on a synced sel is the user *promising*
such a cell exists downstream; sim has no way to model that
promise.

## Test plan

- [x] ``uv run pytest -m sim -q`` → 8 passed (was 6, +2)
- [x] ``uv run pytest -q`` (default) → 545 passed, 24 skipped
- [x] ``uv run ruff check tests/sim/`` → clean
- [x] ``uv run ruff format --check tests/sim/`` → clean
- [x] ``uv run mypy`` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)