### PR TITLE
feat(coverage): add mutants column — 3-surface canonical (closes #221 done-when 6)

### DIFF
--- a/tests/fuzz/coverage.py
+++ b/tests/fuzz/coverage.py
@@ -1,30 +1,42 @@
 """Per-rule coverage reporter over the fuzz corpus.
 
-Stage-3 (rtl-buddy-cdc#221) Layer-C extension: the report tracks
-fires under **each frontend independently** so incomplete slang
-parity is obvious at a glance. The historical single-column
-(Yosys-only) shape is removed in favour of the per-frontend layout.
+Stage-3 (rtl-buddy-cdc#221) full extension: the report tracks fires
+under **each surface independently** so incomplete parity / coverage
+is obvious at a glance. The historical single-column (Yosys-only)
+shape is removed in favour of three independent surfaces:
 
-Layer B (xeno mutator) will add a third ``mutants`` column when it
-lands; the layout below is designed to accept it without further
-restructuring.
+- ``yosys`` — the canonical analyzer path; the historical surface.
+- ``slang`` — the in-process slang frontend (Layer C); empty when
+  pyslang isn't importable.
+- ``mutants`` — xeno-generated mutated SV (Layer B); empty when
+  rtl-buddy-xeno isn't importable. Per-mutant elaboration runs
+  through the Yosys pipeline (mutants are SV-only perturbations
+  of the parent template's source), so the column tracks how
+  many mutant cases fired each rule under the analyzer.
+
+A ``disagree`` column counts per-rule Yosys-vs-slang mismatches —
+high values point at the slang-parity gaps tracked in
+rtl-buddy-cdc#224.
 
 The Stage-2 plan in rtl-buddy-cdc#190 calls for "every shipping rule
-fires ≥10 times across the corpus." With the differential oracle in
-place the bar applies separately per frontend — a rule that fires
-≥10× in Yosys but 0× in slang is still a coverage gap even though
-the rule pack itself is exercised.
+fires ≥10 times across the corpus." With the three-surface report
+each surface is its own ratchet:
+
+- A rule that fires ≥10× in Yosys but 0× in slang is a slang
+  parity gap (track in #224).
+- A rule that fires ≥10× in parent cases but 0× in mutants is a
+  mutator-side coverage gap (track in rtl-buddy-xeno#2).
+- A rule whose ``mutants`` column shows fewer fires than the
+  rtl-buddy-cdc#221 done-when target (≥10 per template) flags
+  insufficient xeno operator coverage for that rule's structural
+  shape.
 
 Invocation::
 
     uv run python -m tests.fuzz.coverage
 
-Output: a table sorted by rule id with columns
-``rule | yosys_fires | slang_fires | disagree | cases``. The
-``disagree`` column counts cases where the per-rule fired counts
-differ between the two frontends — high values point at the
-slang-parity gaps tracked in rtl-buddy-cdc#224. Slang columns
-show ``—`` when pyslang isn't importable in the current env.
+Output: a table sorted by rule id with the columns above.
+Surfaces show ``—`` when their backing dependency isn't installed.
 """
 
 from __future__ import annotations
@@ -34,6 +46,7 @@ from collections import Counter
 
 from rtl_buddy_cdc.rules import RULES
 
+from ._mutator import iter_mutants, xeno_available
 from .runner import collect_cases, run_case, run_case_slang
 from .slang_cache import slang_available
 from .yosys_cache import yosys_available
@@ -45,18 +58,31 @@ def main() -> int:
         return 2
 
     run_slang = slang_available()
+    run_mutants = xeno_available()
 
     yosys_rule_fires: Counter[str] = Counter()
     yosys_rule_cases: Counter[str] = Counter()
     slang_rule_fires: Counter[str] = Counter()
     slang_rule_cases: Counter[str] = Counter()
     per_rule_disagree: Counter[str] = Counter()
+    mutant_rule_fires: Counter[str] = Counter()
+    mutant_rule_cases: Counter[str] = Counter()
     case_count = 0
     failed_cases: list[str] = []
     slang_skip_count = 0
+    mutant_total = 0
+    mutant_skip_count = 0
 
-    for case in collect_cases():
+    # ``canonical`` here mirrors tests/fuzz/test_mutants.py's
+    # canonical-parent strategy: one parent per template family,
+    # so the mutants column doesn't get dominated by sweep-induced
+    # redundancy.
+    canonical: dict[str, object] = {}
+    cases = collect_cases()
+
+    for case in cases:
         case_count += 1
+        canonical.setdefault(case.template_name, case)
         yosys_result = run_case(case)
         if yosys_result.failures:
             failed_cases.append(case.case_id)
@@ -64,30 +90,41 @@ def main() -> int:
             yosys_rule_fires[rule_id] += count
             yosys_rule_cases[rule_id] += 1
 
-        if not run_slang:
-            continue
+        if run_slang:
+            try:
+                slang_result = run_case_slang(case)
+            except Exception:
+                slang_skip_count += 1
+            else:
+                for rule_id, count in slang_result.fired.items():
+                    slang_rule_fires[rule_id] += count
+                    slang_rule_cases[rule_id] += 1
+                # Per-rule disagreement count: any rule whose fired
+                # count differs between the frontends contributes
+                # one to the disagreement column. Per-rule view of
+                # the corpus-level agreement rate from
+                # rtl-buddy-cdc#221 done-when criterion 3.
+                all_rules = set(yosys_result.fired) | set(slang_result.fired)
+                for rule_id in all_rules:
+                    if yosys_result.fired.get(rule_id, 0) != slang_result.fired.get(
+                        rule_id, 0
+                    ):
+                        per_rule_disagree[rule_id] += 1
 
-        try:
-            slang_result = run_case_slang(case)
-        except Exception:
-            # Slang refuses illegal SV; the case still counts as a
-            # Yosys datapoint but skips the slang side.
-            slang_skip_count += 1
-            continue
-
-        for rule_id, count in slang_result.fired.items():
-            slang_rule_fires[rule_id] += count
-            slang_rule_cases[rule_id] += 1
-
-        # Per-rule disagreement count: any rule whose fired count
-        # differs between the frontends contributes one to the
-        # disagreement column. This is the per-rule view of the
-        # corpus-level agreement rate that rtl-buddy-cdc#221 done-when
-        # tracks.
-        all_rules = set(yosys_result.fired) | set(slang_result.fired)
-        for rule_id in all_rules:
-            if yosys_result.fired.get(rule_id, 0) != slang_result.fired.get(rule_id, 0):
-                per_rule_disagree[rule_id] += 1
+    if run_mutants:
+        for parent in canonical.values():
+            for mc in iter_mutants(parent, count=64, seed=0):  # type: ignore[arg-type]
+                mutant_total += 1
+                try:
+                    mutant_result = run_case(mc.case)
+                except Exception:
+                    # Mutant produced invalid SV (xeno v0.0.1 bug; see
+                    # tests/fuzz/test_mutants.py docstring).
+                    mutant_skip_count += 1
+                    continue
+                for rule_id, count in mutant_result.fired.items():
+                    mutant_rule_fires[rule_id] += count
+                    mutant_rule_cases[rule_id] += 1
 
     print(f"Corpus: {case_count} cases (yosys)")
     if run_slang:
@@ -97,30 +134,39 @@ def main() -> int:
         )
     else:
         print("        slang frontend disabled (pyslang not importable)")
+    if run_mutants:
+        print(
+            f"        {mutant_total - mutant_skip_count} cases (mutants); "
+            f"{mutant_skip_count} skipped, "
+            f"{len(canonical)} canonical parents"
+        )
+    else:
+        print("        mutants disabled (rtl-buddy-xeno not importable)")
     if failed_cases:
         print(f"FAILED: {len(failed_cases)} case(s)")
         for cid in failed_cases:
             print(f"  - {cid}")
 
     print()
-    if run_slang:
-        header = (
-            f"{'rule':<10} "
-            f"{'yosys_fires':>11} {'yosys_cases':>11}  "
-            f"{'slang_fires':>11} {'slang_cases':>11}  "
-            f"{'disagree':>8}"
-        )
-        sep = f"{'-' * 10} {'-' * 11} {'-' * 11}  {'-' * 11} {'-' * 11}  {'-' * 8}"
-    else:
-        header = (
-            f"{'rule':<10} {'yosys_fires':>11} {'yosys_cases':>11}  "
-            f"{'slang_fires':>11} {'slang_cases':>11}  {'disagree':>8}"
-        )
-        sep = f"{'-' * 10} {'-' * 11} {'-' * 11}  {'-' * 11} {'-' * 11}  {'-' * 8}"
-
+    header = (
+        f"{'rule':<10} "
+        f"{'yosys_fires':>11} {'yosys_cases':>11}  "
+        f"{'slang_fires':>11} {'slang_cases':>11}  "
+        f"{'mut_fires':>10} {'mut_cases':>10}  "
+        f"{'disagree':>8}"
+    )
+    sep = (
+        f"{'-' * 10} "
+        f"{'-' * 11} {'-' * 11}  "
+        f"{'-' * 11} {'-' * 11}  "
+        f"{'-' * 10} {'-' * 10}  "
+        f"{'-' * 8}"
+    )
     print(header)
     print(sep)
-    seen_rules = sorted(set(yosys_rule_fires) | set(slang_rule_fires))
+    seen_rules = sorted(
+        set(yosys_rule_fires) | set(slang_rule_fires) | set(mutant_rule_fires)
+    )
     for rule_id in seen_rules:
         yf = yosys_rule_fires[rule_id]
         yc = yosys_rule_cases[rule_id]
@@ -130,10 +176,16 @@ def main() -> int:
             disagree_disp: str = str(per_rule_disagree[rule_id])
         else:
             sf_disp = sc_disp = disagree_disp = "—"
+        if run_mutants:
+            mf_disp: str = str(mutant_rule_fires[rule_id])
+            mc_disp: str = str(mutant_rule_cases[rule_id])
+        else:
+            mf_disp = mc_disp = "—"
         print(
             f"{rule_id:<10} "
             f"{yf:>11} {yc:>11}  "
             f"{sf_disp:>11} {sc_disp:>11}  "
+            f"{mf_disp:>10} {mc_disp:>10}  "
             f"{disagree_disp:>8}"
         )
 


### PR DESCRIPTION
## Summary

Closes done-when criterion **6** of rtl-buddy-cdc#221: *"Coverage report's 3-column extension is the canonical surface; the existing single-column output is removed."*

Layer C (#225, merged) shipped the **yosys + slang + disagree** shape; this PR adds the third **mutants** column on top, completing the per-surface layout the issue asks for.

## Output (post-rebase, current main)

```
Corpus: 330 cases (yosys)
        330 cases (slang); 0 skipped
        202 cases (mutants); 2 skipped, 35 canonical parents

rule       yosys_fires yosys_cases  slang_fires slang_cases   mut_fires  mut_cases  disagree
---------- ----------- -----------  ----------- -----------  ---------- ----------  --------
CDC-001             28          28           28          28          43         42         0
CDC-002             12          12           12          12           4          4         0
CDC-003             12          12           12          12           6          6         0
CDC-004             12          12           12          12           7          7         0
CDC-005             12          12           12          12           6          6         0
CDC-006             12          12           12          12           4          4         0
CDC-008             12          12           12          12           7          5         0
CDC-009             12          12           12          12           2          2         0
CDC-010             13          13           13          13           7          7         0
CDC-011             11          11           11          11          14         14         0
CDC-012             13          13           13          13          24         24         0
CDC-013             12          12           12          12           4          4         0
CDC-014             12          12           12          12           3          3         0
CDC-015             12          12           12          12           6          6         0
CDC-016             12          12           12          12          18         18         0
CDC-017             13          13           13          13           4          4         0
CDC-018             12          12           12          12           2          2         0
CDC-019             12          12           12          12           8          8         0
CDC-020             12          12           12          12           8          8         0
CDC-021             10          10           10          10           1          1         0
RDC-001             24          24           24          24          13         13         0
RDC-002             10          10           10          10           6          6         0
RDC-003             12          12           12          12           3          3         0
RDC-004             10          10           10          10           5          5         0
RDC-005             10          10           10          10           3          3         0
RDC-006             10          10           10          10           3          3         0
RDC-007             10          10           10          10          12         12         0
RDC-008             12          12           12          12          10         10         0
```

All ``disagree`` entries are **0**: the six slang-parity rows that originally surfaced in PR #225's first run (cdc006, cdc014, cdc016, gap_g4, rdc004, rdc005 — 57 disagreeing cases) all closed via PRs #227 / #228 / #229's slang-frontend lowering fixes. rtl-buddy-cdc#224 closed alongside them.

Each surface is an independent ratchet:

| Surface low | Interpretation |
|---|---|
| ``yosys`` | Corpus gap (Layer A's job — already met in #223) |
| ``slang`` low while ``yosys`` is high | Slang-frontend parity gap (none today; rtl-buddy-cdc#224 closed) |
| ``mut_fires`` low while ``yosys`` is high | Mutator coverage gap → rtl-buddy-xeno#2 |
| ``disagree`` high | Per-rule frontend-mismatch detail (all zero today) |

Mutants are generated from one canonical parent per template family (35 parents → 202 mutants), bounding the column's cost at ~200 extra Yosys elaborations per coverage run.

## Graceful degradation

Surfaces show ``—`` when their backing dependency is missing:

- ``pyslang`` missing → slang columns + disagree are ``—``
- ``rtl-buddy-xeno`` missing → mutant columns are ``—``

## Rebase notes

Rebased onto current main after #225 and #226 merged. Two ancestor commits (Layer C's diff-oracle commit + Layer B's mutator-wiring commit) dropped via ``git rebase --skip`` since they're now in the base. Only the mutants-column commit remains on this branch.

## Test plan

- [x] ``uv run python -m tests.fuzz.coverage`` — full 3-surface table emits as above
- [x] ``uv run pytest -q`` — 1386 passed, 24 skipped, 26 xfailed (test_mutants xfails)
- [x] ``uv run pytest -m fuzz_diff -q`` — 330 passed, 0 xfailed
- [x] ``uv run ruff check`` / ``ruff format --check`` — clean
- [x] ``uv run mypy`` — clean

## Refs

- Issue: rtl-buddy-cdc#221 (done-when criterion 6)
- Predecessor: PR #225 (Layer C diff oracle, merged)
- Slang-parity umbrella: rtl-buddy-cdc#224 (closed by #227/#228/#229)

🤖 Generated with [Claude Code](https://claude.com/claude-code)