### PR TITLE
feat(fuzz): widen six gap-template sweeps so every rule fires ≥10×

### DIFF
--- a/tests/fuzz/templates/gap_g10.py
+++ b/tests/fuzz/templates/gap_g10.py
@@ -7,10 +7,18 @@ False against every declared clock (no async-group entry), so
 ``_filter_async`` drops every crossing involving the undeclared
 domain and the rule pack stays completely silent.
 
-Asserts CDC-021 fires once on the undeclared ``clk_aux``. Before the
-rule existed, ``run_all`` produced zero findings on this shape — and
-worse, the legitimate ``d_main → q_aux`` crossing was silently
-dropped.
+Stage-3 Layer A (rtl-buddy-cdc#221): the undeclared-port name
+sweeps across :data:`_UNDECLARED_PORT_NAMES` so CDC-021 crosses
+the ≥10× bar without changing the structural shape. The SDC stays
+empty by design — the failure mode is the *absence* of any
+``create_clock`` for the flop's clock source. Port-name renaming
+is the attribute-style cheapest multiplier per the issue's
+Layer-A guidance.
+
+Asserts CDC-021 fires once per case on the undeclared port driving
+the self-loop flop. Before the rule existed, ``run_all`` produced
+zero findings on this shape — and worse, any legitimate
+crossing involving the undeclared domain was silently dropped.
 """
 
 from __future__ import annotations
@@ -21,23 +29,41 @@ from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
 module {top} (
-    input  logic clk_aux,
+    input  logic {clk_port},
     output logic q_out
 );
-    // CLK is the undeclared port clk_aux. Self-loop on Q keeps the
+    // CLK is the undeclared port {clk_port}. Self-loop on Q keeps the
     // template minimal — no data port (which would also fire CDC-011)
     // and no inter-domain crossing (which would also fire CDC-001).
     // The single failure mode the sentinel pins is the undeclared
     // port driving a flop CLK.
     logic q_aux;
-    always_ff @(posedge clk_aux) q_aux <= ~q_aux;
+    always_ff @(posedge {clk_port}) q_aux <= ~q_aux;
 
     assign q_out = q_aux;
 endmodule
 """
 
-# SDC is intentionally empty — clk_aux has no create_clock declaration.
+# SDC is intentionally empty across the sweep — the failure mode
+# *is* the absence of a ``create_clock`` for the flop's clock.
 _SDC = ""
+
+# Ten distinct names for the undeclared clock port. Each variant
+# yields a structurally identical design with a different port name
+# so the Yosys content-hash key (which includes the SV body and the
+# ``top`` name) doesn't dedupe them. All ten fire CDC-021 once.
+_UNDECLARED_PORT_NAMES: list[str] = [
+    "clk_aux",
+    "clk_alt",
+    "clk_misc",
+    "clk_ext",
+    "clk_other",
+    "clk_spare",
+    "clk_undef",
+    "clk_extra",
+    "clk_xtra",
+    "clk_unkn",
+]
 
 
 class GapG10FlopClkUndeclaredPort:
@@ -47,22 +73,24 @@ class GapG10FlopClkUndeclaredPort:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-021", Op.EQ, 1),),
-            # Today the d_main → q_aux crossing is silently dropped
-            # by _filter_async (clk_aux has no async-group entry,
-            # so are_async returns False). Pin that CDC-001 stays
-            # silent so a future ``treat unknown-domain as async``
-            # change doesn't silently double-report.
-            forbidden=(
-                ExpectedFinding("CDC-001", Op.ZERO),
-                ExpectedFinding("CDC-011", Op.ZERO),
-            ),
-        )
+        for clk_port in _UNDECLARED_PORT_NAMES:
+            top = f"fuzz_{cls.name}_{clk_port}"
+            sv = _TEMPLATE.format(top=top, clk_port=clk_port)
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=sv,
+                sdc=_SDC,
+                top=top,
+                params={"clk_port": clk_port},
+                expected=(ExpectedFinding("CDC-021", Op.EQ, 1),),
+                # Today the d_main → q_aux crossing is silently dropped
+                # by _filter_async (the port has no async-group entry,
+                # so are_async returns False). Pin that CDC-001 stays
+                # silent so a future ``treat unknown-domain as async``
+                # change doesn't silently double-report.
+                forbidden=(
+                    ExpectedFinding("CDC-001", Op.ZERO),
+                    ExpectedFinding("CDC-011", Op.ZERO),
+                ),
+            )

--- a/tests/fuzz/templates/gap_g2.py
+++ b/tests/fuzz/templates/gap_g2.py
@@ -8,14 +8,20 @@ where 2 would do. CDC-001 / CDC-002 stay silent because the chain
 is structurally well-formed; CDC-018 surfaces the code-review
 smell.
 
-Asserts CDC-018 fires once on the 4-deep chain. Before the rule
-existed, ``run_all`` produced zero findings on this shape.
+Stage-3 Layer A (rtl-buddy-cdc#221): the SDC clock periods sweep
+across :data:`TWO_CLOCK_PERIODS` so CDC-018 crosses the ≥10× bar
+without changing the structural shape — purely an SDC-only
+multiplier per the issue's Layer-A guidance.
+
+Asserts CDC-018 fires once per case on the 4-deep chain. Before the
+rule existed, ``run_all`` produced zero findings on this shape.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -42,10 +48,10 @@ module {top} (
 endmodule
 """
 
-_SDC = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+_SDC_TEMPLATE = """\
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports d_in]
 """
 
@@ -57,19 +63,22 @@ class GapG2CascadedSynchroniser:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-018", Op.EQ, 1),),
-            # CDC-001/002 silent because the chain is structurally
-            # well-formed at depth >= required_depth. Pin both.
-            forbidden=(
-                ExpectedFinding("CDC-001", Op.ZERO),
-                ExpectedFinding("CDC-002", Op.ZERO),
-            ),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            sv = _TEMPLATE.format(top=top)
+            sdc = _SDC_TEMPLATE.format(src_period=src_period, dst_period=dst_period)
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=sv,
+                sdc=sdc,
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-018", Op.EQ, 1),),
+                # CDC-001/002 silent because the chain is structurally
+                # well-formed at depth >= required_depth. Pin both.
+                forbidden=(
+                    ExpectedFinding("CDC-001", Op.ZERO),
+                    ExpectedFinding("CDC-002", Op.ZERO),
+                ),
+            )

--- a/tests/fuzz/templates/gap_g4.py
+++ b/tests/fuzz/templates/gap_g4.py
@@ -9,14 +9,20 @@ upstream, and the dst can transiently observe incoherent
 combinations between the independently-resolved samples (e.g.
 ``4'b0010`` mid-transition between ``4'b0001`` and ``4'b0100``).
 
-Asserts CDC-019 fires once on the shared decoder. Before the rule
-existed, ``run_all`` produced zero findings on this shape.
+Stage-3 Layer A (rtl-buddy-cdc#221): the SDC clock periods sweep
+across :data:`TWO_CLOCK_PERIODS` so CDC-019 crosses the ≥10× bar
+without changing the structural shape — purely an SDC-only
+multiplier per the issue's Layer-A guidance.
+
+Asserts CDC-019 fires once per case on the shared decoder. Before
+the rule existed, ``run_all`` produced zero findings on this shape.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -60,10 +66,10 @@ module {top} (
 endmodule
 """
 
-_SDC = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+_SDC_TEMPLATE = """\
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports sel]
 """
 
@@ -75,19 +81,22 @@ class GapG4OneHotDecodeIndependentSync:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-019", Op.EQ, 1),),
-            # CDC-004 misses this — each src flop is structurally
-            # 1-bit, so the multi-bit-bus detector doesn't see the
-            # related lanes. Pin that explicitly so a future widening
-            # of CDC-004 to walk back through shared comb cells
-            # doesn't silently double-count.
-            forbidden=(ExpectedFinding("CDC-004", Op.ZERO),),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            sv = _TEMPLATE.format(top=top)
+            sdc = _SDC_TEMPLATE.format(src_period=src_period, dst_period=dst_period)
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=sv,
+                sdc=sdc,
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-019", Op.EQ, 1),),
+                # CDC-004 misses this — each src flop is structurally
+                # 1-bit, so the multi-bit-bus detector doesn't see the
+                # related lanes. Pin that explicitly so a future widening
+                # of CDC-004 to walk back through shared comb cells
+                # doesn't silently double-count.
+                forbidden=(ExpectedFinding("CDC-004", Op.ZERO),),
+            )

--- a/tests/fuzz/templates/gap_g6.py
+++ b/tests/fuzz/templates/gap_g6.py
@@ -11,8 +11,13 @@ Sibling of CDC-019: same per-lane-independent-sync hazard, but the
 source is a true multi-bit register rather than a shared comb
 decoder.
 
-Asserts CDC-020 fires once on the (src_flop, dst_clock) group.
-Before the rule existed, ``run_all`` produced zero findings —
+Stage-3 Layer A (rtl-buddy-cdc#221): the SDC clock periods sweep
+across :data:`TWO_CLOCK_PERIODS` so CDC-020 crosses the ≥10× bar
+without changing the structural shape — purely an SDC-only
+multiplier per the issue's Layer-A guidance.
+
+Asserts CDC-020 fires once per case on the (src_flop, dst_clock)
+group. Before the rule existed, ``run_all`` produced zero findings —
 CDC-004 silent because each lane is width=1, and CDC-019 silent
 because the driver is a flop, not a comb cell.
 """
@@ -21,6 +26,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -55,10 +61,10 @@ module {top} (
 endmodule
 """
 
-_SDC = """\
-create_clock -name src_clk -period 10.0 [get_ports src_clk]
-create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
-set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+_SDC_TEMPLATE = """\
+create_clock -name src_clk -period {src_period} [get_ports src_clk]
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
+set_clock_groups -asynchronous -group {{src_clk}} -group {{dst_clk}}
 set_input_delay -clock src_clk 1.0 [get_ports d_in]
 """
 
@@ -70,20 +76,23 @@ class GapG6SlicedBusReconvergence:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("CDC-020", Op.EQ, 1),),
-            # CDC-004 misses because every crossing is width=1 after
-            # slicing; CDC-019 misses because the driver is a flop,
-            # not a comb cell. Pin both stay silent.
-            forbidden=(
-                ExpectedFinding("CDC-004", Op.ZERO),
-                ExpectedFinding("CDC-019", Op.ZERO),
-            ),
-        )
+        for src_period, dst_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(src_period, dst_period)}"
+            sv = _TEMPLATE.format(top=top)
+            sdc = _SDC_TEMPLATE.format(src_period=src_period, dst_period=dst_period)
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=sv,
+                sdc=sdc,
+                top=top,
+                params={"src_period": src_period, "dst_period": dst_period},
+                expected=(ExpectedFinding("CDC-020", Op.EQ, 1),),
+                # CDC-004 misses because every crossing is width=1 after
+                # slicing; CDC-019 misses because the driver is a flop,
+                # not a comb cell. Pin both stay silent.
+                forbidden=(
+                    ExpectedFinding("CDC-004", Op.ZERO),
+                    ExpectedFinding("CDC-019", Op.ZERO),
+                ),
+            )

--- a/tests/fuzz/templates/gap_g7.py
+++ b/tests/fuzz/templates/gap_g7.py
@@ -10,17 +10,23 @@ the chain as a valid synchroniser — its check only requires
 constant-fed head + same-domain + same-reset, not that the constant
 matches the deassertion polarity.
 
-Asserts RDC-007 fires once on the head-D mismatch shape. Before the
-rule existed, ``run_all`` produced zero findings for this design (and
-worse, every downstream consumer using the broken chain's output was
-silently suppressed from RDC-001..-006 because the chain looked
-structurally valid).
+Stage-3 Layer A (rtl-buddy-cdc#221): the SDC ``dst_clk`` period
+sweeps across :data:`ONE_CLOCK_PERIODS` so RDC-007 crosses the
+≥10× bar without changing the structural shape — purely an
+SDC-only multiplier per the issue's Layer-A guidance.
+
+Asserts RDC-007 fires once per case on the head-D mismatch shape.
+Before the rule existed, ``run_all`` produced zero findings for this
+design (and worse, every downstream consumer using the broken
+chain's output was silently suppressed from RDC-001..-006 because
+the chain looked structurally valid).
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import ONE_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -42,8 +48,8 @@ module {top} (
 endmodule
 """
 
-_SDC = """\
-create_clock -name dst_clk -period 10.0 [get_ports dst_clk]
+_SDC_TEMPLATE = """\
+create_clock -name dst_clk -period {dst_period} [get_ports dst_clk]
 """
 
 
@@ -54,21 +60,24 @@ class GapG7DeassertionPolarityBackwards:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            expected=(ExpectedFinding("RDC-007", Op.EQ, 1),),
-            # The chain is otherwise structurally well-formed
-            # (constant-fed head, same-domain, async-reset shared);
-            # pin that no RDC-001/002 fires on the head's port-sourced
-            # reset (the chain consumes a top-level port, no crossing).
-            forbidden=(
-                ExpectedFinding("RDC-001", Op.ZERO),
-                ExpectedFinding("RDC-002", Op.ZERO),
-            ),
-        )
+        for dst_period in ONE_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(dst_period)}"
+            sv = _TEMPLATE.format(top=top)
+            sdc = _SDC_TEMPLATE.format(dst_period=dst_period)
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=sv,
+                sdc=sdc,
+                top=top,
+                params={"dst_period": dst_period},
+                expected=(ExpectedFinding("RDC-007", Op.EQ, 1),),
+                # The chain is otherwise structurally well-formed
+                # (constant-fed head, same-domain, async-reset shared);
+                # pin that no RDC-001/002 fires on the head's port-sourced
+                # reset (the chain consumes a top-level port, no crossing).
+                forbidden=(
+                    ExpectedFinding("RDC-001", Op.ZERO),
+                    ExpectedFinding("RDC-002", Op.ZERO),
+                ),
+            )

--- a/tests/fuzz/templates/gap_g8.py
+++ b/tests/fuzz/templates/gap_g8.py
@@ -6,14 +6,20 @@ because the reset source is a port (not a foreign-domain flop's Q),
 but the recovery/removal hazard is the same: deassertion edge is
 unsynchronised to the consumer clock.
 
-Asserts RDC-008 fires once. Before the rule existed, ``run_all``
-produced zero findings on this shape.
+Stage-3 Layer A (rtl-buddy-cdc#221): the SDC clock periods sweep
+across :data:`TWO_CLOCK_PERIODS` so RDC-008 crosses the ≥10× bar
+without changing the structural shape — purely an SDC-only
+multiplier per the issue's Layer-A guidance.
+
+Asserts RDC-008 fires once per case. Before the rule existed,
+``run_all`` produced zero findings on this shape.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
 
+from ._sweep import TWO_CLOCK_PERIODS, case_suffix
 from .base import ExpectedFinding, Op, RenderedCase
 
 _TEMPLATE = """\
@@ -62,10 +68,10 @@ module {top} (
 endmodule
 """
 
-_SDC = """\
-create_clock -name clk_a -period 10.0 [get_ports clk_a]
-create_clock -name clk_b -period 7.5  [get_ports clk_b]
-set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
+_SDC_TEMPLATE = """\
+create_clock -name clk_a -period {clk_a_period} [get_ports clk_a]
+create_clock -name clk_b -period {clk_b_period} [get_ports clk_b]
+set_clock_groups -asynchronous -group {{clk_a}} -group {{clk_b}}
 set_input_delay -clock clk_a 1.0 [get_ports d_in_a]
 set_input_delay -clock clk_b 1.0 [get_ports d_in_b]
 """
@@ -78,20 +84,29 @@ class GapG8PrimaryResetUnsynced:
 
     @classmethod
     def cases(cls) -> Iterator[RenderedCase]:
-        top = f"fuzz_{cls.name}"
-        yield RenderedCase(
-            template_name=cls.name,
-            case_id=top,
-            sv=_TEMPLATE.format(top=top),
-            sdc=_SDC,
-            top=top,
-            params={},
-            # Port has a chain in clk_a, missing it in clk_b — one
-            # (port, clk_b) finding under the asymmetric-intent gate.
-            expected=(ExpectedFinding("RDC-008", Op.EQ, 1),),
-            # RDC-001 deliberately stays silent on port-sourced
-            # resets (the source isn't a foreign-domain flop). Pin
-            # that explicitly so a future broadening of RDC-001
-            # doesn't silently double-report.
-            forbidden=(ExpectedFinding("RDC-001", Op.ZERO),),
-        )
+        for clk_a_period, clk_b_period in TWO_CLOCK_PERIODS:
+            top = f"fuzz_{cls.name}_{case_suffix(clk_a_period, clk_b_period)}"
+            sv = _TEMPLATE.format(top=top)
+            sdc = _SDC_TEMPLATE.format(
+                clk_a_period=clk_a_period,
+                clk_b_period=clk_b_period,
+            )
+            yield RenderedCase(
+                template_name=cls.name,
+                case_id=top,
+                sv=sv,
+                sdc=sdc,
+                top=top,
+                params={
+                    "clk_a_period": clk_a_period,
+                    "clk_b_period": clk_b_period,
+                },
+                # Port has a chain in clk_a, missing it in clk_b — one
+                # (port, clk_b) finding under the asymmetric-intent gate.
+                expected=(ExpectedFinding("RDC-008", Op.EQ, 1),),
+                # RDC-001 deliberately stays silent on port-sourced
+                # resets (the source isn't a foreign-domain flop). Pin
+                # that explicitly so a future broadening of RDC-001
+                # doesn't silently double-report.
+                forbidden=(ExpectedFinding("RDC-001", Op.ZERO),),
+            )


### PR DESCRIPTION
## Summary

Stage-3 Layer A of rtl-buddy-cdc#221. Closes the Stage-2 "every shipping rule fires ≥10× across the corpus" gap that re-opened with every new rule landed after the Stage 1–5 umbrella.

| Rule    | Before | After |
|---------|--------|-------|
| CDC-018 | 1      | 12    |
| CDC-019 | 1      | 12    |
| CDC-020 | 1      | 12    |
| CDC-021 | 1      | 10    |
| RDC-007 | 1      | 10    |
| RDC-008 | 1      | 12    |

All 28 rules now fire ≥10×. Corpus grew from 268 → 330 cases; all pass.

## Approach

Per the issue's Layer-A guidance — the cheapest multiplier is an SDC-only sweep since the Yosys cache key is `(top, sv, sdc, extra_passes)` and the structural shape stays identical, so the marginal cost is one Yosys-parse-SV per added case.

- **gap_g2 / g4 / g6 / g8** (two-clock templates): sweep `TWO_CLOCK_PERIODS` (12 entries → 12 cases each).
- **gap_g7** (single-clock template): sweep `ONE_CLOCK_PERIODS` (10 entries → 10 cases).
- **gap_g10** (empty-SDC template — CDC-021 fires *because* the SDC is empty): no SDC axis available, so sweep ten undeclared-port-name variants instead. This is the attribute-style cheapest multiplier the issue's Layer A names alongside SDC sweeps.

The `ExpectedFinding(rule, Op.EQ, 1)` invariant is preserved on every case (the target rule fires exactly once per variant — structural shape is unchanged, only the SDC / port-name varies).

## Test plan

- [x] `uv run python -m tests.fuzz.coverage` — every rule ≥10×, no failed cases
- [x] `uv run pytest -q -m fuzz` — 330 passed
- [x] `uv run pytest -q` — 874 passed, 24 skipped
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy` — clean

Closes rtl-buddy-cdc#221 (Layer A only — Layers B and C will land in follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)