### PR TITLE
chore: empirical xref probe (will close)

### DIFF
--- a/XREF_PROBE.md
+++ b/XREF_PROBE.md
@@ -1,0 +1,1 @@
+throwaway file for empirical cross-reference probe; this branch will be deleted


### PR DESCRIPTION
Empirical probe (will be closed without merging).

Question: does a markdown link whose **destination** points to an issue create a
GitHub cross-reference event in that target, when the body contains no other
reference forms?

[click here](https://github.com/rtl-buddy/rtl_buddy/issues/134)

Body contains only a destination URL — no `owner/repo#N`, no bare prose URL,
no bare `#N`.
