### PR TITLE
Stage-4 grammar integration: coverage column + diff + steering + spec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Run fuzz_diff suite (cross-frontend oracle)
         run: uv run pytest -m fuzz_diff -q
 
+      - name: Run fuzz_grammar suite (Stage-4 grammar topologies)
+        run: uv run pytest -m fuzz_grammar -q
+
       - name: Run sim suite
         run: uv run pytest -m sim -q
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,5 +15,10 @@ def pytest_configure(config) -> None:
     )
     config.addinivalue_line(
         "markers",
+        "fuzz_grammar: Stage-4 grammar-generated topologies "
+        "(gated; run via `pytest -m fuzz_grammar`; needs yosys on PATH)",
+    )
+    config.addinivalue_line(
+        "markers",
         "sim: behavioural simulation oracle (opt-in; needs iverilog)",
     )

--- a/tests/fuzz/coverage.py
+++ b/tests/fuzz/coverage.py
@@ -1,9 +1,10 @@
 """Per-rule coverage reporter over the fuzz corpus.
 
-Stage-3 (rtl-buddy-cdc#221) full extension: the report tracks fires
-under **each surface independently** so incomplete parity / coverage
-is obvious at a glance. The historical single-column (Yosys-only)
-shape is removed in favour of three independent surfaces:
+Stage-3 (rtl-buddy-cdc#221) extension + Stage-4 (rtl-buddy-cdc#222)
+grammar column: the report tracks fires under **each surface
+independently** so incomplete parity / coverage is obvious at a
+glance. The historical single-column (Yosys-only) shape is removed
+in favour of four independent surfaces:
 
 - ``yosys`` — the canonical analyzer path; the historical surface.
 - ``slang`` — the in-process slang frontend (Layer C); empty when
@@ -13,13 +14,27 @@ shape is removed in favour of three independent surfaces:
   through the Yosys pipeline (mutants are SV-only perturbations
   of the parent template's source), so the column tracks how
   many mutant cases fired each rule under the analyzer.
+- ``grammar`` — Stage-4 grammar-generated topologies. Each seed
+  in :data:`_GRAMMAR_SEEDS` is rendered, elaborated through Yosys,
+  and fed to the analyzer; the column reports per-rule fires.
 
 A ``disagree`` column counts per-rule Yosys-vs-slang mismatches —
 high values point at the slang-parity gaps tracked in
 rtl-buddy-cdc#224.
 
+Coverage steering (Stage-4 issue #222 Sketch point 5)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After the report prints, the tool surfaces a *steering hint*
+section: rules whose ``grammar`` column shows zero fires *but*
+that at least one production declares it lifts. That's the
+actionable signal — the production exists, has a chance to lift
+the rule, but the uniform-random seed pass didn't pick it
+frequently enough. Operators can then run a steered pass via
+:func:`tests.fuzz.grammar.productions_lifting`.
+
 The Stage-2 plan in rtl-buddy-cdc#190 calls for "every shipping rule
-fires ≥10 times across the corpus." With the three-surface report
+fires ≥10 times across the corpus." With the four-surface report
 each surface is its own ratchet:
 
 - A rule that fires ≥10× in Yosys but 0× in slang is a slang
@@ -30,13 +45,18 @@ each surface is its own ratchet:
   rtl-buddy-cdc#221 done-when target (≥10 per template) flags
   insufficient xeno operator coverage for that rule's structural
   shape.
+- A rule whose ``grammar`` column shows zero fires *and* has a
+  production declaring it surfaces as a steering hint
+  (rtl-buddy-cdc#222 Sketch point 5).
 
 Invocation::
 
     uv run python -m tests.fuzz.coverage
 
-Output: a table sorted by rule id with the columns above.
-Surfaces show ``—`` when their backing dependency isn't installed.
+Output: a table sorted by rule id with the columns above, plus a
+steering-hint section when grammar productions exist but didn't
+fire under the uniform pass. Surfaces show ``—`` when their
+backing dependency isn't installed.
 """
 
 from __future__ import annotations
@@ -47,9 +67,18 @@ from collections import Counter
 from rtl_buddy_cdc.rules import RULES
 
 from ._mutator import iter_mutants, xeno_available
+from .grammar import PRODUCTIONS as _GRAMMAR_PRODUCTIONS
+from .grammar import generate as _grammar_generate
 from .runner import collect_cases, run_case, run_case_slang
 from .slang_cache import slang_available
 from .yosys_cache import yosys_available
+
+# Seeds used for the grammar column's uniform-random pass. Range
+# is small enough that the coverage report stays under the
+# rtl-buddy-cdc#221 perf budget — 32 grammar cases × ~15 ms Yosys
+# elaboration ≈ 0.5 s added to the report; steering passes (run by
+# operators explicitly) can use a wider range.
+_GRAMMAR_SEEDS = range(32)
 
 
 def main() -> int:
@@ -67,11 +96,14 @@ def main() -> int:
     per_rule_disagree: Counter[str] = Counter()
     mutant_rule_fires: Counter[str] = Counter()
     mutant_rule_cases: Counter[str] = Counter()
+    grammar_rule_fires: Counter[str] = Counter()
+    grammar_rule_cases: Counter[str] = Counter()
     case_count = 0
     failed_cases: list[str] = []
     slang_skip_count = 0
     mutant_total = 0
     mutant_skip_count = 0
+    grammar_skip_count = 0
 
     # ``canonical`` here mirrors tests/fuzz/test_mutants.py's
     # canonical-parent strategy: one parent per template family,
@@ -126,6 +158,26 @@ def main() -> int:
                     mutant_rule_fires[rule_id] += count
                     mutant_rule_cases[rule_id] += 1
 
+    # Stage-4 grammar pass (issue #222). Each seed renders a
+    # composed grammar case; same Yosys pipeline as the corpus and
+    # mutant passes — the only thing different is where the SV
+    # came from. A skip here means the grammar produced SV Yosys
+    # rejected; same shape as the mutant-skip case, and the same
+    # signal: a production is emitting illegal SystemVerilog and
+    # tests/fuzz/test_grammar.py's directional check will catch it.
+    grammar_total = 0
+    for seed in _GRAMMAR_SEEDS:
+        case = _grammar_generate(seed=seed)
+        grammar_total += 1
+        try:
+            grammar_result = run_case(case)
+        except Exception:
+            grammar_skip_count += 1
+            continue
+        for rule_id, count in grammar_result.fired.items():
+            grammar_rule_fires[rule_id] += count
+            grammar_rule_cases[rule_id] += 1
+
     print(f"Corpus: {case_count} cases (yosys)")
     if run_slang:
         print(
@@ -142,6 +194,11 @@ def main() -> int:
         )
     else:
         print("        mutants disabled (rtl-buddy-xeno not importable)")
+    print(
+        f"        {grammar_total - grammar_skip_count} cases (grammar); "
+        f"{grammar_skip_count} skipped, "
+        f"seeds={_GRAMMAR_SEEDS.start}..{_GRAMMAR_SEEDS.stop - 1}"
+    )
     if failed_cases:
         print(f"FAILED: {len(failed_cases)} case(s)")
         for cid in failed_cases:
@@ -153,6 +210,7 @@ def main() -> int:
         f"{'yosys_fires':>11} {'yosys_cases':>11}  "
         f"{'slang_fires':>11} {'slang_cases':>11}  "
         f"{'mut_fires':>10} {'mut_cases':>10}  "
+        f"{'gram_fires':>11} {'gram_cases':>11}  "
         f"{'disagree':>8}"
     )
     sep = (
@@ -160,12 +218,16 @@ def main() -> int:
         f"{'-' * 11} {'-' * 11}  "
         f"{'-' * 11} {'-' * 11}  "
         f"{'-' * 10} {'-' * 10}  "
+        f"{'-' * 11} {'-' * 11}  "
         f"{'-' * 8}"
     )
     print(header)
     print(sep)
     seen_rules = sorted(
-        set(yosys_rule_fires) | set(slang_rule_fires) | set(mutant_rule_fires)
+        set(yosys_rule_fires)
+        | set(slang_rule_fires)
+        | set(mutant_rule_fires)
+        | set(grammar_rule_fires)
     )
     for rule_id in seen_rules:
         yf = yosys_rule_fires[rule_id]
@@ -181,11 +243,14 @@ def main() -> int:
             mc_disp: str = str(mutant_rule_cases[rule_id])
         else:
             mf_disp = mc_disp = "—"
+        gf_disp: str = str(grammar_rule_fires[rule_id])
+        gc_disp: str = str(grammar_rule_cases[rule_id])
         print(
             f"{rule_id:<10} "
             f"{yf:>11} {yc:>11}  "
             f"{sf_disp:>11} {sc_disp:>11}  "
             f"{mf_disp:>10} {mc_disp:>10}  "
+            f"{gf_disp:>11} {gc_disp:>11}  "
             f"{disagree_disp:>8}"
         )
 
@@ -195,6 +260,29 @@ def main() -> int:
         print(f"Never fired ({len(never_fired)}/{len(RULES)}):")
         for rule_id in never_fired:
             print(f"  - {rule_id}")
+
+    # Stage-4 steering hints: rules with a production that
+    # *declares* it lifts them, but whose grammar column shows
+    # zero fires in this uniform-random pass. Actionable signal —
+    # the operator can re-run a steered batch to pull those rules
+    # up. Issue #222 Sketch point 5.
+    steerable: list[tuple[str, list[str]]] = []
+    for prod in _GRAMMAR_PRODUCTIONS:
+        for rule_id in sorted(prod.declared.cdc_rules_added):
+            if grammar_rule_fires.get(rule_id, 0) == 0:
+                steerable.append((rule_id, [prod.name]))
+    if steerable:
+        # Aggregate by rule so a rule with two candidate productions
+        # shows once with both names.
+        agg: dict[str, list[str]] = {}
+        for rule_id, names in steerable:
+            agg.setdefault(rule_id, []).extend(names)
+        print()
+        print(
+            f"Steerable rules ({len(agg)}, grammar fires=0 with a declaring production):"
+        )
+        for rule_id in sorted(agg):
+            print(f"  - {rule_id}: {', '.join(sorted(set(agg[rule_id])))}")
 
     return 0 if not failed_cases else 1
 

--- a/tests/fuzz/grammar/__init__.py
+++ b/tests/fuzz/grammar/__init__.py
@@ -1,0 +1,59 @@
+"""Stage-4 grammar fuzzer (rtl-buddy-cdc#222).
+
+A grammar that emits topologies the hand-authored corpus hasn't seen
+— multi-source aggregators, partial-handshake protocols, deep
+multi-rate pipelines, gray-coded buses paired with control flags,
+reset-sync chains alongside data crossings. Each generated
+:class:`tests.fuzz.templates.base.RenderedCase` flows through the
+same Yosys / slang / analyzer pipeline the Stage-3 corpus uses,
+so a grammar-derived ``.sv`` is just another input to the existing
+runner.
+
+Stage-4 foundation surface
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This first cut lands the surface (core types + ≥3 productions +
+seeded generation), without yet wiring grammar cases into the
+3-column coverage report or the cross-frontend differential oracle
+— those come in the integration PR.
+
+Public entry points:
+
+- :func:`generate` — render a single :class:`RenderedCase` for a seed.
+- :data:`PRODUCTIONS` — the registry of available non-terminals.
+- :class:`Production`, :class:`Prediction`, :class:`Fragment`,
+  :class:`GenContext`, :class:`ClockDomain`, :class:`Port` — the
+  composable grammar surface a future engineer can extend (issue
+  #222 done-when criterion 4).
+
+The grammar is *seeded*, mirroring xeno's mutator contract: a fixed
+seed always produces the same SV bytes. The test surface in
+:mod:`tests.fuzz.test_grammar` pins that reproducibility, so any
+nondeterminism creeping into the productions surfaces immediately.
+"""
+
+from __future__ import annotations
+
+from .core import (
+    ClockDomain,
+    Fragment,
+    GenContext,
+    Port,
+    Prediction,
+    Production,
+    compose,
+    generate,
+)
+from .productions import PRODUCTIONS
+
+__all__ = [
+    "PRODUCTIONS",
+    "ClockDomain",
+    "Fragment",
+    "GenContext",
+    "Port",
+    "Prediction",
+    "Production",
+    "compose",
+    "generate",
+]

--- a/tests/fuzz/grammar/__init__.py
+++ b/tests/fuzz/grammar/__init__.py
@@ -45,6 +45,7 @@ from .core import (
     generate,
 )
 from .productions import PRODUCTIONS
+from .steering import productions_lifting, under_covered_rules
 
 __all__ = [
     "PRODUCTIONS",
@@ -56,4 +57,6 @@ __all__ = [
     "Production",
     "compose",
     "generate",
+    "productions_lifting",
+    "under_covered_rules",
 ]

--- a/tests/fuzz/grammar/core.py
+++ b/tests/fuzz/grammar/core.py
@@ -1,0 +1,316 @@
+"""Grammar core: terminals, productions, composition, top-level driver.
+
+The grammar emits :class:`tests.fuzz.templates.base.RenderedCase`
+instances built by *composing* productions: each production emits
+a :class:`Fragment` (SV snippets + ports + clocks + a verdict delta);
+the driver concatenates the fragments into a single module body,
+unions the verdicts, and renders the module + SDC.
+
+The verdict delta has the same shape as xeno's
+:class:`rtl_buddy_xeno.Prediction` (Stage-3 Layer B), so a grammar
+case's expected finding-set is composable from the productions it
+used. The grammar's runner contract is the same as xeno's mutants:
+``ExpectedFinding(rule_id, Op.GE, 1)`` for added rules,
+``ExpectedFinding(rule_id, Op.ZERO)`` for removed.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from ..templates.base import ExpectedFinding, Op, RenderedCase
+
+
+@dataclass(frozen=True)
+class Prediction:
+    """Per-production verdict delta.
+
+    The same ``added``/``removed`` shape xeno's mutator carries —
+    so a downstream consumer (the analyzer-differential runner or
+    the coverage-steering hook) can reason about grammar
+    productions and mutant operators uniformly.
+    """
+
+    cdc_rules_added: frozenset[str] = frozenset()
+    cdc_rules_removed: frozenset[str] = frozenset()
+    rationale: str = ""
+
+    def merge(self, other: "Prediction") -> "Prediction":
+        """Union the two deltas; ``removed`` wins over ``added``.
+
+        Composing productions that introduce a finding (e.g. an
+        unsynced crossing → CDC-001) and one that silences it (e.g.
+        a globally-applied attribute-mark) leaves the silenced rule
+        out of the combined ``added`` set. Today's foundation
+        productions don't yet use ``removed`` — the union math is
+        trivially additive — but the merge contract is fixed so
+        future productions (e.g. ``cdc_sync_attribute_blanket``)
+        don't have to re-design the composition rule.
+        """
+        added = (self.cdc_rules_added | other.cdc_rules_added) - (
+            self.cdc_rules_removed | other.cdc_rules_removed
+        )
+        removed = self.cdc_rules_removed | other.cdc_rules_removed
+        return Prediction(
+            cdc_rules_added=frozenset(added),
+            cdc_rules_removed=frozenset(removed),
+            rationale=(
+                f"{self.rationale}; {other.rationale}".strip("; ")
+                if self.rationale or other.rationale
+                else ""
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ClockDomain:
+    """A grammar terminal: a clock with a period (ns).
+
+    The grammar's SDC emitter declares one ``create_clock`` per
+    domain and places every pair in the same
+    ``set_clock_groups -asynchronous`` clause — Stage-4 productions
+    treat any two distinct domains as async-to-each-other, matching
+    the hand-authored corpus's SDC convention.
+    """
+
+    name: str
+    period: float
+
+
+@dataclass(frozen=True)
+class Port:
+    """A grammar terminal: a top-level module port.
+
+    ``sampling_clock`` populates the SDC's ``set_input_delay`` for
+    input ports — without it, CDC-011 (unconstrained input) fires
+    on every grammar-introduced input, which would dominate the
+    finding set with a single rule.
+    """
+
+    name: str
+    direction: str  # "input" | "output"
+    width: int = 1
+    sampling_clock: str | None = None
+
+    def declaration(self) -> str:
+        width_part = "" if self.width == 1 else f" [{self.width - 1}:0]"
+        return f"    {self.direction:<6} logic{width_part} {self.name}"
+
+
+@dataclass
+class Fragment:
+    """A production's SV emission + verdict delta.
+
+    Fragments are concatenated by :func:`compose`; ports / clocks
+    are merged into the module header and SDC respectively.
+    Production authors don't see the module-level shape — they
+    only declare what they introduce.
+    """
+
+    decls: list[str] = field(default_factory=list)
+    always_blocks: list[str] = field(default_factory=list)
+    assigns: list[str] = field(default_factory=list)
+    ports: list[Port] = field(default_factory=list)
+    clocks: list[ClockDomain] = field(default_factory=list)
+    prediction: Prediction = field(default_factory=Prediction)
+
+
+@dataclass
+class GenContext:
+    """Per-generate-call mutable state shared across productions.
+
+    The shared :class:`random.Random` is the single source of
+    nondeterminism — productions must draw from ``ctx.rng`` and
+    never from module-level state. The :meth:`uniq` counter
+    guarantees signal-name uniqueness across compositions (two
+    sync-chain productions can coexist in one module without
+    colliding on ``sync_q``).
+    """
+
+    rng: random.Random
+    counter: int = 0
+    declared_clocks: dict[str, ClockDomain] = field(default_factory=dict)
+
+    def uniq(self, base: str) -> str:
+        self.counter += 1
+        return f"{base}_{self.counter}"
+
+    def get_or_declare_clock(self, name: str, period: float) -> ClockDomain:
+        existing = self.declared_clocks.get(name)
+        if existing is not None:
+            return existing
+        clk = ClockDomain(name=name, period=period)
+        self.declared_clocks[name] = clk
+        return clk
+
+
+# A production is a callable that, given the shared context,
+# emits a :class:`Fragment`. The pure-function shape lets productions
+# stay stateless — the only mutation flows through ``ctx``.
+EmitFn = Callable[[GenContext], Fragment]
+
+
+@dataclass(frozen=True)
+class Production:
+    """A grammar non-terminal.
+
+    ``declared`` is the *static* verdict the production carries —
+    used by the coverage-steering hook (issue #222 Sketch point 5)
+    to pick productions that lift under-covered rules. The
+    :class:`Fragment` returned by ``emit`` carries the actual
+    prediction for the emitted instance, which may differ from
+    ``declared`` if the production has parameters that change the
+    verdict (e.g. a sync-chain production with a randomly-chosen
+    depth).
+    """
+
+    name: str
+    emit: EmitFn
+    declared: Prediction
+
+
+def compose(productions: list[Production], ctx: GenContext) -> Fragment:
+    """Chain productions into a single module-body fragment.
+
+    Each production is emitted independently — there is no
+    signal-threading between productions, so a sync-chain followed
+    by a comb-source produces two parallel crossing sites in the
+    same module, not one chained crossing. This keeps each
+    production's verdict locally interpretable.
+    """
+    out = Fragment()
+    for prod in productions:
+        frag = prod.emit(ctx)
+        out.decls.extend(frag.decls)
+        out.always_blocks.extend(frag.always_blocks)
+        out.assigns.extend(frag.assigns)
+        out.ports.extend(frag.ports)
+        out.clocks.extend(frag.clocks)
+        out.prediction = out.prediction.merge(frag.prediction)
+    return out
+
+
+def _render_sdc(clocks: list[ClockDomain], ports: list[Port]) -> str:
+    """Emit the SDC. One ``create_clock`` per declared clock; a single
+    ``set_clock_groups -asynchronous`` listing every clock as its own
+    group (the grammar treats all clocks as mutually async, matching
+    the hand-authored corpus's SDC convention); ``set_input_delay``
+    per input port that declared a ``sampling_clock``.
+    """
+    seen: dict[str, ClockDomain] = {}
+    for c in clocks:
+        seen.setdefault(c.name, c)
+    sorted_clocks = sorted(seen.values(), key=lambda c: c.name)
+
+    lines = [
+        f"create_clock -name {c.name} -period {c.period} [get_ports {c.name}]"
+        for c in sorted_clocks
+    ]
+    if len(sorted_clocks) >= 2:
+        groups = " ".join(f"-group {{{c.name}}}" for c in sorted_clocks)
+        lines.append(f"set_clock_groups -asynchronous {groups}")
+
+    for p in ports:
+        if p.direction == "input" and p.sampling_clock is not None:
+            lines.append(
+                f"set_input_delay -clock {p.sampling_clock} 1.0 [get_ports {p.name}]"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _render_module(top: str, body: Fragment) -> str:
+    """Render the module header (ports) + body (decls + always +
+    assigns). Clocks are rendered as ``input logic`` ports — the
+    grammar uses ``create_clock [get_ports ...]`` in the SDC, so the
+    clock identifiers must be top-level inputs.
+    """
+    clock_ports = [
+        Port(name=c.name, direction="input")
+        for c in sorted({c.name: c for c in body.clocks}.values(), key=lambda c: c.name)
+    ]
+    # Preserve insertion order for non-clock ports — production
+    # authors can rely on the rendered module's port order matching
+    # the order their fragments were composed.
+    all_ports = clock_ports + body.ports
+    header_lines = [p.declaration() + "," for p in all_ports[:-1]]
+    if all_ports:
+        header_lines.append(all_ports[-1].declaration())
+    header = "\n".join(header_lines)
+
+    body_chunks: list[str] = []
+    if body.decls:
+        body_chunks.append("\n".join(body.decls))
+    if body.always_blocks:
+        body_chunks.append("\n\n".join(body.always_blocks))
+    if body.assigns:
+        body_chunks.append("\n".join(body.assigns))
+    body_text = "\n\n".join(body_chunks)
+
+    return f"module {top} (\n{header}\n);\n{body_text}\nendmodule\n"
+
+
+def generate(
+    seed: int,
+    *,
+    productions: list[Production] | None = None,
+    n_productions: int | None = None,
+    top: str | None = None,
+) -> RenderedCase:
+    """Render one grammar-generated :class:`RenderedCase`.
+
+    Deterministic given ``seed`` and ``productions`` — the same
+    inputs always yield byte-identical SV / SDC. This is the
+    reproducibility property issue #222's Sketch point 4 calls out
+    and :mod:`tests.fuzz.test_grammar` pins.
+
+    ``productions`` defaults to the full :data:`PRODUCTIONS`
+    registry; the coverage-steering hook (integration PR) passes a
+    filtered subset to bias generation toward under-covered rules.
+    ``n_productions`` defaults to a random pick from [2, 4] —
+    enough composition to exercise non-trivial topologies, bounded
+    so a single case stays Yosys-elaboratable in <1 s.
+    """
+    if productions is None:
+        from .productions import PRODUCTIONS as _DEFAULT
+
+        productions = list(_DEFAULT)
+    if not productions:
+        raise ValueError("generate() needs at least one production")
+
+    rng = random.Random(seed)
+    ctx = GenContext(rng=rng)
+
+    n = n_productions if n_productions is not None else rng.randint(2, 4)
+    chosen = [rng.choice(productions) for _ in range(n)]
+
+    body = compose(chosen, ctx)
+
+    case_top = top if top is not None else f"fuzz_grammar_seed{seed}"
+    sv = _render_module(case_top, body)
+    sdc = _render_sdc(body.clocks, body.ports)
+
+    expected = tuple(
+        ExpectedFinding(rule_id, Op.GE, 1)
+        for rule_id in sorted(body.prediction.cdc_rules_added)
+    )
+    forbidden = tuple(
+        ExpectedFinding(rule_id, Op.ZERO)
+        for rule_id in sorted(body.prediction.cdc_rules_removed)
+    )
+
+    return RenderedCase(
+        template_name="grammar",
+        case_id=case_top,
+        sv=sv,
+        sdc=sdc,
+        top=case_top,
+        params={
+            "seed": seed,
+            "productions": [p.name for p in chosen],
+            "n_productions": n,
+        },
+        expected=expected,
+        forbidden=forbidden,
+    )

--- a/tests/fuzz/grammar/productions.py
+++ b/tests/fuzz/grammar/productions.py
@@ -1,0 +1,342 @@
+"""Foundation production set for the Stage-4 grammar fuzzer.
+
+Each production emits an *independent* crossing site within the
+module — productions don't thread signals between each other, so a
+case with two productions becomes a module with two parallel
+crossings, each independently exercising its declared rules.
+
+Foundation set covers four of the six non-terminals issue #222
+calls out:
+
+- **sync chain** — :func:`_emit_clean_sync_chain` (depth=2 reference)
+  and :func:`_emit_unsynced_single_bit` (depth=0 negative).
+- **comb source** — :func:`_emit_comb_source` (CDC-006 site).
+- **gray counter** — :func:`_emit_gray_counter_crossing`
+  (CDC-004-clean wide crossing via ``(* cdc_gray *)``).
+- **reset-sync chain** — :func:`_emit_missing_reset_sync` (RDC-001
+  site: foreign-domain async reset on a dst-domain flop's ARST pin).
+
+The two remaining non-terminals (``handshake req/ack pair``,
+``FIFO read/write skeleton``) land in the integration PR alongside
+the coverage-steering hook — they need the steering loop to argue
+their additional Yosys / slang elaboration cost is paying for new
+coverage rather than redundancy with the hand-authored templates.
+
+Two reference clock domains
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The foundation productions share a two-domain reference
+(``src_clk`` + ``dst_clk``) for simplicity. The :class:`GenContext`
+already supports declaring additional domains, so future
+multi-rate-pipeline / multi-source-aggregator productions can
+introduce a third or fourth clock without changing the core.
+"""
+
+from __future__ import annotations
+
+from .core import (
+    ClockDomain,
+    Fragment,
+    GenContext,
+    Port,
+    Prediction,
+    Production,
+)
+
+# Reference clock periods. The grammar picks one of these pairs per
+# generated case so the SDC introduces variety analogous to the
+# Stage-3 Layer A sweep — same SV elaboration cost, distinct Yosys
+# cache buckets per (sv, sdc) digest.
+_PERIOD_PAIRS: tuple[tuple[float, float], ...] = (
+    (10.0, 7.5),
+    (5.0, 13.0),
+    (12.0, 18.5),
+    (8.0, 11.0),
+    (15.5, 6.0),
+    (9.5, 22.0),
+)
+
+
+def _pick_clocks(ctx: GenContext) -> tuple[ClockDomain, ClockDomain]:
+    """Pick (src, dst) clocks for a production, declaring them in
+    ``ctx`` if first seen so multiple productions share the same
+    period choices across a single case.
+    """
+    if "src_clk" in ctx.declared_clocks and "dst_clk" in ctx.declared_clocks:
+        return ctx.declared_clocks["src_clk"], ctx.declared_clocks["dst_clk"]
+    src_period, dst_period = ctx.rng.choice(_PERIOD_PAIRS)
+    src = ctx.get_or_declare_clock("src_clk", src_period)
+    dst = ctx.get_or_declare_clock("dst_clk", dst_period)
+    return src, dst
+
+
+def _emit_clean_sync_chain(ctx: GenContext) -> Fragment:
+    """Textbook 2FF synchroniser on a single bit.
+
+    Same shape as ``GoodTwoFF`` in the hand-authored corpus — the
+    grammar's "no false positives" sentinel. Verdict carries no
+    added rules: a clean chain shouldn't fire anything.
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("clean")
+    d_in = f"d_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    src_q = f"src_q_{suffix}"
+    sync_m = f"sync_m_{suffix}"
+    sync_q = f"sync_q_{suffix}"
+
+    decls = [
+        f"    logic {src_q};",
+        f"    logic {sync_m}, {sync_q};",
+    ]
+    always = [
+        f"    always_ff @(posedge {src.name}) {src_q} <= {d_in};",
+        (
+            f"    always_ff @(posedge {dst.name}) begin\n"
+            f"        {sync_m} <= {src_q};\n"
+            f"        {sync_q} <= {sync_m};\n"
+            f"    end"
+        ),
+    ]
+    assigns = [f"    assign {q_out} = {sync_q};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=d_in, direction="input", sampling_clock=src.name),
+            Port(name=q_out, direction="output"),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(rationale="clean 2FF synchroniser; no added findings"),
+    )
+
+
+def _emit_unsynced_single_bit(ctx: GenContext) -> Fragment:
+    """Direct src→dst flop with no sync chain. CDC-001 fires.
+
+    Depth=0 means CDC-002 stays silent (CDC-001 owns the finding
+    when no chain exists at all — see :mod:`tests.fuzz.templates.cdc001`
+    for the same partition).
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("unsync")
+    d_in = f"d_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    src_q = f"src_q_{suffix}"
+    dst_q = f"dst_q_{suffix}"
+
+    decls = [
+        f"    logic {src_q};",
+        f"    logic {dst_q};",
+    ]
+    always = [
+        f"    always_ff @(posedge {src.name}) {src_q} <= {d_in};",
+        f"    always_ff @(posedge {dst.name}) {dst_q} <= {src_q};",
+    ]
+    assigns = [f"    assign {q_out} = {dst_q};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=d_in, direction="input", sampling_clock=src.name),
+            Port(name=q_out, direction="output"),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(
+            cdc_rules_added=frozenset({"CDC-001"}),
+            rationale="single-bit src→dst with no sync chain",
+        ),
+    )
+
+
+def _emit_comb_source(ctx: GenContext) -> Fragment:
+    """Top-level input feeds the sync chain without a registering
+    flop in the source domain. CDC-006 fires on the unregistered
+    combinational source.
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("comb")
+    a_in = f"a_in_{suffix}"
+    b_in = f"b_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    comb_w = f"comb_w_{suffix}"
+    sync_m = f"sync_m_{suffix}"
+    sync_q = f"sync_q_{suffix}"
+    src_dummy = f"src_dummy_{suffix}"
+
+    decls = [
+        f"    wire {comb_w} = {a_in} & {b_in};",
+        f"    logic {sync_m}, {sync_q};",
+        f"    logic {src_dummy};",
+    ]
+    always = [
+        (
+            f"    always_ff @(posedge {dst.name}) begin\n"
+            f"        {sync_m} <= {comb_w};\n"
+            f"        {sync_q} <= {sync_m};\n"
+            f"    end"
+        ),
+        # Give src_clk at least one consumer so the analyzer treats
+        # it as a real clock domain — same trick CombSource uses.
+        f"    always_ff @(posedge {src.name}) {src_dummy} <= 1'b0;",
+    ]
+    assigns = [f"    assign {q_out} = {sync_q} | {src_dummy};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=a_in, direction="input", sampling_clock=src.name),
+            Port(name=b_in, direction="input", sampling_clock=src.name),
+            Port(name=q_out, direction="output"),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(
+            cdc_rules_added=frozenset({"CDC-006"}),
+            rationale="comb source feeds sync chain without source-side flop",
+        ),
+    )
+
+
+def _emit_gray_counter_crossing(ctx: GenContext) -> Fragment:
+    """Wide bus crossing with ``(* cdc_gray *)`` on both endpoints.
+
+    CDC-004 (multi-bit unrelated-flops crossing) stays silent
+    because the attribute promises gray encoding — every transition
+    flips exactly one bit, so a metastable sample is one of the two
+    legal adjacent codes, not a transient illegal mix.
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("gray")
+    en_in = f"en_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    bin_q = f"bin_q_{suffix}"
+    gray_q = f"gray_q_{suffix}"
+    sync_m = f"sync_m_{suffix}"
+    sync_q = f"sync_q_{suffix}"
+
+    decls = [
+        f"    logic [3:0] {bin_q};",
+        f"    (* cdc_gray *) logic [3:0] {gray_q};",
+        f"    (* cdc_gray *) logic [3:0] {sync_m}, {sync_q};",
+    ]
+    always = [
+        (
+            f"    always_ff @(posedge {src.name}) begin\n"
+            f"        if ({en_in}) {bin_q} <= {bin_q} + 4'd1;\n"
+            f"        {gray_q} <= {bin_q} ^ ({bin_q} >> 1);\n"
+            f"    end"
+        ),
+        (
+            f"    always_ff @(posedge {dst.name}) begin\n"
+            f"        {sync_m} <= {gray_q};\n"
+            f"        {sync_q} <= {sync_m};\n"
+            f"    end"
+        ),
+    ]
+    assigns = [f"    assign {q_out} = {sync_q};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=en_in, direction="input", sampling_clock=src.name),
+            Port(name=q_out, direction="output", width=4),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(
+            rationale="(* cdc_gray *)-marked wide crossing; CDC-004 silenced",
+        ),
+    )
+
+
+def _emit_missing_reset_sync(ctx: GenContext) -> Fragment:
+    """Foreign-domain async reset on a dst-domain flop's ARST pin.
+
+    Same failure mode as ``rdc001_async_reset_crossing`` in the
+    hand-authored corpus: assertion is fine, but recovery/removal
+    timing on deassertion is asynchronous to ``dst_clk``. RDC-001
+    fires.
+    """
+    src, dst = _pick_clocks(ctx)
+    suffix = ctx.uniq("rdc")
+    global_rst_n = f"global_rst_n_{suffix}"
+    rst_req = f"rst_req_{suffix}"
+    d_in = f"d_in_{suffix}"
+    q_out = f"q_out_{suffix}"
+    local_rst_n = f"local_rst_n_{suffix}"
+    dst_q = f"dst_q_{suffix}"
+
+    decls = [
+        f"    logic {local_rst_n};",
+        f"    logic {dst_q};",
+    ]
+    always = [
+        (
+            f"    always_ff @(posedge {src.name} or negedge {global_rst_n})\n"
+            f"        if (!{global_rst_n}) {local_rst_n} <= 1'b0;\n"
+            f"        else                  {local_rst_n} <= ~{rst_req};"
+        ),
+        (
+            f"    always_ff @(posedge {dst.name} or negedge {local_rst_n})\n"
+            f"        if (!{local_rst_n}) {dst_q} <= 1'b0;\n"
+            f"        else                {dst_q} <= {d_in};"
+        ),
+    ]
+    assigns = [f"    assign {q_out} = {dst_q};"]
+    return Fragment(
+        decls=decls,
+        always_blocks=always,
+        assigns=assigns,
+        ports=[
+            Port(name=global_rst_n, direction="input"),
+            Port(name=rst_req, direction="input", sampling_clock=src.name),
+            Port(name=d_in, direction="input", sampling_clock=dst.name),
+            Port(name=q_out, direction="output"),
+        ],
+        clocks=[src, dst],
+        prediction=Prediction(
+            cdc_rules_added=frozenset({"RDC-001"}),
+            rationale="foreign-domain async reset directly on dst-domain ARST",
+        ),
+    )
+
+
+PRODUCTIONS: tuple[Production, ...] = (
+    Production(
+        name="clean_sync_chain",
+        emit=_emit_clean_sync_chain,
+        declared=Prediction(rationale="clean 2FF synchroniser"),
+    ),
+    Production(
+        name="unsynced_single_bit",
+        emit=_emit_unsynced_single_bit,
+        declared=Prediction(
+            cdc_rules_added=frozenset({"CDC-001"}),
+            rationale="unsynced single-bit crossing",
+        ),
+    ),
+    Production(
+        name="comb_source",
+        emit=_emit_comb_source,
+        declared=Prediction(
+            cdc_rules_added=frozenset({"CDC-006"}),
+            rationale="comb source feeds sync chain",
+        ),
+    ),
+    Production(
+        name="gray_counter_crossing",
+        emit=_emit_gray_counter_crossing,
+        declared=Prediction(rationale="(* cdc_gray *)-marked wide crossing"),
+    ),
+    Production(
+        name="missing_reset_sync",
+        emit=_emit_missing_reset_sync,
+        declared=Prediction(
+            cdc_rules_added=frozenset({"RDC-001"}),
+            rationale="async reset crossing on dst-domain ARST",
+        ),
+    ),
+)

--- a/tests/fuzz/grammar/steering.py
+++ b/tests/fuzz/grammar/steering.py
@@ -1,0 +1,71 @@
+"""Coverage steering: pick productions that lift under-covered rules.
+
+Stage-4 issue rtl-buddy-cdc#222 Sketch point 5 — closes the loop
+between corpus growth and coverage gain. The 3-column coverage
+report (Stage-3 Layer C) identifies under-covered rules; this
+module maps those rules back to the productions that declare
+them in :attr:`Production.declared.cdc_rules_added`, so the
+caller can bias :func:`tests.fuzz.grammar.generate` toward
+productions that *should* lift the under-covered rule.
+
+The steering picker is intentionally *static*: it consults the
+production's declared verdict, not its observed firing pattern.
+A production whose declared rule never actually fires is a bug
+in the production (its rendered SV doesn't trigger what its
+verdict claims) and surfaces via the directional check in
+:mod:`tests.fuzz.test_grammar`, not via steering.
+
+Mechanics
+~~~~~~~~~
+
+- :func:`productions_lifting` — given a set of rule ids, return
+  the productions that declare at least one of them. Used by
+  callers that already know which rules they want to exercise.
+- :func:`under_covered_rules` — given a per-rule fire counter and
+  a threshold, return the rules whose fire count is below it.
+  The coverage report uses this to identify steering targets
+  before invoking :func:`productions_lifting`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .core import Production
+from .productions import PRODUCTIONS
+
+
+def productions_lifting(
+    rule_ids: set[str] | frozenset[str],
+    *,
+    productions: tuple[Production, ...] | list[Production] = PRODUCTIONS,
+) -> list[Production]:
+    """Return productions whose declared verdict intersects ``rule_ids``.
+
+    Order is preserved from the input ``productions`` registry so
+    the resulting bias-set is deterministic for a fixed registry.
+    A production is included if *any* of its declared added rules
+    overlaps ``rule_ids`` — even multi-rule productions like a
+    future handshake-with-missing-ack (CDC-001 + CDC-012) get
+    picked for either target.
+    """
+    target = frozenset(rule_ids)
+    return [p for p in productions if p.declared.cdc_rules_added & target]
+
+
+def under_covered_rules(
+    fires: Mapping[str, int],
+    *,
+    threshold: int,
+    rule_universe: set[str] | frozenset[str] | None = None,
+) -> set[str]:
+    """Return rules whose fire count is strictly below ``threshold``.
+
+    ``rule_universe`` defaults to the keys present in ``fires`` —
+    pass the full :data:`rtl_buddy_cdc.rules.RULES` set when you
+    want zero-fire rules to surface too (they don't appear as
+    keys in ``fires`` unless the report seeded them at zero).
+    """
+    if rule_universe is None:
+        rule_universe = set(fires)
+    return {r for r in rule_universe if fires.get(r, 0) < threshold}

--- a/tests/fuzz/test_grammar.py
+++ b/tests/fuzz/test_grammar.py
@@ -1,0 +1,137 @@
+"""Stage-4 grammar fuzzer smoke tests (rtl-buddy-cdc#222).
+
+Foundation surface pin: a fixed seed renders byte-identical SV /
+SDC, and the rendered case can be elaborated by Yosys without
+error. The full per-rule directional check (the grammar's analog
+of :mod:`tests.fuzz.test_mutants`) plus the cross-frontend
+differential oracle (Layer C of Stage 3) come in the integration
+PR — this file only pins the *surface* that PR builds on.
+
+Tests
+~~~~~
+
+- :func:`test_generate_is_deterministic_for_seed` — issue #222
+  Sketch point 4 (seeded reproducibility). Two calls with the
+  same seed produce byte-identical :class:`RenderedCase` SV / SDC
+  / top / params.
+- :func:`test_different_seeds_diverge` — distinct seeds produce
+  distinct SV bytes; the grammar isn't accidentally seed-
+  independent.
+- :func:`test_grammar_case_elaborates_and_runs` — the rendered case
+  flows through Yosys + the analyzer. Gated on
+  :func:`yosys_available` (skip if Yosys isn't on PATH) and the
+  ``fuzz_grammar`` marker (default ``pytest -q`` doesn't run it).
+- :func:`test_predictions_directional` — for each production
+  alone, the analyzer's actual finding set covers every rule in
+  ``Prediction.cdc_rules_added``. The xeno mutant test
+  (:mod:`tests.fuzz.test_mutants`) uses the same lax directional
+  contract — strict equality is the wrong oracle for a verdict
+  that's a delta, not a finding-set claim.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .grammar import PRODUCTIONS, generate
+from .runner import run_case
+from .yosys_cache import yosys_available
+
+pytestmark = pytest.mark.fuzz_grammar
+
+
+def test_generate_is_deterministic_for_seed() -> None:
+    """Same seed → byte-identical SV + SDC + params."""
+    case_a = generate(seed=42)
+    case_b = generate(seed=42)
+    assert case_a.sv == case_b.sv
+    assert case_a.sdc == case_b.sdc
+    assert case_a.top == case_b.top
+    assert case_a.params == case_b.params
+    assert case_a.expected == case_b.expected
+    assert case_a.forbidden == case_b.forbidden
+
+
+def test_different_seeds_diverge() -> None:
+    """Distinct seeds produce distinct SV — the grammar isn't
+    accidentally seed-independent (would silently happen if a
+    production used ``random.choice`` against module-level state
+    instead of ``ctx.rng``)."""
+    sv_bytes = {generate(seed=s).sv for s in range(8)}
+    assert len(sv_bytes) > 1, (
+        "8 distinct seeds collapsed to one SV — the grammar is "
+        "drawing from module-level random instead of ctx.rng"
+    )
+
+
+def test_n_productions_bounds() -> None:
+    """``n_productions`` argument bounds composition length —
+    coverage-steering hook (integration PR) calls this with
+    ``n_productions=1`` to isolate a single production's verdict.
+    """
+    case = generate(seed=0, n_productions=1)
+    assert len(case.params["productions"]) == 1
+
+    case = generate(seed=0, n_productions=3)
+    assert len(case.params["productions"]) == 3
+
+
+@pytest.mark.skipif(not yosys_available(), reason="yosys not on PATH")
+def test_grammar_case_elaborates_and_runs() -> None:
+    """End-to-end smoke: Yosys parses the rendered SV, the
+    analyzer runs without crashing, the expected / forbidden
+    findings hold. Tests several seeds so a single unlucky seed
+    can't false-pass via empty composition.
+    """
+    failures: list[str] = []
+    for seed in range(8):
+        case = generate(seed=seed)
+        result = run_case(case)
+        if result.failures:
+            failures.extend(
+                f"seed={seed} ({case.case_id}): {f}" for f in result.failures
+            )
+    if failures:
+        pytest.fail(
+            "grammar-rendered cases produced unexpected findings:\n  "
+            + "\n  ".join(failures)
+        )
+
+
+@pytest.mark.skipif(not yosys_available(), reason="yosys not on PATH")
+def test_predictions_directional() -> None:
+    """For each non-trivial production, generate a single-production
+    case and verify every rule in ``Prediction.cdc_rules_added``
+    actually fires.
+
+    This is the grammar's analog of :mod:`tests.fuzz.test_mutants`'
+    prediction-directional check — same lax contract (the rule
+    must fire ≥1 time) for the same reason: a verdict is a
+    direction-of-change claim, not a finding-set claim.
+    """
+    failures: list[str] = []
+    for idx, prod in enumerate(PRODUCTIONS):
+        if not prod.declared.cdc_rules_added:
+            continue
+        # Pin a per-production seed so a single failure is locally
+        # reproducible without depending on the full PRODUCTIONS
+        # ordering.
+        case = generate(
+            seed=1000 + idx,
+            productions=[prod],
+            n_productions=1,
+            top=f"fuzz_grammar_solo_{prod.name}",
+        )
+        result = run_case(case)
+        fired = {r for r, n in result.fired.items() if n > 0}
+        missing = set(prod.declared.cdc_rules_added) - fired
+        if missing:
+            failures.append(
+                f"production={prod.name}: predicted {sorted(prod.declared.cdc_rules_added)}, "
+                f"missing {sorted(missing)}, fired {sorted(fired)}"
+            )
+    if failures:
+        pytest.fail(
+            "grammar productions failed their directional prediction:\n  "
+            + "\n  ".join(failures)
+        )

--- a/tests/fuzz/test_grammar_diff.py
+++ b/tests/fuzz/test_grammar_diff.py
@@ -1,0 +1,95 @@
+"""Cross-frontend differential oracle for Stage-4 grammar cases.
+
+Closes done-when criterion 3 of rtl-buddy-cdc#222: "Generated cases
+integrate cleanly with the Stage 3 cross-frontend (``fuzz_diff``)
+oracle — agreement rate matches the hand-authored + mutated corpus
+or the divergence is explained."
+
+This module is the grammar analog of :mod:`tests.fuzz.test_corpus_diff`:
+for each grammar-generated seed, drive the SV through both the
+Yosys frontend and the slang frontend, run the rule pack on each,
+and assert the per-rule fired-count dictionaries agree.
+
+Why gate under ``fuzz_grammar`` (not ``fuzz_diff``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Stage-3 ``fuzz_diff`` selection enumerates the hand-authored
+corpus 1:1 (~330 cases × 2 frontends = ~660 elaborations); adding
+grammar cases there would inflate the selection without changing
+its semantics. Keeping the grammar-side oracle under the
+``fuzz_grammar`` marker lets the operator size the grammar
+selection independently — useful when Stage-4 productions
+multiply.
+
+Known-divergence allowlist
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Empty for now. The hand-authored corpus's slang parity gaps
+(rtl-buddy-cdc#224) all closed in Stage-3 PRs #227–229; the
+foundation productions emit SV in the same lexical idiom as those
+templates, so structural parity is expected by construction. A new
+divergence here would be either a genuine new slang gap (file
+against #224) or a production emitting SV the two frontends
+disagree on (file against the production, not the slang frontend).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .grammar import generate
+from .runner import run_case, run_case_slang
+from .slang_cache import slang_available
+from .yosys_cache import yosys_available
+
+_SEEDS = range(16)
+
+pytestmark = [
+    pytest.mark.fuzz_grammar,
+    pytest.mark.skipif(not slang_available(), reason="pyslang not importable"),
+    pytest.mark.skipif(not yosys_available(), reason="yosys not on PATH"),
+]
+
+
+@pytest.mark.parametrize("seed", _SEEDS)
+def test_grammar_frontends_agree(seed: int) -> None:
+    """Yosys and slang must produce identical fired-rule counts on
+    every grammar-generated case in :data:`_SEEDS`. Per-seed
+    parametrisation so a single divergence is locally
+    reproducible — ``pytest -k seed0`` re-runs exactly the
+    failing case.
+    """
+    case = generate(seed=seed)
+    try:
+        yosys_result = run_case(case)
+    except Exception as exc:
+        pytest.skip(f"yosys frontend failed: {exc}")
+        return
+    try:
+        slang_result = run_case_slang(case)
+    except Exception as exc:
+        # Slang correctly rejects SV that isn't legal SystemVerilog;
+        # same skip semantics tests/fuzz/test_corpus_diff.py uses.
+        pytest.skip(f"slang frontend failed: {exc}")
+        return
+
+    yosys_fired = yosys_result.fired
+    slang_fired = slang_result.fired
+    if yosys_fired == slang_fired:
+        return
+
+    all_rules = sorted(set(yosys_fired) | set(slang_fired))
+    diff_rows = [
+        f"  {r:<10} yosys={yosys_fired.get(r, 0):>3}  slang={slang_fired.get(r, 0):>3}"
+        for r in all_rules
+        if yosys_fired.get(r, 0) != slang_fired.get(r, 0)
+    ]
+    pytest.fail(
+        f"\ngrammar seed: {seed}\n"
+        f"case: {case.case_id}\n"
+        f"productions: {case.params['productions']}\n"
+        "yosys vs slang per-rule disagreement:\n" + "\n".join(diff_rows) + "\n"
+        "Either a grammar production is emitting SV the two frontends "
+        "disagree on, or a new slang-frontend parity gap (file against "
+        "rtl-buddy-cdc#224)."
+    )

--- a/tests/fuzz/test_grammar_steering.py
+++ b/tests/fuzz/test_grammar_steering.py
@@ -1,0 +1,82 @@
+"""Coverage-steering unit tests for the Stage-4 grammar fuzzer.
+
+Pure-Python tests — no Yosys, no analyzer. The steering picker is
+a static function over :data:`tests.fuzz.grammar.PRODUCTIONS` and
+the declared verdict on each production; these tests pin its
+contract independently of the elaboration pipeline so a steering
+regression surfaces in the no-yosys CI job too.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .grammar import PRODUCTIONS, productions_lifting, under_covered_rules
+
+pytestmark = pytest.mark.fuzz_grammar
+
+
+def test_productions_lifting_picks_only_declared_targets() -> None:
+    """A production is included iff its declared ``cdc_rules_added``
+    intersects the requested rule set."""
+    picks = productions_lifting({"CDC-001"})
+    assert picks, "expected at least one production to declare CDC-001"
+    for p in picks:
+        assert "CDC-001" in p.declared.cdc_rules_added
+
+    # The clean-chain production declares no added rules — it must
+    # never appear in any lifting set, regardless of which rule we
+    # ask for.
+    clean = next(p for p in PRODUCTIONS if p.name == "clean_sync_chain")
+    assert clean not in productions_lifting({"CDC-001"})
+    assert clean not in productions_lifting({"CDC-006", "RDC-001"})
+
+
+def test_productions_lifting_preserves_registry_order() -> None:
+    """Order is deterministic — the picker preserves the input
+    registry's order so consumers can rely on the bias-set being
+    stable for a fixed PRODUCTIONS tuple."""
+    target_rules = {"CDC-001", "CDC-006", "RDC-001"}
+    picks = productions_lifting(target_rules)
+    registry_index = {p.name: i for i, p in enumerate(PRODUCTIONS)}
+    indices = [registry_index[p.name] for p in picks]
+    assert indices == sorted(indices)
+
+
+def test_under_covered_rules_threshold() -> None:
+    fires = {"CDC-001": 0, "CDC-006": 5, "CDC-014": 12}
+    # With threshold=10, CDC-001 + CDC-006 are under-covered.
+    assert under_covered_rules(fires, threshold=10) == {"CDC-001", "CDC-006"}
+    # With threshold=1, only CDC-001 (zero fires) is under-covered.
+    assert under_covered_rules(fires, threshold=1) == {"CDC-001"}
+
+
+def test_under_covered_rules_universe_surfaces_zero_fire_rules() -> None:
+    """A rule absent from ``fires`` defaults to zero fires — without
+    ``rule_universe``, that rule is invisible to the picker. With
+    ``rule_universe`` containing it, it surfaces as under-covered."""
+    fires: dict[str, int] = {"CDC-001": 99}
+    universe = {"CDC-001", "CDC-002", "RDC-008"}
+    # CDC-002 and RDC-008 default to 0 fires, both below threshold 10.
+    assert under_covered_rules(fires, threshold=10, rule_universe=universe) == {
+        "CDC-002",
+        "RDC-008",
+    }
+
+
+def test_steering_round_trip() -> None:
+    """End-to-end: from a fires-counter, identify the
+    under-covered rules and ask the picker for productions that
+    would lift them. The picker must return at least one production
+    when the under-covered rule is declared by *any* production
+    in the registry — the round-trip's actionable signal."""
+    fires = {p: 0 for p in {"CDC-001", "CDC-006", "RDC-001"}}
+    targets = under_covered_rules(fires, threshold=1)
+    picks = productions_lifting(targets)
+    assert picks, "registry has productions declaring CDC-001 / CDC-006 / RDC-001"
+    declared = set()
+    for p in picks:
+        declared |= p.declared.cdc_rules_added
+    # Every requested under-covered rule is declared by at least
+    # one picked production — that's the contract steering relies on.
+    assert targets.issubset(declared)

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -1468,3 +1468,142 @@ In addition:
 The pre-built JSON fixtures are committed so the test suite doesn't
 require Yosys to be installed (the wrapper integration tests do, but
 the unit suite does not).
+
+## 15. Grammar fuzzer (Stage 4)
+
+Stage 4 (rtl-buddy-cdc#222) sits above the hand-authored corpus
+and the Stage-3 xeno mutator (Layer B of rtl-buddy-cdc#221): a
+**grammar** that emits novel topologies the corpus hasn't seen, on
+the same `RenderedCase` → Yosys / slang → analyzer pipeline the
+template-driven fuzz uses. A grammar-derived `.sv` is just another
+input to `tests.fuzz.runner.run_case` — the Yosys cache, the slang
+cache, the rule pack, and the analyzer-differential oracle all
+treat it identically to a template case.
+
+The grammar lives under `tests/fuzz/grammar/`:
+
+- `core.py` — terminal / non-terminal types, composition, top-level
+  driver.
+- `productions.py` — concrete productions (the registered
+  non-terminals).
+- `steering.py` — coverage-steering picker.
+
+### 15.1 Terminals
+
+The grammar's leaf alphabet — the things production bodies stitch
+into rendered SV:
+
+| Terminal       | Module                          | Notes                                                                          |
+| -------------- | ------------------------------- | ------------------------------------------------------------------------------ |
+| `ClockDomain`  | `grammar.core.ClockDomain`      | Name + period (ns). One `create_clock` per declared domain.                    |
+| `Port`         | `grammar.core.Port`             | Top-level module port. Inputs with a `sampling_clock` get a `set_input_delay`. |
+| Flop kind      | (open-coded inside productions) | Sync / async-reset / gated forms picked per-production.                        |
+| Comb cells     | (open-coded inside productions) | E.g. `wire comb = a & b` in `_emit_comb_source`.                               |
+| SV attributes  | (open-coded inside productions) | E.g. `(* cdc_gray *)` on the gray-counter production's net decls.              |
+| SDC clauses    | `grammar.core._render_sdc`      | `create_clock`, `set_clock_groups -asynchronous`, `set_input_delay`.           |
+
+Flop kinds, comb cells, and SV attributes are open-coded inside
+each production today rather than promoted to typed terminals.
+Promotion is a follow-up if a future production needs to *parametrise*
+over them (e.g. a flop-kind sweep) — until then the per-production
+literal SV stays the cheapest representation.
+
+### 15.2 Non-terminals (productions)
+
+A `Production` is `(name, emit, declared)`. `emit(ctx) -> Fragment`
+generates the SV bits; `declared: Prediction` is the production's
+static verdict — the rule ids it claims to lift, mirroring xeno's
+`Prediction.cdc_rules_added` / `cdc_rules_removed` shape so the
+coverage-steering picker can reason about productions and mutant
+operators uniformly.
+
+| Production              | Declared `cdc_rules_added` | Non-terminal class issue #222 calls out |
+| ----------------------- | -------------------------- | --------------------------------------- |
+| `clean_sync_chain`      | (empty)                    | sync chain (clean reference)            |
+| `unsynced_single_bit`   | `{CDC-001}`                | sync chain (negative — depth=0)         |
+| `comb_source`           | `{CDC-006}`                | comb source                             |
+| `gray_counter_crossing` | (empty)                    | gray counter                            |
+| `missing_reset_sync`    | `{RDC-001}`                | reset-sync chain                        |
+
+`handshake req/ack pair` and `FIFO read/write skeleton` are
+deferred (issue #222 closes them as the grammar matures).
+
+### 15.3 Composition
+
+`compose(productions, ctx)` is the driver. Each production is
+emitted independently — there is no signal-threading between
+productions, so a case with two productions becomes one module
+with two parallel crossing sites. The composed `Fragment` carries
+the union of all production SV (decls + always_blocks + assigns +
+ports + clocks), and the verdict is `Prediction.merge`-folded
+across the chosen productions.
+
+`Prediction.merge` is *removed-wins*: a production introducing a
+finding (e.g. an unsynced crossing → CDC-001) combined with one
+silencing it (e.g. a hypothetical `cdc_sync_attribute_blanket`
+that strips the rule globally) leaves the rule out of the combined
+`cdc_rules_added`. Today's productions don't use `cdc_rules_removed`
+— union math is trivially additive — but the merge contract is
+fixed so future silencing productions don't have to re-design the
+composition rule.
+
+### 15.4 Generation
+
+`generate(seed)` is the public entry point. Deterministic given
+the seed (and the production registry) — same seed always
+produces byte-identical SV / SDC / params. This is the
+reproducibility property issue #222 Sketch point 4 calls out;
+`tests/fuzz/test_grammar.py::test_generate_is_deterministic_for_seed`
+pins it.
+
+Defaults: `n_productions = rng.randint(2, 4)`. Productions are
+sampled uniformly from the registry. Coverage steering (next
+section) passes a filtered subset to bias generation.
+
+### 15.5 Coverage steering
+
+`grammar.steering` is the loop that closes corpus growth ↔ coverage
+gain. Two functions:
+
+- `under_covered_rules(fires, threshold, rule_universe=None)` —
+  given a per-rule fires counter and a threshold, return the
+  rules whose fire count is below it. Pass `rule_universe =
+  set(rules.RULES)` to surface zero-fire rules too.
+- `productions_lifting(rule_ids)` — given a set of rules, return
+  the productions whose `declared.cdc_rules_added` intersects
+  them. Pass the result back to `generate(productions=...)` to
+  bias the picker.
+
+The `tests/fuzz/coverage.py` report surfaces *steerable rules*:
+rules with zero fires in the uniform-pass grammar column but at
+least one production declaring them. That's the actionable
+signal — re-run a steered batch to lift them.
+
+### 15.6 Adding a non-terminal
+
+A future engineer wanting to add (e.g.) a credit-based
+flow-control wrapper:
+
+1. Add a private `_emit_credit_handshake(ctx) -> Fragment`
+   function in `productions.py`. The function builds SV strings
+   via `ctx.uniq("credit")` for unique signal names, declares
+   any new ports / clocks it needs, and packs them into a
+   `Fragment` alongside its `Prediction` delta.
+2. Append a `Production("credit_handshake", _emit_credit_handshake,
+   declared=Prediction(cdc_rules_added=frozenset({...})))` row
+   to the `PRODUCTIONS` tuple.
+3. The coverage report's steering hints will surface the new
+   production's declared rules automatically; no change to the
+   report or the steering picker is required. The directional
+   check in `tests/fuzz/test_grammar.py::test_predictions_directional`
+   parametrises over `PRODUCTIONS`, so the new production gets
+   its own per-rule assertion for free.
+
+### 15.7 Cross-frontend differential
+
+Grammar cases run through the same Yosys / slang oracle the
+hand-authored corpus uses (Stage-3 Layer C of rtl-buddy-cdc#221).
+The grammar-side test lives in `tests/fuzz/test_grammar_diff.py`
+under the `fuzz_grammar` marker (not `fuzz_diff`) so the grammar
+selection can be sized independently as the production registry
+grows.


### PR DESCRIPTION
## Summary

- `coverage.py` gains a 4th `grammar` column (32-seed uniform pass) plus a "Steerable rules" hint section: rules with zero grammar fires that ≥1 production declares lifting — the actionable steering signal.
- `grammar.steering` exposes `productions_lifting()` and `under_covered_rules()`, the picker round-trip the report's hint uses.
- `test_grammar_diff.py` runs the Stage-3 Layer C oracle (Yosys vs slang per-rule equality) over grammar cases, gated under `fuzz_grammar`.
- Architecture spec §15 documents grammar terminals, non-terminals, composition, generation, steering, and the "adding a non-terminal" recipe.

## Stacked on the foundation PR

Built on top of `feat/stage4-grammar-foundation` (rtl-buddy-cdc#234). This PR targets `main` per the workspace's stacked-PR convention; the diff shown here includes the foundation commit until #234 merges, at which point this branch rebases onto main and the diff cleans up to just the integration changes (~500 lines).

## Done-when (rtl-buddy-cdc#222 criteria progress)

- [x] **#3 fuzz_diff integration** — 16 seeds × Yosys+slang in `test_grammar_diff.py`, agreement asserted per rule. Allowlist empty (no known divergences).
- [x] **#4 spec documents productions** — architecture spec §15 covers terminals/non-terminals/composition/steering plus the "adding a non-terminal" recipe.
- Foundation pieces for **#1 (rate)** and **#2 (new gap)**: the coverage report's steerable-rules section is the actionable signal a gap-mining run watches; the rate side trivially satisfies (~30 ms / case via the Yosys cache, ≫ ≥N/min for any plausible N).

## Test plan

- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` clean
- [x] `uv run pytest -q` → 1412 passed (no regression)
- [x] `uv run pytest -m fuzz -q` → 508 passed (existing fuzz selection unchanged)
- [x] `uv run pytest -m fuzz_diff -q` → 330 passed (cross-frontend oracle unchanged)
- [x] `uv run pytest -m fuzz_grammar -v` → 26 passed (5 existing + 16 cross-frontend + 5 steering)
- [x] `uv run python -m tests.fuzz.coverage` prints the 4-column report; grammar column shows CDC-001=12, CDC-006=22, RDC-001=21 fires across the 32 seeds (matches the productions' declared verdicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)