### PR TITLE
ci: actually run fuzz + sim suites on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
       - '.python-version'
       - 'src/**/*.py'
       - 'tests/**/*.py'
+      - 'tests/**/*.sv'
   pull_request:
     branches: [main]
     paths:
@@ -19,6 +20,7 @@ on:
       - '.python-version'
       - 'src/**/*.py'
       - 'tests/**/*.py'
+      - 'tests/**/*.sv'
 
 jobs:
   # Primary job: install with the [slang] extra so the pyslang-backed
@@ -70,3 +72,44 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest -q
+
+  # Fuzz + sim suites. Gated behind ``@pytest.mark.fuzz`` /
+  # ``@pytest.mark.sim`` and skipped by every other job because they
+  # require yosys / iverilog on PATH. This job installs both, then
+  # runs the two marker selections separately so the CI summary
+  # shows their case counts independently.
+  #
+  # Marginal cost: ~30 s for the apt-install + a few seconds per
+  # suite (cached by Yosys content hash + iverilog SHA inside the
+  # runner). Worth it to catch regressions in the differential
+  # harness or sim oracle that would otherwise skip silently in the
+  # other jobs.
+  fuzz-and-sim:
+    name: fuzz + sim oracle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install yosys + iverilog
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends yosys iverilog
+          yosys -V | head -1
+          iverilog -V | head -1
+
+      - name: Install test dependencies
+        run: uv sync --group test --python 3.13
+
+      - name: Run fuzz suite
+        run: uv run pytest -m fuzz -q
+
+      - name: Run sim suite
+        run: uv run pytest -m sim -q
+
+      - name: Coverage report (fuzz rule firings)
+        run: uv run python -m tests.fuzz.coverage


### PR DESCRIPTION
## Summary

Today CI's two pytest jobs install neither yosys nor iverilog, so
every fuzz / sim test self-skips:

\`\`\`
tests/fuzz/test_corpus.py        ssssssssssssssssssssssssss   (26 skipped)
tests/sim/test_glitch_oracle.py  ss                           (2 skipped)
tests/sim/test_oracle.py         ssss                         (4 skipped)
tests/sim/test_reset_oracle.py   ss                           (2 skipped)
\`\`\`

CI reports green but the differential harness and sim oracle never
actually execute. A regression in the meta-flop injection or in
the rule-coverage harness would slip past CI and only surface on
someone's local Mac (where Homebrew yosys + iverilog happen to be
installed).

## Change

Adds a third workflow job, ``fuzz-and-sim``, which:

1. Installs ``yosys`` + ``iverilog`` from Ubuntu's repos
   (``apt-get install -y --no-install-recommends``).
2. Runs ``pytest -m fuzz -q`` and ``pytest -m sim -q`` in separate
   steps, so the CI summary reports each suite's case count
   independently.
3. Dumps the coverage report (``python -m tests.fuzz.coverage``)
   at the end so per-rule fire counts land in the log.

Also extends the workflow's path filter to include
``tests/**/*.sv``, so DUT-only changes trigger the run.

## Why not on every Python matrix entry

Fuzz / sim don't exercise Python-version-specific code paths — the
analyzer itself is what's being tested, and that's the same code
regardless of Python interpreter. Running once on Python 3.13 is
enough; adding 2× more matrix entries would just triple the
yosys + iverilog install cost without new signal.

## Cost

- ~20–30 s for ``apt-get install`` (one-time per CI runner; not
  cached across PRs but the runner image hash means Ubuntu's apt
  mirror is local).
- ~1 s for ``pytest -m fuzz`` (mostly Yosys, content-hash-cached
  inside the runner — second-and-subsequent runs are nearly
  instant; cold first run is ~30–60 s).
- ~1 s for ``pytest -m sim`` (iverilog elaboration + vvp, similarly
  cached by SHA).

Tested locally on Mac. Will verify the Linux paths once this PR's
own CI run executes.

## Test plan

- [ ] CI on this PR runs the new ``fuzz-and-sim`` job to green
- [ ] CI on this PR reports ~26 fuzz + 8 sim cases as **passed**
      rather than skipped
- [ ] Coverage step prints the 22/22 rules table

🤖 Generated with [Claude Code](https://claude.com/claude-code)