### PR TITLE
chore: empirical xref probe 2 (will close)

### DIFF
--- a/XREF_PROBE.md
+++ b/XREF_PROBE.md
@@ -1,0 +1,1 @@
+throwaway file for empirical cross-reference probe 2; branch will be deleted


### PR DESCRIPTION
Empirical probe 2 (will be closed without merging).

Question: do backticked references — both `owner/repo#N` and URL forms —
get scanned by GitHub for cross-references?

Inline backticked ref: `rtl-buddy/rtl_buddy#134`

Backticked URL: `https://github.com/rtl-buddy/rtl_buddy/issues/134`

Body intentionally contains NO unprotected reference forms (no markdown link,
no bare URL outside backticks, no bare `#N`).
