### PR TITLE
feat(slang): lower NetSymbol inline initializers (closes 4 slang-parity rows)

### DIFF
--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -612,11 +612,48 @@ class _ModuleBuilder:
             self._emit_continuous_assign(member)
         elif kind == "InstanceSymbol":
             self._emit_child_instance(member, hier_prefix)
+        elif kind == "NetSymbol":
+            # ``wire foo = <expr>;`` lowers as a NetSymbol whose
+            # ``initializer`` carries the RHS. pyslang doesn't emit a
+            # separate ContinuousAssignSymbol for this shape, so without
+            # this branch the inline initializer is silently dropped
+            # — the rule pack then sees the net's bits driven by
+            # nothing, which masks inter-stage comb hazards (CDC-014).
+            self._emit_net_initializer(member)
         # GenerateBlock(Array)Symbol are pre-expanded by ``_iter_scope``
         # before reaching this dispatch; any other unmodelled kind
         # falls through silently — the missing flops surface in
         # ``analyze`` output, which is a better failure mode than
         # crashing on an unrecognised member kind.
+
+    def _emit_net_initializer(self, member: Any) -> None:
+        """Lower a ``wire foo = <expr>;`` inline assignment.
+
+        Slang's :class:`NetSymbol` exposes the RHS via ``.initializer``.
+        We lower it via :meth:`_bits_of_expression` and alias the net's
+        own bits to the RHS bits — exact same shape
+        :meth:`_emit_continuous_assign` produces for the explicit
+        ``assign foo = <expr>;`` form. The two paths converge in
+        the underlying ``$not`` / ``$and`` / `$mux`` / … cell emission,
+        so the rule pack treats both spellings identically.
+
+        Closes the CDC-014 inter-stage-comb-preservation leg of the
+        cross-frontend parity gap tracked in rtl-buddy-cdc#221 /
+        rtl-buddy-cdc#224.
+        """
+        init_expr = getattr(member, "initializer", None)
+        if init_expr is None:
+            return
+        rhs_bits = self._bits_of_expression(init_expr)
+        if rhs_bits is None:
+            return
+        canonical = self._canonical_var(member)
+        # Allocate the net's bits if it's the first time we've seen it;
+        # then merge them into the RHS bits via the same alias-rewrite
+        # primitive ``_emit_continuous_assign`` uses, so any reader of
+        # the net follows through to the driving cell's output.
+        net_bits = self._alloc_bits(member)
+        self._merge_canonical_var(canonical, net_bits, rhs_bits)
 
     def _emit_child_instance(self, child: Any, parent_prefix: str) -> None:
         """Inline a child instance's body into the flat ``Module``.

--- a/tests/test_slang_elaboration.py
+++ b/tests/test_slang_elaboration.py
@@ -356,6 +356,71 @@ endmodule
     }, adff.parameters
 
 
+def test_cdc_014_fires_on_inline_wire_initializer(tmp_path: Path) -> None:
+    """A ``wire foo = ~bar;`` inline initializer between two sync
+    chain stages must preserve the comb cell so the rule pack's
+    inter-stage-comb detector (CDC-014) fires.
+
+    Closes the CDC-014 leg of the cross-frontend parity gap tracked
+    in rtl-buddy-cdc#221 / #224. pyslang lowers
+    ``wire foo = <expr>;`` to a ``NetSymbol`` whose ``initializer``
+    carries the RHS — *not* a separate ``ContinuousAssignSymbol``.
+    Before the fix, the slang frontend only handled the
+    ``ContinuousAssignSymbol`` shape; the inline form was silently
+    dropped and the rule pack saw the second sync flop's D driven
+    by a stale net, masking the inter-stage hazard.
+    """
+    src = """module m (
+    input  logic src_clk,
+    input  logic dst_clk,
+    input  logic d_in,
+    output logic q_out
+);
+    logic src_q;
+    always_ff @(posedge src_clk) src_q <= d_in;
+
+    logic sync_meta;
+    always_ff @(posedge dst_clk) sync_meta <= src_q;
+
+    wire sync_meta_n = ~sync_meta;
+
+    logic sync_q;
+    always_ff @(posedge dst_clk) sync_q <= sync_meta_n;
+
+    assign q_out = sync_q;
+endmodule
+"""
+    sdc = """\
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5 [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+set_input_delay -clock src_clk 1.0 [get_ports d_in]
+"""
+    from rtl_buddy_cdc import sdc as sdc_mod
+    from rtl_buddy_cdc.domain import find_crossings
+    from rtl_buddy_cdc.rules import run_all
+
+    sv = tmp_path / "m.sv"
+    sdc_path = tmp_path / "m.sdc"
+    sv.write_text(src)
+    sdc_path.write_text(sdc)
+
+    module = elaborate([sv], "m", frontend=Frontend.slang)
+    spec = sdc_mod.parse_file(sdc_path)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    violations = run_all(module, crossings, spec)
+    fired = {v.rule_id for v in violations}
+    assert "CDC-014" in fired, sorted(fired)
+
+    # Direct structural check: a ``$not`` cell is preserved between
+    # the two dst-clock flops. Without the fix the comb cell is gone
+    # and the rule pack only sees a one-stage chain (CDC-001 fires
+    # instead of CDC-014).
+    not_cells = [c for c in module.cells.values() if c.type == "$not"]
+    assert len(not_cells) == 1, [c.type for c in module.cells.values()]
+
+
 def test_dff_parameters_have_width_but_no_arst(tmp_path: Path) -> None:
     """The plain ``$dff`` case (no async reset) should still get
     ``WIDTH`` + ``CLK_POLARITY``, but no ``ARST_*`` keys — Yosys omits


### PR DESCRIPTION
## Summary

Closes **four** rows of the slang-parity umbrella (rtl-buddy-cdc#224) and the matching done-when criteria 2 + 3 of rtl-buddy-cdc#221.

pyslang lowers ``wire foo = <expr>;`` to a ``NetSymbol`` whose ``initializer`` carries the RHS — *not* a separate ``ContinuousAssignSymbol``. The slang frontend's pass-3 dispatch only handled ``ContinuousAssignSymbol``, so inline net initializers were silently dropped; every reader of the inline-driven net saw freshly-allocated bits with no driving cell.

Four corpus template families all use this shape:

| Template family | Inline wire | Rule that fires on Yosys |
|---|---|---|
| ``cdc006_comb_source`` | ``wire comb_in = a & b;`` (driving a sync chain head) | CDC-006 |
| ``cdc014_comb_between_stages`` | ``wire sync_meta_n = ~sync_meta;`` (between two sync stages) | CDC-014 |
| ``rdc004_comb_driven_reset`` | ``wire combined_rst_n = rst_n & ~enable_q;`` (driving ARST) | RDC-004 |
| ``rdc005_multi_source_reset`` | ``wire combined_rst_n = global_rst_n & local_rst_n;`` (multi-source reset fan-in) | RDC-005 |

Under slang (before the fix), the inline-driven net was undriven, so:

- CDC-006's comb-driven-sync-chain detector saw a constant input
- CDC-014's chain walker saw a depth-1 chain (CDC-001 fired instead)
- RDC-004's comb-in-reset-path detector saw a clean port-sourced reset
- RDC-005's multi-source-reset detector saw a single port

## Fix

| Surface | Change |
|---|---|
| ``_emit_for_member`` | Adds a ``NetSymbol`` branch. |
| ``_emit_net_initializer`` (new) | Reads ``member.initializer``, lowers it via ``_bits_of_expression`` (emits the appropriate ``$not`` / ``$and`` / ``$mux`` / … comb cell), and merges the net's bits into the RHS bits via the same alias-rewrite primitive ``_emit_continuous_assign`` uses. |

The two spellings of "wire driven by a comb expression" converge at the underlying cell emission, so the rule pack treats them identically.

## Tests

- ``test_cdc_014_fires_on_inline_wire_initializer`` (new) — full inter-stage-comb chain elaborates through slang, fires CDC-014, and the ``$not`` cell count is structurally pinned (one ``$not`` between the two sync stages).
- The existing fixture-based slang-elaboration tests (27 cases) still pass.

## Follow-up

PR #225 (Stage-3 Layer C diff oracle)'s ``_KNOWN_SLANG_PARITY_GAPS`` will drop the ``cdc006_comb_source`` / ``cdc014_comb_between_stages`` / ``rdc004_comb_driven_reset`` / ``rdc005_multi_source_reset`` rows alongside the ``cdc016_opposite_edge`` row from #227 once all three land. Only ``gap_g4_onehot_decode_independent_sync`` (CDC-019) will remain — its ``always_comb`` indexed-write shape is a different gap, not closed by this PR.

## Test plan

- [x] ``uv run pytest tests/test_slang_elaboration.py -q`` — 28 passed (was 27)
- [x] ``uv run pytest -q`` — 813 passed, 24 skipped
- [x] ``uv run ruff check`` / ``ruff format --check`` — clean
- [x] ``uv run mypy`` — clean
- [x] Manual verification: ``CDC-006`` fires on ``cdc006`` template, ``CDC-014`` on ``cdc014``, ``RDC-004`` on ``rdc004``, ``RDC-005`` on ``rdc005`` (all under ``--frontend slang``).

## Refs

- Issue: rtl-buddy-cdc#221 (done-when criteria 2 + 3, partial → close to met)
- Umbrella: rtl-buddy-cdc#224 (4 rows closed; ``cdc019_onehot_decode`` is the only remaining slang-parity gap after #227 + #228)

🤖 Generated with [Claude Code](https://claude.com/claude-code)