### PR TITLE
Stage-4 grammar foundation: core + 5 productions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Run fuzz_diff suite (cross-frontend oracle)
         run: uv run pytest -m fuzz_diff -q
 
+      - name: Run fuzz_grammar suite (Stage-4 grammar topologies)
+        run: uv run pytest -m fuzz_grammar -q
+
       - name: Run sim suite
         run: uv run pytest -m sim -q
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,5 +15,10 @@ def pytest_configure(config) -> None:
     )
     config.addinivalue_line(
         "markers",
+        "fuzz_grammar: Stage-4 grammar-generated topologies "
+        "(gated; run via `pytest -m fuzz_grammar`; needs yosys on PATH)",
+    )
+    config.addinivalue_line(
+        "markers",
         "sim: behavioural simulation oracle (opt-in; needs iverilog)",
     )

--- a/tests/fuzz/grammar/__init__.py
+++ b/tests/fuzz/grammar/__init__.py
@@ -1,0 +1,59 @@
+"""Stage-4 grammar fuzzer (rtl-buddy-cdc#222).
+
+A grammar that emits topologies the hand-authored corpus hasn't seen
+— multi-source aggregators, partial-handshake protocols, deep
+multi-rate pipelines, gray-coded buses paired with control flags,
+reset-sync chains alongside data crossings. Each generated
+:class:`tests.fuzz.templates.base.RenderedCase` flows through the
+same Yosys / slang / analyzer pipeline the Stage-3 corpus uses,
+so a grammar-derived ``.sv`` is just another input to the existing
+runner.
+
+Stage-4 foundation surface
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This first cut lands the surface (core types + ≥3 productions +
+seeded generation), without yet wiring grammar cases into the
+3-column coverage report or the cross-frontend differential oracle
+— those come in the integration PR.
+
+Public entry points:
+
+- :func:`generate` — render a single :class:`RenderedCase` for a seed.
+- :data:`PRODUCTIONS` — the registry of available non-terminals.
+- :class:`Production`, :class:`Prediction`, :class:`Fragment`,
+  :class:`GenContext`, :class:`ClockDomain`, :class:`Port` — the
+  composable grammar surface a future engineer can extend (issue
+  #222 done-when criterion 4).
+
+The grammar is *seeded*, mirroring xeno's mutator contract: a fixed
+seed always produces the same SV bytes. The test surface in
+:mod:`tests.fuzz.test_grammar` pins that reproducibility, so any
+nondeterminism creeping into the productions surfaces immediately.
+"""
+
+from __future__ import annotations
+
+from .core import (
+    ClockDomain,
+    Fragment,
+    GenContext,
+    Port,
+    Prediction,
+    Production,
+    compose,
+    generate,
+)
+from .productions import PRODUCTIONS
+
+__all__ = [
+    "PRODUCTIONS",
+    "ClockDomain",
+    "Fragment",
+    "GenContext",
+    "Port",
+    "Prediction",
+    "Production",
+    "compose",
+    "generate",
+]

--- a/tests/fuzz/grammar/core.py
+++ b/tests/fuzz/grammar/core.py
@@ -1,0 +1,316 @@
+"""Grammar core: terminals, productions, composition, top-level driver.
+
+The grammar emits :class:`tests.fuzz.templates.base.RenderedCase`
+instances built by *composing* productions: each production emits
+a :class:`Fragment` (SV snippets + ports + clocks + a verdict delta);
+the driver concatenates the fragments into a single module body,
+unions the verdicts, and renders the module + SDC.
+
+The verdict delta has the same shape as xeno's
+:class:`rtl_buddy_xeno.Prediction` (Stage-3 Layer B), so a grammar
+case's expected finding-set is composable from the productions it
+used. The grammar's runner contract is the same as xeno's mutants:
+``ExpectedFinding(rule_id, Op.GE, 1)`` for added rules,
+``ExpectedFinding(rule_id, Op.ZERO)`` for removed.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from ..templates.base import ExpectedFinding, Op, RenderedCase
+
+
+@dataclass(frozen=True)
+class Prediction:
+    """Per-production verdict delta.
+
+    The same ``added``/``removed`` shape xeno's mutator carries —
+    so a downstream consumer (the analyzer-differential runner or
+    the coverage-steering hook) can reason about grammar
+    productions and mutant operators uniformly.
+    """
+
+    cdc_rules_added: frozenset[str] = frozenset()
+    cdc_rules_removed: frozenset[str] = frozenset()
+    rationale: str = ""
+
+    def merge(self, other: "Prediction") -> "Prediction":
+        """Union the two deltas; ``removed`` wins over ``added``.
+
+        Composing productions that introduce a finding (e.g. an
+        unsynced crossing → CDC-001) and one that silences it (e.g.
+        a globally-applied attribute-mark) leaves the silenced rule
+        out of the combined ``added`` set. Today's foundation
+        productions don't yet use ``removed`` — the union math is
+        trivially additive — but the merge contract is fixed so
+        future productions (e.g. ``cdc_sync_attribute_blanket``)
+        don't have to re-design the composition rule.
+        """
+        added = (self.cdc_rules_added | other.cdc_rules_added) - (
+            self.cdc_rules_removed | other.cdc_rules_removed
+        )
+        removed = self.cdc_rules_removed | other.cdc_rules_removed
+        return Prediction(
+            cdc_rules_added=frozenset(added),
+            cdc_rules_removed=frozenset(removed),
+            rationale=(
+                f"{self.rationale}; {other.rationale}".strip("; ")
+                if self.rationale or other.rationale
+                else ""
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ClockDomain:
+    """A grammar terminal: a clock with a period (ns).
+
+    The grammar's SDC emitter declares one ``create_clock`` per
+    domain and places every pair in the same
+    ``set_clock_groups -asynchronous`` clause — Stage-4 productions
+    treat any two distinct domains as async-to-each-other, matching
+    the hand-authored corpus's SDC convention.
+    """
+
+    name: str
+    period: float
+
+
+@dataclass(frozen=True)
+class Port:
+    """A grammar terminal: a top-level module port.
+
+    ``sampling_clock`` populates the SDC's ``set_input_delay`` for
+    input ports — without it, CDC-011 (unconstrained input) fires
+    on every grammar-introduced input, which would dominate the
+    finding set with a single rule.
+    """
+
+    name: str
+    direction: str  # "input" | "output"
+    width: int = 1
+    sampling_clock: str | None = None
+
+    def declaration(self) -> str:
+        width_part = "" if self.width == 1 else f" [{self.width - 1}:0]"
+        return f"    {self.direction:<6} logic{width_part} {self.name}"
+
+
+@dataclass
+class Fragment:
+    """A production's SV emission + verdict delta.
+
+    Fragments are concatenated by :func:`compose`; ports / clocks
+    are merged into the module header and SDC respectively.
+    Production authors don't see the module-level shape — they
+    only declare what they introduce.
+    """
+
+    decls: list[str] = field(default_factory=list)
+    always_blocks: list[str] = field(default_factory=list)
+    assigns: list[str] = field(default_factory=list)
+    ports: list[Port] = field(default_factory=list)
+    clocks: list[ClockDomain] = field(default_factory=list)
+    prediction: Prediction = field(default_factory=Prediction)
+
+
+@dataclass
+class GenContext:
+    """Per-generate-call mutable state shared across productions.
+
+    The shared :class:`random.Random` is the single source of
+    nondeterminism — productions must draw from ``ctx.rng`` and
+    never from module-level state. The :meth:`uniq` counter
+    guarantees signal-name uniqueness across compositions (two
+    sync-chain productions can coexist in one module without
+    colliding on ``sync_q``).
+    """
+
+    rng: random.Random
+    counter: int = 0
+    declared_clocks: dict[str, ClockDomain] = field(default_factory=dict)
+
+    def uniq(self, base: str) -> str:
+        self.counter += 1
+        return f"{base}_{self.counter}"
+
+    def get_or_declare_clock(self, name: str, period: float) -> ClockDomain:
+        existing = self.declared_clocks.get(name)
+        if existing is not None:
+            return existing
+        clk = ClockDomain(name=name, period=period)
+        self.declared_clocks[name] = clk
+        return clk
+
+
+# A production is a callable that, given the shared context,
+# emits a :class:`Fragment`. The pure-function shape lets productions
+# stay stateless — the only mutation flows through ``ctx``.
+EmitFn = Callable[[GenContext], Fragment]
+
+
+@dataclass(frozen=True)
+class Production:
+    """A grammar non-terminal.
+
+    ``declared`` is the *static* verdict the production carries —
+    used by the coverage-steering hook (issue #222 Sketch point 5)
+    to pick productions that lift under-covered rules. The
+    :class:`Fragment` returned by ``emit`` carries the actual
+    prediction for the emitted instance, which may differ from
+    ``declared`` if the production has parameters that change the
+    verdict (e.g. a sync-chain production with a randomly-chosen
+    depth).
+    """
+
+    name: str
+    emit: EmitFn
+    declared: Prediction
+
+
+def compose(productions: list[Production], ctx: GenContext) -> Fragment:
+    """Chain productions into a single module-body fragment.
+
+    Each production is emitted independently — there is no
+    signal-threading between productions, so a sync-chain followed
+    by a comb-source produces two parallel crossing sites in the
+    same module, not one chained crossing. This keeps each
+    production's verdict locally interpretable.
+    """
+    out = Fragment()
+    for prod in productions:
+        frag = prod.emit(ctx)
+        out.decls.extend(frag.decls)
+        out.always_blocks.extend(frag.always_blocks)
+        out.assigns.extend(frag.assigns)
+        out.ports.extend(frag.ports)
+        out.clocks.extend(frag.clocks)
+        out.prediction = out.prediction.merge(frag.prediction)
+    return out
+
+
+def _render_sdc(clocks: list[ClockDomain], ports: list[Port]) -> str:
+    """Emit the SDC. One ``create_clock`` per declared clock; a single
+    ``set_clock_groups -asynchronous`` listing every clock as its own
+    group (the grammar treats all clocks as mutually async, matching
+    the hand-authored corpus's SDC convention); ``set_input_delay``
+    per input port that declared a ``sampling_clock``.
+    """
+    seen: dict[str, ClockDomain] = {}
+    for c in clocks:
+        seen.setdefault(c.name, c)
+    sorted_clocks = sorted(seen.values(), key=lambda c: c.name)
+
+    lines = [
+        f"create_clock -name {c.name} -period {c.period} [get_ports {c.name}]"
+        for c in sorted_clocks
+    ]
+    if len(sorted_clocks) >= 2:
+        groups = " ".join(f"-group {{{c.name}}}" for c in sorted_clocks)
+        lines.append(f"set_clock_groups -asynchronous {groups}")
+
+    for p in ports:
+        if p.direction == "input" and p.sampling_clock is not None:
+            lines.append(
+                f"set_input_delay -clock {p.sampling_clock} 1.0 [get_ports {p.name}]"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _render_module(top: str, body: Fragment) -> str:
+    """Render the module header (ports) + body (decls + always +
+    assigns). Clocks are rendered as ``input logic`` ports — the
+    grammar uses ``create_clock [get_ports ...]`` in the SDC, so the
+    clock identifiers must be top-level inputs.
+    """
+    clock_ports = [
+        Port(name=c.name, direction="input")
+        for c in sorted({c.name: c for c in body.clocks}.values(), key=lambda c: c.name)
+    ]
+    # Preserve insertion order for non-clock ports — production
+    # authors can rely on the rendered module's port order matching
+    # the order their fragments were composed.
+    all_ports = clock_ports + body.ports
+    header_lines = [p.declaration() + "," for p in all_ports[:-1]]
+    if all_ports:
+        header_lines.append(all_ports[-1].declaration())
+    header = "\n".join(header_lines)
+
+    body_chunks: list[str] = []
+    if body.decls:
+        body_chunks.append("\n".join(body.decls))
+    if body.always_blocks:
+        body_chunks.append("\n\n".join(body.always_blocks))
+    if body.assigns:
+        body_chunks.append("\n".join(body.assigns))
+    body_text = "\n\n".join(body_chunks)
+
+    return f"module {top} (\n{header}\n);\n{body_text}\nendmodule\n"
+
+
+def generate(
+    seed: int,
+    *,
+    productions: list[Production] | None = None,
+    n_productions: int | None = None,
+    top: str | None = None,
+) -> RenderedCase:
+    """Render one grammar-generated :class:`RenderedCase`.
+
+    Deterministic given ``seed`` and ``productions`` — the same
+    inputs always yield byte-identical SV / SDC. This is the
+    reproducibility property issue #222's Sketch point 4 calls out
+    and :mod:`tests.fuzz.test_grammar` pins.
+
+    ``productions`` defaults to the full :data:`PRODUCTIONS`
+    registry; the coverage-steering hook (integration PR) passes a
+    filtered subset to bias generation toward under-covered rules.
+    ``n_productions`` defaults to a random pick from [2, 4] —
+    enough composition to exercise non-trivial topologies, bounded
+    so a single case stays Yosys-elaboratable in <1 s.
+    """
+    if productions is None:
+        from .productions import PRODUCTIONS as _DEFAULT
+
+        productions = list(_DEFAULT)
+    if not productions:
+        raise ValueError("generate() needs at least one production")
+
+    rng = random.Random(seed)
+    ctx = GenContext(rng=rng)
+
+    n = n_productions if n_productions is not None else rng.randint(2, 4)
+    chosen = [rng.choice(productions) for _ in range(n)]
+
+    body = compose(chosen, ctx)
+
+    case_top = top if top is not None else f"fuzz_grammar_seed{seed}"
+    sv = _render_module(case_top, body)
+    sdc = _render_sdc(body.clocks, body.ports)
+
+    expected = tuple(
+        ExpectedFinding(rule_id, Op.GE, 1)
+        for rule_id in sorted(body.prediction.cdc_rules_added)
+    )
+    forbidden = tuple(
+        ExpectedFinding(rule_id, Op.ZERO)
+        for rule_id in sorted(body.prediction.cdc_rules_removed)
+    )
+
+    return RenderedCase(
+        template_name="grammar",
+        case_id=case_top,
+        sv=sv,
+        sdc=sdc,
+        top=case_top,
+        params={
+            "seed": seed,
+            "productions": [p.name for p in chosen],
+            "n_productions": n,
+        },
+        expected=expected,
+        forbidden=forbidden,
+    )

--- a/tests/fuzz/grammar/productions.py
+++ b/tests/fuzz/grammar/productions.py
@@ -1,0 +1,342 @@
+"""Foundation production set for the Stage-4 grammar fuzzer.
+
+Each production emits an *independent* crossing site within the
+module — productions don't thread signals between each other, so a
+case with two productions becomes a module with two parallel
+crossings, each independently exercising its declared rules.
+
+Foundation set covers four of the six non-terminals issue #222
+calls out:
+
+- **sync chain** — :func:`_emit_clean_sync_chain` (depth=2 reference)
+  and :func:`_emit_unsynced_single_bit` (depth=0 negative).
+- **comb source** — :func:`_emit_comb_source` (CDC-006 site).
+- **gray counter** — :func:`_emit_gray_counter_crossing`
+  (CDC-004-clean wide crossing via ``(* cdc_gray *)``).
+- **reset-sync chain** — :func:`_emit_missing_reset_sync` (RDC-001
+  site: foreign-domain async reset on a dst-domain flop's ARST pin).
+
+The two remaining non-terminals (``handshake req/ack pair``,
+``FIFO read/write skeleton``) land in the integration PR alongside
+the coverage-steering hook — they need the steering loop to argue
+their additional Yosys / slang elaboration cost is paying for new
+coverage rather than redundancy with the hand-authored templates.
+
+Two reference clock domains
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The foundation productions share a two-domain reference
+(``src_clk`` + ``dst_clk``) for simplicity. The :class:`GenContext`
+already supports declaring additional domains, so future
+multi-rate-pipeline / multi-source-aggregator productions can
+introduce a third or fourth clock without changing the core.
+"""
+
+from __future__ import annotations
+
+from .core import (
+    ClockDomain,
+    Fragment,
+    GenContext,
+    Port,
+    Prediction,
+    Production,
+)
+
+# Reference clock periods. The grammar picks one of these pairs per
+# generated case so the SDC introduces variety analogous to the
+# Stage-3 Layer A sweep — same SV elaboration cost, distinct Yosys
+# cache buckets per (sv, sdc) digest.
+_PERIOD_PAIRS: tuple[tuple[float, float], ...] = (
+    (10.0, 7.5),
+    (5.0, 13.0),
+    (12.0, 18.5),
+    (8.0, 11.0),
+    (15.5, 6.0),
+    (9.5, 22.0),
+)
+
+
+def _pick_clocks(ctx: GenContext) -> tuple[ClockDomain, ClockDomain]:
+    """Pick (src, dst) clocks for a production, declaring them in
+    ``ctx`` if first seen so multiple productions share the same
+    period choices across a single case.
+    """
+    if "src_clk" in ctx.declared_clocks and "dst_clk" in ctx.declared_clocks:
+        return ctx.declared_clocks["src_clk"], ctx.declared_clocks["dst_clk"]
+    src_period, dst_period = ctx.rng.choice(_PERIOD_PAIRS)
+    src = ctx.get_or_declare_clock("src_clk", src_period)
+    dst = ctx.get_or_declare_clock("dst_clk", dst_period)
+    return src, dst
+
+
+def _emit_clean_sync_chain(ctx: GenContext) -> Fragment:
+    """Textbook 2FF synchroniser on a single bit.
+
+    Same shape as ``GoodTwoFF`` in the hand-authored corpus — the
+    grammar's "no false positives" sentinel. Verdict carries no
+    added rules: a clean chain shouldn't fire anything.
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("clean")
+    d_in = f"d_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    src_q = f"src_q_{suffix}"
+    sync_m = f"sync_m_{suffix}"
+    sync_q = f"sync_q_{suffix}"
+
+    decls = [
+        f"    logic {src_q};",
+        f"    logic {sync_m}, {sync_q};",
+    ]
+    always = [
+        f"    always_ff @(posedge {src.name}) {src_q} <= {d_in};",
+        (
+            f"    always_ff @(posedge {dst.name}) begin\n"
+            f"        {sync_m} <= {src_q};\n"
+            f"        {sync_q} <= {sync_m};\n"
+            f"    end"
+        ),
+    ]
+    assigns = [f"    assign {q_out} = {sync_q};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=d_in, direction="input", sampling_clock=src.name),
+            Port(name=q_out, direction="output"),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(rationale="clean 2FF synchroniser; no added findings"),
+    )
+
+
+def _emit_unsynced_single_bit(ctx: GenContext) -> Fragment:
+    """Direct src→dst flop with no sync chain. CDC-001 fires.
+
+    Depth=0 means CDC-002 stays silent (CDC-001 owns the finding
+    when no chain exists at all — see :mod:`tests.fuzz.templates.cdc001`
+    for the same partition).
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("unsync")
+    d_in = f"d_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    src_q = f"src_q_{suffix}"
+    dst_q = f"dst_q_{suffix}"
+
+    decls = [
+        f"    logic {src_q};",
+        f"    logic {dst_q};",
+    ]
+    always = [
+        f"    always_ff @(posedge {src.name}) {src_q} <= {d_in};",
+        f"    always_ff @(posedge {dst.name}) {dst_q} <= {src_q};",
+    ]
+    assigns = [f"    assign {q_out} = {dst_q};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=d_in, direction="input", sampling_clock=src.name),
+            Port(name=q_out, direction="output"),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(
+            cdc_rules_added=frozenset({"CDC-001"}),
+            rationale="single-bit src→dst with no sync chain",
+        ),
+    )
+
+
+def _emit_comb_source(ctx: GenContext) -> Fragment:
+    """Top-level input feeds the sync chain without a registering
+    flop in the source domain. CDC-006 fires on the unregistered
+    combinational source.
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("comb")
+    a_in = f"a_in_{suffix}"
+    b_in = f"b_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    comb_w = f"comb_w_{suffix}"
+    sync_m = f"sync_m_{suffix}"
+    sync_q = f"sync_q_{suffix}"
+    src_dummy = f"src_dummy_{suffix}"
+
+    decls = [
+        f"    wire {comb_w} = {a_in} & {b_in};",
+        f"    logic {sync_m}, {sync_q};",
+        f"    logic {src_dummy};",
+    ]
+    always = [
+        (
+            f"    always_ff @(posedge {dst.name}) begin\n"
+            f"        {sync_m} <= {comb_w};\n"
+            f"        {sync_q} <= {sync_m};\n"
+            f"    end"
+        ),
+        # Give src_clk at least one consumer so the analyzer treats
+        # it as a real clock domain — same trick CombSource uses.
+        f"    always_ff @(posedge {src.name}) {src_dummy} <= 1'b0;",
+    ]
+    assigns = [f"    assign {q_out} = {sync_q} | {src_dummy};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=a_in, direction="input", sampling_clock=src.name),
+            Port(name=b_in, direction="input", sampling_clock=src.name),
+            Port(name=q_out, direction="output"),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(
+            cdc_rules_added=frozenset({"CDC-006"}),
+            rationale="comb source feeds sync chain without source-side flop",
+        ),
+    )
+
+
+def _emit_gray_counter_crossing(ctx: GenContext) -> Fragment:
+    """Wide bus crossing with ``(* cdc_gray *)`` on both endpoints.
+
+    CDC-004 (multi-bit unrelated-flops crossing) stays silent
+    because the attribute promises gray encoding — every transition
+    flips exactly one bit, so a metastable sample is one of the two
+    legal adjacent codes, not a transient illegal mix.
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("gray")
+    en_in = f"en_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    bin_q = f"bin_q_{suffix}"
+    gray_q = f"gray_q_{suffix}"
+    sync_m = f"sync_m_{suffix}"
+    sync_q = f"sync_q_{suffix}"
+
+    decls = [
+        f"    logic [3:0] {bin_q};",
+        f"    (* cdc_gray *) logic [3:0] {gray_q};",
+        f"    (* cdc_gray *) logic [3:0] {sync_m}, {sync_q};",
+    ]
+    always = [
+        (
+            f"    always_ff @(posedge {src.name}) begin\n"
+            f"        if ({en_in}) {bin_q} <= {bin_q} + 4'd1;\n"
+            f"        {gray_q} <= {bin_q} ^ ({bin_q} >> 1);\n"
+            f"    end"
+        ),
+        (
+            f"    always_ff @(posedge {dst.name}) begin\n"
+            f"        {sync_m} <= {gray_q};\n"
+            f"        {sync_q} <= {sync_m};\n"
+            f"    end"
+        ),
+    ]
+    assigns = [f"    assign {q_out} = {sync_q};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=en_in, direction="input", sampling_clock=src.name),
+            Port(name=q_out, direction="output", width=4),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(
+            rationale="(* cdc_gray *)-marked wide crossing; CDC-004 silenced",
+        ),
+    )
+
+
+def _emit_missing_reset_sync(ctx: GenContext) -> Fragment:
+    """Foreign-domain async reset on a dst-domain flop's ARST pin.
+
+    Same failure mode as ``rdc001_async_reset_crossing`` in the
+    hand-authored corpus: assertion is fine, but recovery/removal
+    timing on deassertion is asynchronous to ``dst_clk``. RDC-001
+    fires.
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("rdc")
+    global_rst_n = f"global_rst_n_{suffix}"
+    rst_req = f"rst_req_{suffix}"
+    d_in = f"d_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    local_rst_n = f"local_rst_n_{suffix}"
+    dst_q = f"dst_q_{suffix}"
+
+    decls = [
+        f"    logic {local_rst_n};",
+        f"    logic {dst_q};",
+    ]
+    always = [
+        (
+            f"    always_ff @(posedge {src.name} or negedge {global_rst_n})\n"
+            f"        if (!{global_rst_n}) {local_rst_n} <= 1'b0;\n"
+            f"        else                  {local_rst_n} <= ~{rst_req};"
+        ),
+        (
+            f"    always_ff @(posedge {dst.name} or negedge {local_rst_n})\n"
+            f"        if (!{local_rst_n}) {dst_q} <= 1'b0;\n"
+            f"        else                {dst_q} <= {d_in};"
+        ),
+    ]
+    assigns = [f"    assign {q_out} = {dst_q};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=global_rst_n, direction="input"),
+            Port(name=rst_req, direction="input", sampling_clock=src.name),
+            Port(name=d_in, direction="input", sampling_clock=dst.name),
+            Port(name=q_out, direction="output"),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(
+            cdc_rules_added=frozenset({"RDC-001"}),
+            rationale="foreign-domain async reset directly on dst-domain ARST",
+        ),
+    )
+
+
+PRODUCTIONS: tuple[Production, ...] = (
+    Production(
+        name="clean_sync_chain",
+        emit=_emit_clean_sync_chain,
+        declared=Prediction(rationale="clean 2FF synchroniser"),
+    ),
+    Production(
+        name="unsynced_single_bit",
+        emit=_emit_unsynced_single_bit,
+        declared=Prediction(
+            cdc_rules_added=frozenset({"CDC-001"}),
+            rationale="unsynced single-bit crossing",
+        ),
+    ),
+    Production(
+        name="comb_source",
+        emit=_emit_comb_source,
+        declared=Prediction(
+            cdc_rules_added=frozenset({"CDC-006"}),
+            rationale="comb source feeds sync chain",
+        ),
+    ),
+    Production(
+        name="gray_counter_crossing",
+        emit=_emit_gray_counter_crossing,
+        declared=Prediction(rationale="(* cdc_gray *)-marked wide crossing"),
+    ),
+    Production(
+        name="missing_reset_sync",
+        emit=_emit_missing_reset_sync,
+        declared=Prediction(
+            cdc_rules_added=frozenset({"RDC-001"}),
+            rationale="async reset crossing on dst-domain ARST",
+        ),
+    ),
+)

--- a/tests/fuzz/test_grammar.py
+++ b/tests/fuzz/test_grammar.py
@@ -1,0 +1,137 @@
+"""Stage-4 grammar fuzzer smoke tests (rtl-buddy-cdc#222).
+
+Foundation surface pin: a fixed seed renders byte-identical SV /
+SDC, and the rendered case can be elaborated by Yosys without
+error. The full per-rule directional check (the grammar's analog
+of :mod:`tests.fuzz.test_mutants`) plus the cross-frontend
+differential oracle (Layer C of Stage 3) come in the integration
+PR — this file only pins the *surface* that PR builds on.
+
+Tests
+~~~~~
+
+- :func:`test_generate_is_deterministic_for_seed` — issue #222
+  Sketch point 4 (seeded reproducibility). Two calls with the
+  same seed produce byte-identical :class:`RenderedCase` SV / SDC
+  / top / params.
+- :func:`test_different_seeds_diverge` — distinct seeds produce
+  distinct SV bytes; the grammar isn't accidentally seed-
+  independent.
+- :func:`test_grammar_case_elaborates_and_runs` — the rendered case
+  flows through Yosys + the analyzer. Gated on
+  :func:`yosys_available` (skip if Yosys isn't on PATH) and the
+  ``fuzz_grammar`` marker (default ``pytest -q`` doesn't run it).
+- :func:`test_predictions_directional` — for each production
+  alone, the analyzer's actual finding set covers every rule in
+  ``Prediction.cdc_rules_added``. The xeno mutant test
+  (:mod:`tests.fuzz.test_mutants`) uses the same lax directional
+  contract — strict equality is the wrong oracle for a verdict
+  that's a delta, not a finding-set claim.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .grammar import PRODUCTIONS, generate
+from .runner import run_case
+from .yosys_cache import yosys_available
+
+pytestmark = pytest.mark.fuzz_grammar
+
+
+def test_generate_is_deterministic_for_seed() -> None:
+    """Same seed → byte-identical SV + SDC + params."""
+    case_a = generate(seed=42)
+    case_b = generate(seed=42)
+    assert case_a.sv == case_b.sv
+    assert case_a.sdc == case_b.sdc
+    assert case_a.top == case_b.top
+    assert case_a.params == case_b.params
+    assert case_a.expected == case_b.expected
+    assert case_a.forbidden == case_b.forbidden
+
+
+def test_different_seeds_diverge() -> None:
+    """Distinct seeds produce distinct SV — the grammar isn't
+    accidentally seed-independent (would silently happen if a
+    production used ``random.choice`` against module-level state
+    instead of ``ctx.rng``)."""
+    sv_bytes = {generate(seed=s).sv for s in range(8)}
+    assert len(sv_bytes) > 1, (
+        "8 distinct seeds collapsed to one SV — the grammar is "
+        "drawing from module-level random instead of ctx.rng"
+    )
+
+
+def test_n_productions_bounds() -> None:
+    """``n_productions`` argument bounds composition length —
+    coverage-steering hook (integration PR) calls this with
+    ``n_productions=1`` to isolate a single production's verdict.
+    """
+    case = generate(seed=0, n_productions=1)
+    assert len(case.params["productions"]) == 1
+
+    case = generate(seed=0, n_productions=3)
+    assert len(case.params["productions"]) == 3
+
+
+@pytest.mark.skipif(not yosys_available(), reason="yosys not on PATH")
+def test_grammar_case_elaborates_and_runs() -> None:
+    """End-to-end smoke: Yosys parses the rendered SV, the
+    analyzer runs without crashing, the expected / forbidden
+    findings hold. Tests several seeds so a single unlucky seed
+    can't false-pass via empty composition.
+    """
+    failures: list[str] = []
+    for seed in range(8):
+        case = generate(seed=seed)
+        result = run_case(case)
+        if result.failures:
+            failures.extend(
+                f"seed={seed} ({case.case_id}): {f}" for f in result.failures
+            )
+    if failures:
+        pytest.fail(
+            "grammar-rendered cases produced unexpected findings:\n  "
+            + "\n  ".join(failures)
+        )
+
+
+@pytest.mark.skipif(not yosys_available(), reason="yosys not on PATH")
+def test_predictions_directional() -> None:
+    """For each non-trivial production, generate a single-production
+    case and verify every rule in ``Prediction.cdc_rules_added``
+    actually fires.
+
+    This is the grammar's analog of :mod:`tests.fuzz.test_mutants`'
+    prediction-directional check — same lax contract (the rule
+    must fire ≥1 time) for the same reason: a verdict is a
+    direction-of-change claim, not a finding-set claim.
+    """
+    failures: list[str] = []
+    for idx, prod in enumerate(PRODUCTIONS):
+        if not prod.declared.cdc_rules_added:
+            continue
+        # Pin a per-production seed so a single failure is locally
+        # reproducible without depending on the full PRODUCTIONS
+        # ordering.
+        case = generate(
+            seed=1000 + idx,
+            productions=[prod],
+            n_productions=1,
+            top=f"fuzz_grammar_solo_{prod.name}",
+        )
+        result = run_case(case)
+        fired = {r for r, n in result.fired.items() if n > 0}
+        missing = set(prod.declared.cdc_rules_added) - fired
+        if missing:
+            failures.append(
+                f"production={prod.name}: predicted {sorted(prod.declared.cdc_rules_added)}, "
+                f"missing {sorted(missing)}, fired {sorted(fired)}"
+            )
+    if failures:
+        pytest.fail(
+            "grammar productions failed their directional prediction:\n  "
+            + "\n  ".join(failures)
+        )


### PR DESCRIPTION
## Summary

- Lands the Stage-4 grammar fuzzer surface (rtl-buddy-cdc#222): terminals, productions, composition, seeded `generate()`.
- Five foundation productions covering four of the six non-terminals the issue lists (sync chain, comb source, gray counter, reset-sync chain). Handshake req/ack + FIFO skeleton ship with the integration PR.
- New `fuzz_grammar` pytest marker + matching CI step in the existing fuzz-and-sim job.

## Scope kept tight

- No edits to `coverage.py`, `runner.py`, `ALL_TEMPLATES`, or the `fuzz` / `fuzz_diff` test surfaces. A grammar-derived `.sv` is just another input to `run_case()`; the integration PR is what wires it into the 3-column coverage report, the cross-frontend diff oracle, and the coverage-steering loop.
- Grammar deltas use the same `Prediction(cdc_rules_added, cdc_rules_removed, rationale)` shape xeno's mutator carries (Stage-3 Layer B), so steering / coverage tooling can reason about both surfaces uniformly.

## Test plan

- [x] `uv run ruff check` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy` clean
- [x] `uv run pytest -q` → 1391 passed (no regression in the default suite)
- [x] `uv run pytest -m fuzz -q` → 508 passed (existing fuzz selection unchanged)
- [x] `uv run pytest -m fuzz_grammar -v` → 5 passed:
  - reproducibility (same seed → byte-identical SV/SDC/params)
  - seed divergence (8 seeds → >1 distinct SV)
  - `n_productions` bound respected
  - 8-seed end-to-end smoke (Yosys elaboration + analyzer findings match expectation)
  - per-production directional prediction holds

## Done-when (Stage-4 progress)

This PR alone doesn't close any of rtl-buddy-cdc#222's four done-when criteria — it lands the surface those criteria are measured against. The integration PR will:

- wire grammar cases into `coverage.py`'s 3-column report (criterion 3, "agreement rate matches the hand-authored corpus");
- run grammar cases under the `fuzz_diff` oracle (criterion 3);
- add coverage-steering to lift under-covered rules (criterion 2);
- document grammar terminals/non-terminals/productions in the architecture spec (criterion 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)