### PR TITLE
chore: empirical xref probe 3 (will close)

### DIFF
--- a/XREF_PROBE.md
+++ b/XREF_PROBE.md
@@ -1,0 +1,1 @@
+throwaway file for empirical cross-reference probe 3; branch will be deleted


### PR DESCRIPTION
Empirical probe 3 (will be closed without merging).

Question: does the new plain-text neutering style — `owner/repo N (issue)`
or `owner/repo N (pull request)`, no `#`, no URL — produce a cross-reference
event on the named target?

Plain-text reference: rtl-buddy/rtl_buddy 134 (issue)

Also testing prose forms that the updated transform will produce in the wild:
- "pre-rtl-buddy/rtl_buddy 134 (issue)" style
- "Track rtl-buddy/rtl_buddy 134 (issue)" style

Body intentionally contains NO `#N`, NO URL, NO `owner/repo#N` patterns.
