### PR TITLE
feat(slang): preserve clock edge as CLK_POLARITY on $dff/$adff/$sdff (closes CDC-016 parity gap)

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -114,12 +114,16 @@ What is NOT yet implemented (next slices)
   :meth:`_walk_case_statement` lowering treats every label as a
   full ``$eq`` match, so wildcard bits in the label aren't honored.
   Uncommon in CDC-sensitive code and not yet wired up.
-- **``CLK_POLARITY = "0"`` for negedge-clocked flops** — the
-  procedural-block lowering assumes posedge today, so
-  ``CLK_POLARITY`` is hard-coded to ``"1"`` in :meth:`_emit_flop_cell`.
-  ``WIDTH`` / ``ARST_VALUE`` / ``ARST_POLARITY`` are populated in
-  Yosys-binary form per issue #40, and width comes straight from the
-  Q bit-tuple, so multi-bit flops have correct parameter shape.
+- (was: ``CLK_POLARITY = "0"`` for negedge-clocked flops — landed
+  in rtl-buddy-cdc#221 to close the CDC-016 cross-frontend parity
+  gap. ``_analyse_event_list`` now reports the clock edge alongside
+  the reset edge, ``_emit_procedural_block`` stashes it as
+  ``self._clk_negedge``, and ``_emit_flop_cell`` reads it when
+  populating the ``CLK_POLARITY`` parameter. ``WIDTH`` /
+  ``ARST_VALUE`` / ``ARST_POLARITY`` are still populated in
+  Yosys-binary form per issue #40, and width comes straight from
+  the Q bit-tuple, so multi-bit flops have correct parameter
+  shape.)
 - **Yosys-only constructs** (``$_BUF_`` / ``$_NOT_`` primitives in SV
   source) are correctly rejected by slang — they're post-synthesis
   cells, not legal SV. Fixtures that rely on them
@@ -711,9 +715,18 @@ class _ModuleBuilder:
         # Expected shape: TimedStatement(timing=EventListControl, stmt=...)
         if self._kind_name(body) != "TimedStatement":
             return
-        clk_sym, reset_sym, reset_active_low = self._analyse_event_list(body.timing)
+        clk_sym, reset_sym, reset_active_low, clk_negedge = self._analyse_event_list(
+            body.timing
+        )
         if clk_sym is None:
             return  # can't identify clock — skip rather than crash
+        # Stash the clock edge as instance state so ``_emit_flop_cell``
+        # can read it without threading a polarity parameter through
+        # every ``_emit_assignments_*`` helper. The save/restore in the
+        # surrounding try/finally keeps nested always_ff blocks correct
+        # (an unusual but legal SV shape).
+        prev_clk_negedge = getattr(self, "_clk_negedge", False)
+        self._clk_negedge = clk_negedge
         # Drill through the optional BlockStatement wrapper.
         inner = body.stmt
         if self._kind_name(inner) == "BlockStatement":
@@ -802,6 +815,7 @@ class _ModuleBuilder:
         finally:
             self._proc_writes = {}
             self._proc_resets = {}
+            self._clk_negedge = prev_clk_negedge
 
     def _collect_reset_assignments(self, stmt: Any) -> None:
         """Walk an ``always_ff`` reset arm (``if (!rst_n) <stmt>``) and
@@ -840,15 +854,22 @@ class _ModuleBuilder:
             return
         self._proc_resets[q_bits] = val
 
-    def _analyse_event_list(self, timing: Any) -> tuple[Any | None, Any | None, bool]:
+    def _analyse_event_list(
+        self, timing: Any
+    ) -> tuple[Any | None, Any | None, bool, bool]:
         """Pick clock + (optional) async-reset symbols out of the
         timing control.
 
-        Returns ``(clock_sym, reset_sym, reset_active_low)``. The reset
-        identification is provisional — the canonical conditional body
-        shape gives the authoritative answer and we override here when
-        we see it. The polarity comes from the event edge: ``negedge``
-        on the reset event means the reset asserts low.
+        Returns ``(clock_sym, reset_sym, reset_active_low,
+        clock_negedge)``. The reset identification is provisional —
+        the canonical conditional body shape gives the authoritative
+        answer and we override here when we see it. The polarity
+        comes from the event edge: ``negedge`` on the reset event
+        means the reset asserts low. ``clock_negedge`` reports the
+        clock-event edge directly; it threads through to
+        :meth:`_emit_flop_cell` as the ``CLK_POLARITY`` parameter
+        (rtl-buddy-cdc#221 — closes the CDC-016 parity gap tracked
+        in #224).
 
         pyslang exposes two timing-control shapes:
 
@@ -861,22 +882,35 @@ class _ModuleBuilder:
         """
         # SignalEventControl: single event, no ``.events`` list.
         if getattr(timing, "events", None) is None and hasattr(timing, "expr"):
-            return getattr(timing.expr, "symbol", None), None, False
+            clk_edge = str(getattr(timing, "edge", "")).rsplit(".", 1)[-1]
+            return (
+                getattr(timing.expr, "symbol", None),
+                None,
+                False,
+                clk_edge == "NegEdge",
+            )
         events = list(getattr(timing, "events", []) or [])
         if not events:
-            return None, None, False
+            return None, None, False, False
         # Single-event case: that's the clock, no reset.
         if len(events) == 1:
             ev = events[0]
-            return getattr(ev.expr, "symbol", None), None, False
+            clk_edge = str(getattr(ev, "edge", "")).rsplit(".", 1)[-1]
+            return (
+                getattr(ev.expr, "symbol", None),
+                None,
+                False,
+                clk_edge == "NegEdge",
+            )
         # Two-event case (the common async-reset shape): the event
         # whose edge matches the conventional clock side is the clock;
         # the other is provisionally the reset.
         clk_ev, rst_ev = events[0], events[1]
         clk_sym = getattr(clk_ev.expr, "symbol", None)
         rst_sym = getattr(rst_ev.expr, "symbol", None)
+        clk_edge = str(getattr(clk_ev, "edge", "")).rsplit(".", 1)[-1]
         rst_edge = str(getattr(rst_ev, "edge", "")).rsplit(".", 1)[-1]
-        return clk_sym, rst_sym, rst_edge == "NegEdge"
+        return clk_sym, rst_sym, rst_edge == "NegEdge", clk_edge == "NegEdge"
 
     @staticmethod
     def _extract_condition_symbol(expr: Any) -> Any | None:
@@ -1643,15 +1677,18 @@ class _ModuleBuilder:
                 # ``"async"`` (or unspecified — pre-#86 default).
                 connections["ARST"] = self._alloc_bits(reset_sym)
                 cell_type = "$adff"
-        # CLK_POLARITY: slang lowering only emits posedge-clocked flops
-        # today, so this is hard-coded to "1". Negedge support (issue
-        # out-of-scope for #40) will need a polarity arg threaded down.
-        # WIDTH / *RST_POLARITY match Yosys' 32-bit binary-string param
-        # encoding; *RST_VALUE matches the flop's bit width so the
-        # string length lines up with the D / Q nets.
+        # CLK_POLARITY: read off the procedural-block lowering's
+        # active clock edge (rtl-buddy-cdc#221 — closes the CDC-016
+        # parity gap tracked in #224). ``_emit_procedural_block``
+        # stashes ``self._clk_negedge`` from ``_analyse_event_list``
+        # around its drain call. WIDTH / *RST_POLARITY match Yosys'
+        # 32-bit binary-string param encoding; *RST_VALUE matches the
+        # flop's bit width so the string length lines up with the
+        # D / Q nets.
         width = len(q_bits)
+        clk_polarity = "0" if getattr(self, "_clk_negedge", False) else "1"
         parameters: dict[str, str] = {
-            "CLK_POLARITY": "1",
+            "CLK_POLARITY": clk_polarity,
             "WIDTH": _param_int32(width),
         }
         if reset_sym is not None:

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -377,6 +377,105 @@ endmodule
     }, dff.parameters
 
 
+def test_negedge_dff_has_clk_polarity_zero(tmp_path: Path) -> None:
+    """A negedge-clocked ``always_ff`` emits ``CLK_POLARITY = "0"``
+    on the resulting ``$dff`` — closes the CDC-016 cross-frontend
+    parity gap from rtl-buddy-cdc#221 / #224.
+
+    Before the fix, the slang lowering hard-coded ``CLK_POLARITY``
+    to ``"1"`` regardless of the event-list edge, so the rule
+    pack's CDC-016 detector (which keys off
+    ``cell.parameters["CLK_POLARITY"]`` on adjacent chain stages)
+    saw a polarity-uniform chain and stayed silent. The Yosys
+    frontend gets this right via ``write_json`` reading the
+    parameter directly from the elaborator, so this gap was a
+    slang-lowering-only bug.
+    """
+    src = """module m (
+    input  logic clk, d,
+    output logic q
+);
+    always_ff @(negedge clk) q <= d;
+endmodule
+"""
+    sv = tmp_path / "m.sv"
+    sv.write_text(src)
+    module = elaborate([sv], "m", frontend=Frontend.slang)
+    dff = next(c for c in module.cells.values() if c.type == "$dff")
+    assert dff.parameters["CLK_POLARITY"] == "0", dff.parameters
+
+
+def test_cdc_016_fires_on_opposite_edge_chain(tmp_path: Path) -> None:
+    """Slang-elaborated opposite-edge sync chain fires CDC-016 —
+    the corpus-discovered parity gap (rtl-buddy-cdc#224) for this
+    template family now closes via the ``CLK_POLARITY`` plumbing
+    landed in this PR.
+
+    Two stages on ``dst_clk`` whose edges disagree: stage 1 is
+    ``posedge`` (``$adff`` CLK_POLARITY=1), stage 2 is ``negedge``
+    (``$adff`` CLK_POLARITY=0). CDC-016 keys off the adjacent-stage
+    polarity mismatch — before the fix slang's $adff emission
+    forced CLK_POLARITY="1" on both stages, so the rule's detector
+    stayed silent on a structurally valid mismatch.
+    """
+    src = """module m (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic rst_n,
+    input  logic d_in,
+    output logic q_out
+);
+    logic src_q;
+    always_ff @(posedge src_clk or negedge rst_n)
+        if (!rst_n) src_q <= 1'b0;
+        else        src_q <= d_in;
+
+    logic sync_meta;
+    always_ff @(posedge dst_clk or negedge rst_n)
+        if (!rst_n) sync_meta <= 1'b0;
+        else        sync_meta <= src_q;
+
+    logic sync_q;
+    always_ff @(negedge dst_clk or negedge rst_n)
+        if (!rst_n) sync_q <= 1'b0;
+        else        sync_q <= sync_meta;
+
+    assign q_out = sync_q;
+endmodule
+"""
+    sdc = """\
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5 [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+"""
+    from rtl_buddy_cdc import sdc as sdc_mod
+    from rtl_buddy_cdc.domain import find_crossings
+    from rtl_buddy_cdc.rules import run_all
+
+    sv = tmp_path / "m.sv"
+    sdc_path = tmp_path / "m.sdc"
+    sv.write_text(src)
+    sdc_path.write_text(sdc)
+
+    module = elaborate([sv], "m", frontend=Frontend.slang)
+    spec = sdc_mod.parse_file(sdc_path)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    violations = run_all(module, crossings, spec)
+
+    fired_rules = {v.rule_id for v in violations}
+    assert "CDC-016" in fired_rules, sorted(fired_rules)
+
+    # Polarity-direct check: dst-side chain has one stage at each
+    # polarity; the dst flops carry the polarity-mismatch evidence
+    # the rule pack inspects.
+    dst_adffs = [c for c in module.cells.values() if c.type == "$adff"]
+    polarities = sorted(c.parameters.get("CLK_POLARITY") for c in dst_adffs)
+    # One src flop (CLK_POLARITY=1) + posedge dst stage (=1) +
+    # negedge dst stage (=0) → ["0", "1", "1"].
+    assert polarities == ["0", "1", "1"], polarities
+
+
 # --- Issue #15 regression: child-port netnames preserved as aliases --------
 
 


### PR DESCRIPTION
## Summary

Closes the CDC-016 leg of the cross-frontend parity gap tracked by rtl-buddy-cdc#221 done-when (criteria 2 + 3) and rtl-buddy-cdc#224 (slang-parity umbrella).

The slang lowering historically hard-coded ``CLK_POLARITY = "1"`` on every flop cell because ``_emit_procedural_block`` only kept the *reset* edge from the event list — the clock edge was silently dropped. CDC-016 keys off ``cell.parameters["CLK_POLARITY"]`` on adjacent chain stages, so every opposite-edge sync hazard the slang frontend touched stayed silent.

## Fix

| Surface | Change |
|---|---|
| ``_analyse_event_list`` | Returns a 4-tuple ``(clk_sym, rst_sym, rst_active_low, clk_negedge)``. Both ``SignalEventControl`` (one-event) and ``EventListControl`` (multi-event) paths now read ``ev.edge`` and report ``edge == NegEdge``. |
| ``_emit_procedural_block`` | Stashes the clock edge as ``self._clk_negedge`` around the drain call (save/restore scoped to the try/finally so nested ``always_ff`` blocks stay correct). |
| ``_emit_flop_cell`` | Reads ``self._clk_negedge`` when filling the ``CLK_POLARITY`` parameter. The rest of the param shape is unchanged. |

## Tests

- ``test_negedge_dff_has_clk_polarity_zero`` — minimal ``always_ff @(negedge clk)`` flop; pins ``CLK_POLARITY == "0"`` on the resulting ``$dff``.
- ``test_cdc_016_fires_on_opposite_edge_chain`` — full 3-stage opposite-edge chain elaborates through slang and fires CDC-016; the per-cell polarity tuple ``["0", "1", "1"]`` is pinned so regressions tell you exactly which stage drifted.

## Follow-up

When PR #225 (Stage-3 Layer C, ``fuzz_diff`` cross-frontend oracle) lands, its ``_KNOWN_SLANG_PARITY_GAPS`` table needs ``cdc016_opposite_edge`` removed. If this PR lands first, that's a one-line follow-up to Layer C's branch; if Layer C lands first, this PR's CI will fail the diff-oracle XPASS check until the allowlist update lands. I'll push the allowlist update to Layer C's branch alongside this PR's merge.

## Test plan

- [x] ``uv run pytest tests/test_slang_elaboration.py -q`` — 29 passed (was 27)
- [x] ``uv run pytest -q`` — 814 passed, 24 skipped
- [x] ``uv run ruff check`` / ``ruff format --check`` — clean
- [x] ``uv run mypy`` — clean

## Refs

- Issue: rtl-buddy-cdc#221 (done-when criteria 2 + 3, partial)
- Umbrella: rtl-buddy-cdc#224 (one row closed: ``cdc016_opposite_edge``; 5 remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)