### PR TITLE
feat(sdc): clock-graph conflict linter (G-11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   methodology bug while staying silent on designs that use the raw
   port directly everywhere (a common simplification in small RTL).
 
+- **SDC clock-graph conflict linter** (#218). Closes G-11 from the
+  #188 coverage survey. New `validate_clock_graph(spec)` in
+  `rtl_buddy_cdc.sdc` runs after `parse_file` and emits cross-
+  statement diagnostics that the per-command parsers don't see:
+  same top-level port claimed by multiple clocks; generated clock
+  with an unresolved `-master_clock`; generated-clock master
+  cycles (A→B→A). Duplicate clock names (two
+  `create_clock -name X`) are caught inline by the per-command
+  handlers. All diagnostics flow through the existing
+  `spec.partial_warnings` surface so they reach the user via the
+  text-format warning channel; JSON/SARIF promotion to proper
+  `Violation` records is a deferred followup.
+
 - **Per-fixture `README.md` with mermaid clock-domain diagrams**
   (#164). Every fixture under `tests/fixtures/` now has a generated
   README that browsers see when navigating the directory on GitHub:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Primary mode (`analyze`):
 | Input | Required | Purpose |
 |---|---|---|
 | Yosys netlist JSON | yes | Flattened design (output of `write_json`) |
-| **SDC** (`.sdc`) | recommended | Clock declarations + async groups; without it, rule checks are skipped and the run is just a structural summary |
+| **SDC** (`.sdc`) | recommended | Clock declarations + async groups; without it, rule checks are skipped and the run is just a structural summary. Cross-statement clock-graph diagnostics — same-port-in-multiple-clocks, unresolved master, master cycles, duplicate clock name — are surfaced as warnings (G-11 / rtl-buddy-cdc#218). |
 | Waiver file | optional | Per-violation suppression with reason (see [Waivers](#waivers)) |
 | `--baseline FILE.json` | optional | Filter out findings already present in a prior JSON report; the carried-over set is surfaced as a separate tally and never drives the exit code. Useful for "fail PR only on new findings". Matches on `(rule_id, cell_name, message)`. |
 | `--strict` | optional | Promote every `warning`-severity violation to `error` before reporting (see [Rules](#rules)). Exit code is unchanged — the flag is reframing, not gating. |

--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -563,6 +563,11 @@ def _analyze_module_and_report(
         # existing port-walk emit port-sourced crossings for them so
         # CDC-011 can fire — see ``sdc.synthesize_unconstrained_inputs``.
         sdc_mod.synthesize_unconstrained_inputs(spec, module)
+        # G-11 (rtl-buddy-cdc#218): cross-statement clock-graph
+        # diagnostics — same-port-in-multiple-clocks, unresolved
+        # master, master cycles. Merged into partial_warnings so
+        # they flow through the existing CLI warning surface.
+        spec.partial_warnings.extend(sdc_mod.validate_clock_graph(spec))
         if spec.partial_warnings and fmt is OutputFormat.text and not no_findings:
             for w in spec.partial_warnings:
                 typer.echo(f"warning: {sdc_path}: {w}", err=True)

--- a/src/rtl_buddy_cdc/sdc.py
+++ b/src/rtl_buddy_cdc/sdc.py
@@ -246,6 +246,111 @@ def parse_file(path: str | Path) -> ClockSpec:
     return parse(Path(path).read_text())
 
 
+def validate_clock_graph(spec: ClockSpec) -> list[str]:
+    """G-11 (rtl-buddy-cdc#218): cross-statement clock-graph diagnostics.
+
+    The per-command parsers (:func:`_handle_create_clock` etc.) catch
+    line-local issues like missing ``-name`` or bare ``-filter``
+    clauses; this validator looks at the *collective* clock graph
+    after every statement has been parsed and surfaces shapes that
+    individually-valid statements compose into an inconsistent or
+    undefined whole.
+
+    Returns a list of human-readable diagnostic sentences (same shape
+    as :attr:`ClockSpec.partial_warnings`); the caller is expected to
+    merge them into ``spec.partial_warnings`` so they flow through
+    the existing CLI warning surface.
+
+    Checks:
+
+    1. **Same port in multiple clocks** — two ``create_clock``s
+       declaring different clock names but listing the same top-level
+       port. ``clock_for_port`` is deterministic (it returns the first
+       match found while scanning ``spec.clocks.values()``) but the
+       user's intent is ambiguous; the value-derived rules (CDC-001,
+       CDC-011, CDC-021, RDC-008) silently see one clock and not the
+       other.
+
+    2. **Unresolved master clock** — a ``create_generated_clock`` whose
+       ``-master_clock`` names a clock not present in ``spec.clocks``.
+       :meth:`ClockSpec.resolve` returns the unknown name unchanged,
+       so :meth:`are_async` falls back to "different roots, not
+       declared async" and the generated clock effectively floats.
+
+    3. **Generated-clock master cycle** — a chain of
+       ``create_generated_clock``s whose master chain never terminates
+       at a primary clock (A → B → A is the smallest cycle).
+       :meth:`ClockSpec.resolve` has a cycle guard that prevents
+       infinite-loop, but the SDC is methodology-broken; surface it.
+
+    Duplicate clock names (two ``create_clock -name X``, or
+    ``create_clock -name X`` followed by ``create_generated_clock -name
+    X``) are caught inline by the per-command handlers — there the
+    "this is overriding the previous" detection has both sides
+    visible, which is cheaper than re-deriving from the final spec.
+    """
+    out: list[str] = []
+
+    # Check 1: same port in multiple clocks.
+    port_owners: dict[str, list[str]] = {}
+    for clk in spec.clocks.values():
+        for port in clk.ports:
+            port_owners.setdefault(port, []).append(clk.name)
+    for port, owners in sorted(port_owners.items()):
+        if len(owners) < 2:
+            continue
+        out.append(
+            f"port '{port}' is claimed by multiple clocks: "
+            f"{', '.join(sorted(owners))} (clock_for_port returns "
+            f"'{owners[0]}')"
+        )
+
+    # Check 2: unresolved master.
+    declared = set(spec.clocks.keys())
+    for clk in spec.clocks.values():
+        if clk.master is None:
+            continue
+        if clk.master not in declared:
+            out.append(
+                f"create_generated_clock '{clk.name}': master "
+                f"'{clk.master}' is not declared elsewhere — async "
+                f"classification will misbehave"
+            )
+
+    # Check 3: master cycle. Walk every generated clock's master chain
+    # with a per-walk visited set; if we revisit a node we hit a cycle.
+    seen_cycle: set[frozenset[str]] = set()
+    for start_name, start_clk in spec.clocks.items():
+        if not start_clk.is_generated or start_clk.master is None:
+            continue
+        visited: list[str] = [start_name]
+        cur: str | None = start_clk.master
+        cycle_found: list[str] | None = None
+        while cur is not None:
+            if cur in visited:
+                # Found a cycle. Slice from the first occurrence to the
+                # end to get the cycle members.
+                cycle_found = visited[visited.index(cur) :]
+                break
+            visited.append(cur)
+            nxt_clk = spec.clocks.get(cur)
+            if nxt_clk is None or not nxt_clk.is_generated:
+                break
+            cur = nxt_clk.master
+        if cycle_found:
+            cycle_key = frozenset(cycle_found)
+            if cycle_key in seen_cycle:
+                continue
+            seen_cycle.add(cycle_key)
+            out.append(
+                f"create_generated_clock cycle detected involving "
+                f"{', '.join(sorted(cycle_found))} (master chain "
+                f"doesn't terminate at a primary clock)"
+            )
+
+    return out
+
+
 def synthesize_unconstrained_inputs(spec: ClockSpec, module: "Module") -> list[str]:
     """Assign :data:`UNCONSTRAINED_SENTINEL` to input ports not already
     typed by the SDC.
@@ -630,6 +735,14 @@ def _handle_create_clock(spec: ClockSpec, p: Parsed) -> None:
         spec.partial_warnings.append(
             f"create_clock {name}: ignored unsupported [get_ports -filter ...]"
         )
+    if name in spec.clocks:
+        # G-11 (rtl-buddy-cdc#218): duplicate clock name silently
+        # overrides; surface as a partial warning so the user sees the
+        # second declaration won.
+        spec.partial_warnings.append(
+            f"duplicate clock name '{name}': second create_clock silently "
+            f"overrides the first"
+        )
     spec.clocks[name] = Clock(name=name, period=period, ports=tuple(ports))
 
 
@@ -693,6 +806,12 @@ def _handle_create_generated_clock(spec: ClockSpec, p: Parsed) -> None:
     else:
         clock_ports = tuple(targets)
 
+    if name in spec.clocks:
+        # G-11 duplicate-name check, mirroring create_clock's surface.
+        spec.partial_warnings.append(
+            f"duplicate clock name '{name}': second create_generated_clock "
+            f"silently overrides the first"
+        )
     spec.clocks[name] = Clock(
         name=name,
         period=period,

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -610,3 +610,88 @@ def test_set_input_delay_bracket_clock_argument() -> None:
         """
     )
     assert spec.clock_for_port("d_in") == "clk"
+
+
+# --- G-11 clock-graph validation (rtl-buddy-cdc#218) -----------------------
+
+from rtl_buddy_cdc.sdc import validate_clock_graph
+
+
+def test_g11_duplicate_clock_name_warns_at_parse_time() -> None:
+    """Two ``create_clock -name X`` statements: second silently
+    overrides; the parser surfaces a partial warning."""
+    spec = parse(
+        """
+        create_clock -name clk -period 10.0 [get_ports a]
+        create_clock -name clk -period  7.5 [get_ports b]
+        """
+    )
+    msgs = [w for w in spec.partial_warnings if "duplicate clock name 'clk'" in w]
+    assert msgs, spec.partial_warnings
+    # The second declaration wins.
+    assert spec.clocks["clk"].period == 7.5
+
+
+def test_g11_same_port_in_multiple_clocks() -> None:
+    """Two distinct clock names listing the same port. ``clock_for_port``
+    is deterministic but the user's intent is ambiguous."""
+    spec = parse(
+        """
+        create_clock -name ck0 -period 10.0 [get_ports p]
+        create_clock -name ck1 -period  7.5 [get_ports p]
+        """
+    )
+    warnings = validate_clock_graph(spec)
+    assert any("port 'p' is claimed by multiple clocks" in w for w in warnings), (
+        warnings
+    )
+
+
+def test_g11_unresolved_master_clock() -> None:
+    """A generated clock whose ``-master_clock`` isn't declared
+    elsewhere — the master chain dead-ends and async classification
+    misbehaves silently."""
+    spec = parse(
+        """
+        create_clock -name root -period 10.0 [get_ports root]
+        create_generated_clock -name div2 -master_clock ck_unknown \\
+            -divide_by 2 [get_pins u_div/clk_out]
+        """
+    )
+    warnings = validate_clock_graph(spec)
+    assert any(
+        "create_generated_clock 'div2'" in w and "master 'ck_unknown'" in w
+        for w in warnings
+    ), warnings
+
+
+def test_g11_generated_clock_master_cycle() -> None:
+    """A→B→A master cycle. ``ClockSpec.resolve`` has a guard against
+    infinite-loop, but the SDC is methodology-broken."""
+    spec = parse(
+        """
+        create_generated_clock -name A -master_clock B \\
+            -divide_by 1 [get_pins u_a/clk_out]
+        create_generated_clock -name B -master_clock A \\
+            -divide_by 1 [get_pins u_b/clk_out]
+        """
+    )
+    warnings = validate_clock_graph(spec)
+    assert any(
+        "create_generated_clock cycle detected" in w and "A" in w and "B" in w
+        for w in warnings
+    ), warnings
+
+
+def test_g11_clean_sdc_produces_no_warnings() -> None:
+    """A well-formed SDC produces zero G-11 warnings."""
+    spec = parse(
+        """
+        create_clock -name src_clk -period 10.0 [get_ports src_clk]
+        create_clock -name dst_clk -period  7.5 [get_ports dst_clk]
+        create_generated_clock -name div2 -master_clock src_clk \\
+            -divide_by 2 [get_pins u_div/clk_out]
+        set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+        """
+    )
+    assert validate_clock_graph(spec) == []

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -1059,7 +1059,45 @@ corpus. Future revisions can widen via an opt-in flag.
 Severity `error` — methodology bug; the chain's absence is the
 root cause of a class of intermittent silicon issues.
 
-### 8.14 CDC-013 — fast-to-slow control-event loss on a toggle sync
+### 8.14 SDC clock-graph validation (G-11)
+
+`validate_clock_graph(spec)` is the cross-statement counterpart to
+the per-command `_handle_*` parsers in `sdc.py`. Where the latter
+catch line-local issues (missing `-name`, bare `-filter` clauses),
+the validator looks at the *collective* clock graph after every
+statement has been parsed and surfaces shapes that individually-
+valid statements compose into an inconsistent or undefined whole.
+
+Three checks:
+
+1. **Same port in multiple clocks**: scan `Clock.ports` across every
+   declared clock; flag any port that appears in ≥2 clocks.
+   `clock_for_port` is deterministic (first match wins) but the
+   user's intent is ambiguous.
+
+2. **Unresolved master**: for each generated clock with
+   `Clock.master` set, check the master name exists in
+   `spec.clocks`. An unresolved master makes `ClockSpec.resolve`
+   return the unknown name unchanged, breaking `are_async`'s
+   root-comparison.
+
+3. **Master cycle**: walk each generated clock's master chain with
+   a per-walk visited list; if a name is revisited, the chain is
+   cyclic. `ClockSpec.resolve` has a cycle guard, but the SDC is
+   methodology-broken.
+
+Duplicate clock names are caught inline by the per-command
+handlers (`_handle_create_clock` / `_handle_create_generated_clock`):
+they check `name in spec.clocks` before assignment and append a
+warning if so. Inline detection has both sides visible — cheaper
+than re-deriving from the final spec.
+
+All diagnostics flow through `spec.partial_warnings` so they reach
+the user via the existing text-format warning channel.
+JSON/SARIF promotion to proper `Violation` records is a deferred
+followup; this PR keeps the linter scoped to its low-risk surface.
+
+### 8.15 CDC-013 — fast-to-slow control-event loss on a toggle sync
 
 CDC-013 is the structural complement of CDC-009. CDC-009 owns the
 raw-pulse case (`D = A & ~A_d` edge detector — narrow src pulse
@@ -1093,7 +1131,7 @@ holds value until ack returns, synced back through a 2FF) or an
 event counter with backpressure, both of which produce a non-toggle
 `D` and silence the rule structurally.
 
-### 8.15 CDC-012 — functional data-hold on a gated multi-bit crossing
+### 8.16 CDC-012 — functional data-hold on a gated multi-bit crossing
 
 CDC-012 layers a functional check on top of CDC-004's structural
 gated-bus exemption. CDC-004 accepts a multi-bit crossing whose


### PR DESCRIPTION
## Summary

Closes rtl-buddy-cdc#218 (G-11 from rtl-buddy-cdc#188).

The per-command parsers catch line-local SDC issues like missing \`-name\` or bare \`-filter\` clauses. This PR adds the **cross-statement view**: shapes that individually-valid statements compose into an inconsistent or undefined whole.

## What lands

New \`validate_clock_graph(spec)\` in \`rtl_buddy_cdc.sdc\` runs after \`parse_file\` and emits three diagnostics:

1. **Same port in multiple clocks** — two \`create_clock\`s with different names listing the same top-level port. \`clock_for_port\` returns the first match deterministically, but the user's intent is ambiguous.
2. **Unresolved master** — \`create_generated_clock\` whose \`-master_clock\` isn't declared elsewhere. \`ClockSpec.resolve\` returns the unknown name unchanged, breaking \`are_async\` root comparison.
3. **Master cycle** — generated-clock master chain that revisits a node (A→B→A). \`resolve\` has a cycle guard but the SDC is methodology-broken.

**Duplicate clock names** (two \`create_clock -name X\`) are caught inline by the per-command handlers (\`_handle_create_clock\` / \`_handle_create_generated_clock\` check \`name in spec.clocks\` before assignment and append a warning). Inline detection has both sides visible — cheaper than re-deriving from the final spec.

All diagnostics flow through the existing \`spec.partial_warnings\` surface so they reach the user via the text-format warning channel.

## Validation

Per the rtl-buddy-cdc#188 harness convention, but G-11 is parser-level so the validation is unit tests rather than fuzz/sim:

1. **Unit tests** \`tests/test_sdc.py::test_g11_*\` — five new cases covering each diagnostic (duplicate name, same-port-multiple-clocks, unresolved master, master cycle) plus a clean-SDC negative-control.
2. **CLI wiring** — \`_analyze_module_and_report\` calls \`validate_clock_graph\` right after \`synthesize_unconstrained_inputs\` and merges the result into \`spec.partial_warnings\`.
3. **Docs** — README inputs table, architecture spec §8.6, CHANGELOG updated.

## Test plan

- [x] \`uv run ruff check\` + \`uv run ruff format --check\`
- [x] \`uv run mypy\` (no new errors)
- [x] \`uv run pytest\` (783 passed, 24 skipped — 5 new test_sdc tests landed clean)
- [x] \`uv run pytest -m fuzz\` (260 passed)
- [x] \`uv run pytest -m sim\` (8 passed)

## Out of scope (per the issue)

- **Promotion to \`Violation\`**: sticks to the existing \`partial_warnings\` surface for v1. A future PR can promote SDC diagnostics into proper \`Violation\` records so JSON/SARIF consumers see them.
- \`set_clock_groups\` membership consistency — same framework, separate PR.
- Period contradictions on duplicate names — caught indirectly; per-attribute diffing is overengineering for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)