### PR TITLE
test(cdc-016): broaden sentinel to full chain-walker partition

### DIFF
--- a/tests/fuzz/templates/cdc016.py
+++ b/tests/fuzz/templates/cdc016.py
@@ -7,17 +7,22 @@ chain and stay silent; CDC-016 fires on the adjacent-stage
 polarity mismatch.
 
 **Regression sentinel** (rtl-buddy-cdc#193): this template doubles
-as a partitioning regression check for the CDC-001/-002 deferral
-plumbing. The chain walker (``_sync_chain_depth``), the
+as a partitioning regression check for the chain-walker plumbing
+shared across CDC-001 / -002 / -014 / -015 / -016. The chain
+walker (``_sync_chain_depth``, ``_sync_chain_flops``), the
 inter-stage-comb deferral (``_chain_has_inter_stage_comb``), and
-the polarity helper (``_clk_polarity``) are shared between CDC-001
-/ -014 / -015 / -016. A refactor that breaks the partitioning
-would cause CDC-001 to start firing on this chain and mislead the
-user into "adding a 2FF chain you already have". The
-``forbidden=(CDC-001, ZERO)`` clause below is the canary —
-independently derived from the hand-authored fixture's assertion
-in ``tests/test_bad_opposite_edge_sync.py``. Do not remove or
-weaken either when pruning the fuzz corpus.
+the polarity helper (``_clk_polarity``) all key off the same
+chain-traversal primitives. A refactor that unifies any of those
+predicates could silently regress the partitioning and cause the
+wrong rule to fire on a clean polarity-flip chain — misleading
+the user into e.g. "add a 2FF chain you already have"
+(CDC-001/-002) or "remove the comb you don't have" (CDC-014).
+
+The ``forbidden`` clause below is the canary: every chain-walker
+rule but CDC-016 is asserted to stay silent. Independently
+derived from the hand-authored fixture's assertion in
+``tests/test_bad_opposite_edge_sync.py::test_chain_walker_partitioning_silent``.
+Do not remove or weaken either when pruning the fuzz corpus.
 """
 
 from __future__ import annotations
@@ -84,5 +89,7 @@ class OppositeEdgeChain:
                 forbidden=(
                     ExpectedFinding("CDC-001", Op.ZERO),
                     ExpectedFinding("CDC-002", Op.ZERO),
+                    ExpectedFinding("CDC-014", Op.ZERO),
+                    ExpectedFinding("CDC-015", Op.ZERO),
                 ),
             )

--- a/tests/test_bad_opposite_edge_sync.py
+++ b/tests/test_bad_opposite_edge_sync.py
@@ -62,28 +62,36 @@ def test_only_cdc_016_fires(context) -> None:
     )
 
 
-def test_cdc_001_and_002_explicitly_silent(context) -> None:
-    """Explicit assertion that CDC-001/-002 stay silent on the
-    opposite-edge chain (rtl-buddy-cdc#193).
+def test_chain_walker_partitioning_silent(context) -> None:
+    """Explicit per-rule silence assertion for the chain-walker partition.
 
-    The chain walker (``_sync_chain_depth``) and the deferral
-    predicate (``_chain_has_inter_stage_comb``) are shared
-    plumbing between CDC-001 / -014 / -015 / -016. A future
-    refactor that touches any of those could silently regress
-    the partitioning and cause CDC-001 to start firing on a
-    polarity-flip chain — which would mislead the user into
-    "adding a 2FF chain you already have". This explicit
-    assertion is the canary: the rule_ids equality in
-    test_only_cdc_016_fires already covers this, but spelling
-    it out by name makes the partitioning invariant readable
-    in the test name and unambiguous in the failure message."""
+    The chain walker (``_sync_chain_depth``, ``_sync_chain_flops``)
+    and the deferral predicate (``_chain_has_inter_stage_comb``)
+    are shared plumbing between CDC-001 / -002 / -014 / -015 / -016
+    (rtl-buddy-cdc#193). On the opposite-edge fixture every one
+    of those rules but CDC-016 must stay silent:
+
+    * **CDC-001/-002** — chain depth is 2, no deferral hazard.
+    * **CDC-014** — no combinational logic between stages.
+    * **CDC-015** — both stages share ``rst_n`` (single reset
+      domain).
+
+    A future refactor that unifies the deferral predicates, the
+    chain walker, or the same-clock guard could silently regress
+    any one of those partition lines and start firing the wrong
+    rule on a clean polarity-flip chain. The rule_ids equality in
+    :func:`test_only_cdc_016_fires` already catches this, but the
+    per-rule assertion below pins each partition line by name so
+    the failure message identifies *which* rule leaked rather than
+    "the set is different"."""
     module, crossings, spec = context
     violations = run_all_rules(module, crossings, spec)
-    spurious = [v for v in violations if v.rule_id in {"CDC-001", "CDC-002"}]
-    assert spurious == [], (
-        f"CDC-001/-002 leaked onto opposite-edge chain — sync chain "
-        f"polarity partitioning has regressed: "
-        f"{[(v.rule_id, v.message) for v in spurious]}"
+    partition_rules = {"CDC-001", "CDC-002", "CDC-014", "CDC-015"}
+    leaks = sorted({v.rule_id for v in violations if v.rule_id in partition_rules})
+    assert leaks == [], (
+        f"chain-walker partition regressed — {leaks} leaked onto the "
+        f"opposite-edge chain that only CDC-016 should fire on: "
+        f"{[(v.rule_id, v.message) for v in violations if v.rule_id in partition_rules]}"
     )
 
 


### PR DESCRIPTION
## Summary

Strengthens the rtl-buddy-cdc#193 sentinel from CDC-001/-002 silence to the full chain-walker partition: **CDC-001 / -002 / -014 / -015**. The opposite-edge 2FF fixture is now asserted to be silent on every rule that shares the chain-walker plumbing (`_sync_chain_depth`, `_sync_chain_flops`, `_chain_has_inter_stage_comb`, `_clk_polarity`) — not just the two PR-#197 covered.

## Motivation

PR rtl-buddy-cdc#197 (commit `669dc27`) closed two of three rtl-buddy-cdc#193 follow-ons opportunistically and pinned CDC-001/-002 silence on `bad_opposite_edge_sync`. But the issue body explicitly names CDC-001/-002/-014/-015/-016 as the shared-plumbing partition, and the existing assertion left CDC-014 (no comb between stages) and CDC-015 (single reset domain) unpinned. A refactor that unifies the deferral predicates could silently regress CDC-014/-015 on this fixture and start firing the wrong rule on a clean polarity-flip chain, misleading the user into "remove the comb you don't have" or "fix the reset routing that's already correct".

## Changes

- **`tests/test_bad_opposite_edge_sync.py`** — replaced `test_cdc_001_and_002_explicitly_silent` with `test_chain_walker_partitioning_silent`, asserting CDC-001/-002/-014/-015 all stay silent and reporting *which* rule leaked on failure (the rule_ids equality in `test_only_cdc_016_fires` already caught it via set inequality, but the named assertion makes the partition line explicit in failure output).
- **`tests/fuzz/templates/cdc016.py`** — extended the `forbidden` clause to include `CDC-014` and `CDC-015` alongside CDC-001/-002 so the fuzz oracle independently re-derives the same partition assertion across the generated SDC/clock-period sweep. Tightened the regression-sentinel docstring to name the full partition and link to the renamed hand-authored test.

## Test plan

- [x] `uv run pytest -q` — 812 passed, 24 skipped (unchanged)
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy` — clean
- [x] Manual confirmation: only CDC-016 fires on `bad_opposite_edge_sync` today

Closes rtl-buddy-cdc#193

🤖 Generated with [Claude Code](https://claude.com/claude-code)