### PR TITLE
Raise test coverage 84% → 93%, ratchet gate to 90%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,16 +41,27 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
-      - name: Install test dependencies (with [slang] extra)
-        run: uv sync --extra slang --group test --python ${{ matrix.python-version }}
+      - name: Install test dependencies (with [slang] + [hints] extras)
+        # [hints] pulls in PyYAML so the reset-hints YAML loader
+        # (reset_hints.py) is exercised under coverage instead of
+        # skipping — the coverage gate below counts those paths.
+        run: uv sync --extra slang --extra hints --group test --python ${{ matrix.python-version }}
 
       # Pass `--python` to `uv run` too — without it, uv re-resolves the
       # venv against `.python-version` (3.13), wipes the matrix-specific
       # env from the previous step, and ends up running every matrix
       # entry on 3.13 with pyslang silently absent. Surfaced by the
       # coverage gate in #120 / #121.
+      #
+      # ``--cov-fail-under=90``: the coverage ratchet. Raised from 78
+      # once the per-module test sweep (tests/test_cov_*.py) brought
+      # the analyzer + frontends + reporter + CLI to ≥90% line+branch.
+      # The number is measured WITHOUT yosys/iverilog (the fuzz / sim
+      # selections skip in this job), so it reflects exactly what this
+      # job exercises — pyslang elaboration, committed-JSON fixtures,
+      # and CliRunner-driven flows.
       - name: Run pytest (with coverage)
-        run: uv run --python ${{ matrix.python-version }} pytest --cov --cov-report=term-missing --cov-fail-under=78
+        run: uv run --python ${{ matrix.python-version }} pytest --cov --cov-report=term-missing --cov-fail-under=90
 
   # Companion job: install WITHOUT the [slang] extra to verify the
   # AGENTS.md "default install stays typer-only" promise. Specifically

--- a/tests/test_cov_cli.py
+++ b/tests/test_cov_cli.py
@@ -1,0 +1,863 @@
+"""CLI coverage tests for ``rtl_buddy_cdc.cli`` driven through ``CliRunner``.
+
+These exercise the Typer command surface end-to-end without ever invoking
+a real Yosys binary: the ``analyze`` path consumes committed Yosys-JSON
+fixtures, ``lint`` runs the pyslang frontend on tmp ``.sv`` files, and the
+frontend-failure branches are reached by monkeypatching the ``elaborate``
+factory the CLI imported (so no toolchain is needed to drive exit code 2).
+
+Every assertion pins observable CLI behaviour: rendered report substrings,
+parsed JSON/SARIF payloads, emitted map files, stderr diagnostics, and the
+process exit codes the downstream ``rtl_buddy`` wrapper keys off (0 clean,
+1 at least one unsuppressed violation, 2 frontend/loader failure).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import rtl_buddy_cdc.cli as cli_mod
+from rtl_buddy_cdc.cli import app
+from rtl_buddy_cdc.frontends.slang import SlangFrontendUnavailable
+from rtl_buddy_cdc.frontends.yosys import YosysError
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+PYYAML_INSTALLED = importlib.util.find_spec("yaml") is not None
+
+runner = CliRunner()
+
+FIX = Path(__file__).parent / "fixtures"
+
+# bad_single_ff_sync: exactly one CDC-001 error → exit 1.
+_BAD_DIR = FIX / "bad_single_ff_sync"
+_BAD_JSON = _BAD_DIR / "bad_single_ff_sync.json"
+_BAD_SDC = _BAD_DIR / "bad_single_ff_sync.sdc"
+
+# good_reset_sync: fully clean fixture (no violations) → exit 0.
+_CLEAN_DIR = FIX / "good_reset_sync"
+_CLEAN_JSON = _CLEAN_DIR / "good_reset_sync.json"
+_CLEAN_SDC = _CLEAN_DIR / "good_reset_sync.sdc"
+
+# good_2ff_sync: silent at depth 2, fires one CDC-002 warning at depth 3.
+_2FF_DIR = FIX / "good_2ff_sync"
+_2FF_JSON = _2FF_DIR / "good_2ff_sync.json"
+_2FF_SDC = _2FF_DIR / "good_2ff_sync.sdc"
+
+# good_exclusive_clock_mux: async + physically_exclusive — the crossing
+# is dropped as unreachable by _filter_async before rule checks.
+_EXCL_DIR = FIX / "good_exclusive_clock_mux"
+_EXCL_JSON = _EXCL_DIR / "good_exclusive_clock_mux.json"
+_EXCL_SDC = _EXCL_DIR / "good_exclusive_clock_mux.sdc"
+
+
+def _skip_if_missing(*paths: Path) -> None:
+    for p in paths:
+        if not p.exists():
+            pytest.skip(f"fixture not built: {p}")
+
+
+# --- analyze: output formats -------------------------------------------------
+
+
+def test_analyze_text_format_reports_violation_and_exits_1() -> None:
+    """Default text format on a bad fixture renders the CDC-001 finding,
+    a FAIL banner, and exits 1 (one unsuppressed violation)."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    result = runner.invoke(app, ["analyze", "-n", str(_BAD_JSON), "-s", str(_BAD_SDC)])
+    assert result.exit_code == 1
+    assert "CDC-001" in result.stdout
+    assert "FAIL" in result.stdout
+
+
+def test_analyze_json_format_to_stdout() -> None:
+    """``--format json`` emits a parseable payload whose summary counts
+    the single violation; exit code 1."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    result = runner.invoke(
+        app,
+        ["analyze", "-n", str(_BAD_JSON), "-s", str(_BAD_SDC), "--format", "json"],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["module"] == "bad_single_ff_sync"
+    assert payload["summary"]["violations"] == 1
+    assert payload["violations"][0]["rule_id"] == "CDC-001"
+
+
+def test_analyze_sarif_format_to_stdout() -> None:
+    """``--format sarif`` (cli.py line 736-737) emits SARIF 2.1.0 with the
+    CDC-001 result mapped to ``level: error``."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    result = runner.invoke(
+        app,
+        ["analyze", "-n", str(_BAD_JSON), "-s", str(_BAD_SDC), "-f", "sarif"],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["version"] == "2.1.0"
+    results = payload["runs"][0]["results"]
+    assert [r["ruleId"] for r in results] == ["CDC-001"]
+    assert results[0]["level"] == "error"
+
+
+def test_analyze_output_to_file_forces_color_off(tmp_path: Path) -> None:
+    """``--output FILE`` for the text format writes the report to disk
+    with color forced off (no ANSI escapes), per cli.py's file branch."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    out = tmp_path / "report.txt"
+    result = runner.invoke(
+        app, ["analyze", "-n", str(_BAD_JSON), "-s", str(_BAD_SDC), "-o", str(out)]
+    )
+    assert result.exit_code == 1
+    text = out.read_text()
+    assert "CDC-001" in text
+    assert "\x1b[" not in text  # color suppressed when writing to a file
+
+
+def test_analyze_json_output_to_file(tmp_path: Path) -> None:
+    """``--format json --output FILE`` closes the file handle and writes
+    valid JSON (exercises the close_after branch)."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    out = tmp_path / "report.json"
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "-f",
+            "json",
+            "-o",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(out.read_text())
+    assert payload["summary"]["violations"] == 1
+
+
+# --- analyze: exit codes -----------------------------------------------------
+
+
+def test_analyze_clean_fixture_exits_0() -> None:
+    """A fixture with no rule violations exits 0 and renders PASS."""
+    _skip_if_missing(_CLEAN_JSON, _CLEAN_SDC)
+    result = runner.invoke(
+        app, ["analyze", "-n", str(_CLEAN_JSON), "-s", str(_CLEAN_SDC)]
+    )
+    assert result.exit_code == 0
+    assert "PASS" in result.stdout
+    assert "No rule violations" in result.stdout
+
+
+def test_analyze_no_sdc_skips_rule_checks(tmp_path: Path) -> None:
+    """Without ``--sdc`` the analyzer takes the else-branch (cli.py
+    597-598): it still assigns domains and finds crossings but runs no
+    rules, so the exit code is 0 even on a fixture that would fail with
+    its SDC."""
+    _skip_if_missing(_BAD_JSON)
+    out = tmp_path / "report.json"
+    result = runner.invoke(
+        app, ["analyze", "-n", str(_BAD_JSON), "-f", "json", "-o", str(out)]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(out.read_text())
+    assert payload["summary"]["violations"] == 0
+
+
+def test_analyze_missing_netlist_is_usage_error() -> None:
+    """A nonexistent ``--netlist`` is rejected by Typer's ``exists=True``
+    before any analysis runs — exit code 2 (usage error)."""
+    result = runner.invoke(app, ["analyze", "-n", "/no/such/netlist.json"])
+    assert result.exit_code == 2
+
+
+def test_analyze_missing_required_netlist_is_usage_error() -> None:
+    """Omitting the required ``--netlist`` option is a usage error (2)."""
+    result = runner.invoke(app, ["analyze", "-s", str(_BAD_SDC)])
+    assert result.exit_code == 2
+
+
+def test_analyze_exclusive_clock_groups_drops_unreachable_crossing() -> None:
+    """A crossing whose roots are in different exclusive clock groups is
+    unreachable at runtime; ``_filter_async`` skips it (cli.py 800) before
+    rule checks, so this otherwise-async pair is clean → exit 0."""
+    _skip_if_missing(_EXCL_JSON, _EXCL_SDC)
+    result = runner.invoke(
+        app, ["analyze", "-n", str(_EXCL_JSON), "-s", str(_EXCL_SDC), "-f", "json"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    # The structural crossing is detected but dropped from the async set
+    # the rule pack sees — no violations fire.
+    assert payload["summary"]["violations"] == 0
+    assert payload["summary"]["async_crossings"] == 0
+
+
+# --- analyze: flags ----------------------------------------------------------
+
+
+def test_analyze_sync_depth_raises_cdc_002() -> None:
+    """``--sync-depth 3`` promotes the textbook 2FF chain into a CDC-002
+    warning that the depth-2 default keeps silent — exit 1."""
+    _skip_if_missing(_2FF_JSON, _2FF_SDC)
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_2FF_JSON),
+            "-s",
+            str(_2FF_SDC),
+            "--sync-depth",
+            "3",
+            "-f",
+            "json",
+        ],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    cdc_002 = [v for v in payload["violations"] if v["rule_id"] == "CDC-002"]
+    assert len(cdc_002) == 1
+    assert cdc_002[0]["severity"] == "warning"
+
+
+def test_analyze_sync_depth_default_is_silent() -> None:
+    """At the default ``--sync-depth 2`` the 2FF fixture is clean (0)."""
+    _skip_if_missing(_2FF_JSON, _2FF_SDC)
+    result = runner.invoke(app, ["analyze", "-n", str(_2FF_JSON), "-s", str(_2FF_SDC)])
+    assert result.exit_code == 0
+
+
+def test_analyze_sync_depth_below_min_is_rejected() -> None:
+    """``--sync-depth 1`` violates the ``min=2`` constraint — usage error."""
+    result = runner.invoke(
+        app,
+        ["analyze", "-n", str(_BAD_JSON), "-s", str(_BAD_SDC), "--sync-depth", "1"],
+    )
+    assert result.exit_code == 2
+
+
+def test_analyze_strict_promotes_warning_to_error() -> None:
+    """``--strict`` reframes the CDC-002 warning as an error in the JSON
+    payload; the exit code stays 1 (the finding already drove it)."""
+    _skip_if_missing(_2FF_JSON, _2FF_SDC)
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_2FF_JSON),
+            "-s",
+            str(_2FF_SDC),
+            "--sync-depth",
+            "3",
+            "--strict",
+            "-f",
+            "json",
+        ],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    cdc_002 = [v for v in payload["violations"] if v["rule_id"] == "CDC-002"]
+    assert len(cdc_002) == 1
+    assert cdc_002[0]["severity"] == "error"
+
+
+def test_analyze_verbose_emits_crossing_listing() -> None:
+    """``--verbose`` adds the per-crossing structural listing to the text
+    report (a section the default report omits)."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    plain = runner.invoke(app, ["analyze", "-n", str(_BAD_JSON), "-s", str(_BAD_SDC)])
+    verbose = runner.invoke(
+        app, ["analyze", "-n", str(_BAD_JSON), "-s", str(_BAD_SDC), "--verbose"]
+    )
+    assert verbose.exit_code == 1
+    # The verbose report is strictly longer — it carries extra framing the
+    # plain report does not.
+    assert len(verbose.stdout) > len(plain.stdout)
+    assert "Crossings" in verbose.stdout
+
+
+def test_analyze_waivers_suppress_violation(tmp_path: Path) -> None:
+    """A matching waiver moves the CDC-001 finding to the suppressed
+    bucket: the kept count drops to 0 and the exit code falls to 0
+    (waived findings don't fail the run)."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    waivers = tmp_path / "cdc.waivers"
+    waivers.write_text("waive CDC-001 .* reviewed\n")
+    out = tmp_path / "report.json"
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "-w",
+            str(waivers),
+            "-f",
+            "json",
+            "-o",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(out.read_text())
+    assert payload["summary"]["violations"] == 0
+    assert payload["summary"]["suppressed"] == 1
+    assert payload["suppressed"][0]["rule_id"] == "CDC-001"
+
+
+def test_analyze_missing_waivers_file_is_usage_error() -> None:
+    """A nonexistent ``--waivers`` path is rejected by Typer (exit 2)."""
+    result = runner.invoke(
+        app,
+        ["analyze", "-n", str(_BAD_JSON), "-s", str(_BAD_SDC), "-w", "/no/waivers"],
+    )
+    assert result.exit_code == 2
+
+
+# --- analyze: SDC clock-graph partial warnings (cli.py 571-573) --------------
+
+
+def test_analyze_emits_clock_graph_warning_on_shared_port(tmp_path: Path) -> None:
+    """When the SDC declares the same top-level port under two clock
+    names, ``validate_clock_graph`` flags it and the CLI surfaces a
+    ``warning:`` diagnostic on stderr (cli.py 571-573) for the text
+    format. The diagnostic is emitted regardless of the final exit
+    code; assert on the warning content, not the code."""
+    _skip_if_missing(_CLEAN_JSON)
+    # good_reset_sync declares src_clk + dst_clk; additionally claim the
+    # data port d_in under two clock names to force the
+    # same-port-multiple-clocks diagnostic without removing the real
+    # async grouping.
+    sdc = tmp_path / "ambiguous.sdc"
+    sdc.write_text(
+        "create_clock -name src_clk -period 10 [get_ports src_clk]\n"
+        "create_clock -name dst_clk -period 7.5 [get_ports dst_clk]\n"
+        "create_clock -name ghost_a -period 10 [get_ports d_in]\n"
+        "create_clock -name ghost_b -period 10 [get_ports d_in]\n"
+        "set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}\n"
+    )
+    result = runner.invoke(app, ["analyze", "-n", str(_CLEAN_JSON), "-s", str(sdc)])
+    # CliRunner mixes stderr into .output by default.
+    assert "warning:" in result.output
+    assert "claimed by multiple clocks" in result.output
+
+
+# --- analyze: --emit-domain-map / --emit-reset-domain-map / --no-findings ----
+
+
+def test_analyze_emit_domain_map_no_findings(tmp_path: Path) -> None:
+    """``--emit-domain-map`` with ``--no-findings`` (cli.py 669-685, 718)
+    writes a v1.0 clock-domain map and suppresses the normal report,
+    exiting 0 on successful emission."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    map_path = tmp_path / "domain_map.json"
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "--emit-domain-map",
+            str(map_path),
+            "--no-findings",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == ""  # report suppressed
+    payload = json.loads(map_path.read_text())
+    assert payload["schema_version"].startswith("1.")
+    assert "clocks" in payload
+    assert "flop_domains" in payload
+
+
+def test_analyze_emit_reset_domain_map(tmp_path: Path) -> None:
+    """``--emit-reset-domain-map`` (cli.py 688-712) writes a v1.0 reset
+    map alongside the run. Combined with ``--no-findings`` for a
+    map-only run (exit 0)."""
+    _skip_if_missing(_CLEAN_JSON, _CLEAN_SDC)
+    map_path = tmp_path / "reset_map.json"
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_CLEAN_JSON),
+            "-s",
+            str(_CLEAN_SDC),
+            "--emit-reset-domain-map",
+            str(map_path),
+            "--no-findings",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(map_path.read_text())
+    assert payload["schema_version"].startswith("1.")
+    # Reset map carries flop reset assignments distinct from the clock map.
+    assert "reset_domains" in payload or "flop_resets" in payload or payload
+
+
+def test_analyze_emit_both_maps_in_one_run(tmp_path: Path) -> None:
+    """Both ``--emit-domain-map`` and ``--emit-reset-domain-map`` can be
+    passed together; each writes its own file."""
+    _skip_if_missing(_CLEAN_JSON, _CLEAN_SDC)
+    dmap = tmp_path / "d.json"
+    rmap = tmp_path / "r.json"
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_CLEAN_JSON),
+            "-s",
+            str(_CLEAN_SDC),
+            "--emit-domain-map",
+            str(dmap),
+            "--emit-reset-domain-map",
+            str(rmap),
+            "--no-findings",
+        ],
+    )
+    assert result.exit_code == 0
+    assert json.loads(dmap.read_text())["schema_version"].startswith("1.")
+    assert json.loads(rmap.read_text())["schema_version"].startswith("1.")
+
+
+def test_analyze_emit_domain_map_without_sdc(tmp_path: Path) -> None:
+    """``--emit-domain-map`` works with no SDC (spec is None) — the
+    clock_network crossing helper is called with ``clock_for_port=None``
+    (cli.py 672)."""
+    _skip_if_missing(_CLEAN_JSON)
+    map_path = tmp_path / "d.json"
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_CLEAN_JSON),
+            "--emit-domain-map",
+            str(map_path),
+            "--no-findings",
+        ],
+    )
+    assert result.exit_code == 0
+    assert json.loads(map_path.read_text())["schema_version"].startswith("1.")
+
+
+# --- analyze: --reset-hints loader error paths (cli.py 549-554) --------------
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_analyze_reset_hints_malformed_exits_2(tmp_path: Path) -> None:
+    """A malformed ``--reset-hints`` YAML (unknown key) fails the run
+    before analysis with exit code 2 and a ``error:`` diagnostic
+    (cli.py 552-554, ResetHintsError branch)."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    hints = tmp_path / "hints.yaml"
+    hints.write_text("reset-hints:\n  totally_bogus_key: 1\n")
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "--reset-hints",
+            str(hints),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "error:" in result.output
+    assert "unknown key" in result.output
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_analyze_reset_hints_valid_runs(tmp_path: Path) -> None:
+    """A well-formed ``--reset-hints`` file is accepted and the run
+    proceeds normally (the loader returns ResetHints; cli.py 548)."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    hints = tmp_path / "hints.yaml"
+    hints.write_text(
+        "reset-hints:\n"
+        '  schema_version: "1.0"\n'
+        "  ports:\n"
+        "    - name: rst_n\n"
+        "      polarity: low\n"
+    )
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "--reset-hints",
+            str(hints),
+            "-f",
+            "json",
+        ],
+    )
+    # bad_single_ff_sync still fires CDC-001 regardless of reset hints.
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["violations"] == 1
+
+
+# --- analyze: --baseline -----------------------------------------------------
+
+
+def test_analyze_baseline_carryover_drops_exit_code(tmp_path: Path) -> None:
+    """Re-running with the prior JSON report as ``--baseline`` moves the
+    finding to the carryover tally — kept count 0, exit code 0."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    baseline = tmp_path / "baseline.json"
+    first = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "-f",
+            "json",
+            "-o",
+            str(baseline),
+        ],
+    )
+    assert first.exit_code == 1
+    out = tmp_path / "second.json"
+    second = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "-f",
+            "json",
+            "-o",
+            str(out),
+            "--baseline",
+            str(baseline),
+        ],
+    )
+    assert second.exit_code == 0
+    payload = json.loads(out.read_text())
+    assert payload["summary"]["violations"] == 0
+    assert payload["summary"]["baseline_carryover"] == 1
+
+
+def test_analyze_baseline_non_matching_keeps_finding(tmp_path: Path) -> None:
+    """A baseline that lists only a DIFFERENT finding leaves the current
+    CDC-001 in the kept set (cli.py 616, the ``kept.append`` branch) —
+    the filter is exact-match on (rule_id, cell_name, message), so the
+    exit code stays 1."""
+    _skip_if_missing(_BAD_JSON, _BAD_SDC)
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "violations": [
+                    {
+                        "rule_id": "CDC-999",
+                        "cell_name": "ghost",
+                        "message": "phantom finding from another design",
+                    }
+                ]
+            }
+        )
+    )
+    out = tmp_path / "report.json"
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "-f",
+            "json",
+            "-o",
+            str(out),
+            "--baseline",
+            str(baseline),
+        ],
+    )
+    assert result.exit_code == 1
+    payload = json.loads(out.read_text())
+    assert payload["summary"]["violations"] == 1
+    assert payload["summary"]["baseline_carryover"] == 0
+
+
+def test_analyze_missing_baseline_file_is_usage_error() -> None:
+    """A nonexistent ``--baseline`` path is rejected by Typer (exit 2)."""
+    result = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_BAD_JSON),
+            "-s",
+            str(_BAD_SDC),
+            "--baseline",
+            "/no/b.json",
+        ],
+    )
+    assert result.exit_code == 2
+
+
+# --- lint (slang frontend, no yosys) -----------------------------------------
+
+
+def _write_cdc_design(tmp_path: Path) -> tuple[Path, Path]:
+    """A two-domain single-FF design (fires CDC-001) plus its async SDC."""
+    sv = tmp_path / "m.sv"
+    sv.write_text(
+        "module m (input logic clk_a, clk_b, rst_n, d, output logic q);\n"
+        "  logic a;\n"
+        "  always_ff @(posedge clk_a or negedge rst_n)\n"
+        "    if (!rst_n) a <= 0; else a <= d;\n"
+        "  always_ff @(posedge clk_b or negedge rst_n)\n"
+        "    if (!rst_n) q <= 0; else q <= a;\n"
+        "endmodule\n"
+    )
+    sdc = tmp_path / "m.sdc"
+    sdc.write_text(
+        "create_clock -name clk_a -period 10 [get_ports clk_a]\n"
+        "create_clock -name clk_b -period 7 [get_ports clk_b]\n"
+        "set_clock_groups -asynchronous -group {clk_a} -group {clk_b}\n"
+        # Constrain the data input so only CDC-001 fires (no CDC-011
+        # unconstrained-input noise).
+        "set_input_delay -clock clk_a 1.0 [get_ports d]\n"
+    )
+    return sv, sdc
+
+
+@pytest.mark.skipif(not PYSLANG_INSTALLED, reason="pyslang not installed")
+def test_lint_slang_text_preamble_and_violation(tmp_path: Path) -> None:
+    """``lint --frontend slang`` elaborates via pyslang (no yosys), emits
+    the human-readable preamble (``frontend: slang`` / ``top:`` / ``src:``,
+    cli.py 325-334) and fires CDC-001 → exit 1."""
+    sv, sdc = _write_cdc_design(tmp_path)
+    result = runner.invoke(
+        app, ["lint", str(sv), "--top", "m", "--frontend", "slang", "-s", str(sdc)]
+    )
+    assert result.exit_code == 1
+    assert "frontend: slang" in result.stdout
+    assert "top:      m" in result.stdout
+    assert f"src:      {sv}" in result.stdout
+    assert "CDC-001" in result.stdout
+
+
+@pytest.mark.skipif(not PYSLANG_INSTALLED, reason="pyslang not installed")
+def test_lint_auto_frontend_preamble_marks_auto(tmp_path: Path) -> None:
+    """``--frontend auto`` resolves to slang when pyslang is importable and
+    the preamble tags it ``(auto)`` (cli.py 328-329)."""
+    sv, sdc = _write_cdc_design(tmp_path)
+    result = runner.invoke(
+        app, ["lint", str(sv), "--top", "m", "--frontend", "auto", "-s", str(sdc)]
+    )
+    assert result.exit_code == 1
+    assert "frontend: slang (auto)" in result.stdout
+
+
+@pytest.mark.skipif(not PYSLANG_INSTALLED, reason="pyslang not installed")
+def test_lint_slang_json_has_no_preamble(tmp_path: Path) -> None:
+    """For structured output the preamble is suppressed (cli.py 325 guard)
+    — the JSON payload parses cleanly with no leading ``frontend:`` line."""
+    sv, sdc = _write_cdc_design(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "lint",
+            str(sv),
+            "--top",
+            "m",
+            "--frontend",
+            "slang",
+            "-s",
+            str(sdc),
+            "-f",
+            "json",
+        ],
+    )
+    assert result.exit_code == 1
+    assert not result.stdout.lstrip().startswith("frontend:")
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["violations"] == 1
+
+
+def test_lint_missing_source_is_usage_error() -> None:
+    """A nonexistent source file is rejected by Typer's ``exists=True``
+    on the positional argument — exit 2."""
+    result = runner.invoke(
+        app, ["lint", "/no/such/file.sv", "--top", "m", "--frontend", "slang"]
+    )
+    assert result.exit_code == 2
+
+
+# --- lint frontend-failure branches (cli.py 345-355) -------------------------
+#
+# These reach the except-handlers without a real toolchain by patching the
+# ``elaborate`` symbol the CLI module imported, so each handler's exit
+# code (2) and stderr framing are pinned independent of pyslang/yosys.
+
+
+def test_lint_slang_unavailable_exits_2(tmp_path: Path, monkeypatch) -> None:
+    """When ``elaborate`` raises ``SlangFrontendUnavailable`` the lint
+    command prints ``error:`` to stderr and exits 2 (cli.py 345-347)."""
+    sv, sdc = _write_cdc_design(tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise SlangFrontendUnavailable("pyslang missing for test")
+
+    monkeypatch.setattr(cli_mod, "elaborate", _boom)
+    result = runner.invoke(
+        app, ["lint", str(sv), "--top", "m", "--frontend", "slang", "-s", str(sdc)]
+    )
+    assert result.exit_code == 2
+    assert "error: pyslang missing for test" in result.output
+
+
+def test_lint_yosys_error_exits_2(tmp_path: Path, monkeypatch) -> None:
+    """A ``YosysError`` from ``elaborate`` maps to exit 2 with ``error:``
+    framing (cli.py 348-350)."""
+    sv, sdc = _write_cdc_design(tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise YosysError("yosys blew up for test")
+
+    monkeypatch.setattr(cli_mod, "elaborate", _boom)
+    result = runner.invoke(
+        app, ["lint", str(sv), "--top", "m", "--frontend", "slang", "-s", str(sdc)]
+    )
+    assert result.exit_code == 2
+    assert "error: yosys blew up for test" in result.output
+
+
+def test_lint_not_implemented_exits_2(tmp_path: Path, monkeypatch) -> None:
+    """A ``NotImplementedError`` from a stub frontend maps to exit 2
+    (cli.py 351-355) — a distinct signal from a missing-binary failure."""
+    sv, sdc = _write_cdc_design(tmp_path)
+
+    def _boom(*args, **kwargs):
+        raise NotImplementedError("frontend stub for test")
+
+    monkeypatch.setattr(cli_mod, "elaborate", _boom)
+    result = runner.invoke(
+        app, ["lint", str(sv), "--top", "m", "--frontend", "slang", "-s", str(sdc)]
+    )
+    assert result.exit_code == 2
+    assert "error: frontend stub for test" in result.output
+
+
+# --- render (pure transform over an emitted domain map) ----------------------
+
+
+def test_render_mermaid_from_emitted_map(tmp_path: Path) -> None:
+    """End-to-end: emit a domain map then ``render`` it to a mermaid
+    fenced block written to ``--output``."""
+    _skip_if_missing(_CLEAN_JSON, _CLEAN_SDC)
+    map_path = tmp_path / "d.json"
+    emit = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_CLEAN_JSON),
+            "-s",
+            str(_CLEAN_SDC),
+            "--emit-domain-map",
+            str(map_path),
+            "--no-findings",
+        ],
+    )
+    assert emit.exit_code == 0
+    out = tmp_path / "diagram.md"
+    result = runner.invoke(app, ["render", "--map", str(map_path), "-o", str(out)])
+    assert result.exit_code == 0
+    diagram = out.read_text()
+    assert diagram.startswith("```mermaid")
+    assert "flowchart LR" in diagram
+
+
+def test_render_mermaid_to_stdout(tmp_path: Path) -> None:
+    """Without ``--output`` the mermaid diagram is written to stdout
+    (cli.py render's ``output_path is None`` branch, line 438)."""
+    _skip_if_missing(_CLEAN_JSON, _CLEAN_SDC)
+    map_path = tmp_path / "d.json"
+    emit = runner.invoke(
+        app,
+        [
+            "analyze",
+            "-n",
+            str(_CLEAN_JSON),
+            "-s",
+            str(_CLEAN_SDC),
+            "--emit-domain-map",
+            str(map_path),
+            "--no-findings",
+        ],
+    )
+    assert emit.exit_code == 0
+    result = runner.invoke(app, ["render", "--map", str(map_path)])
+    assert result.exit_code == 0
+    assert result.stdout.startswith("```mermaid")
+
+
+def test_render_invalid_json_exits_1(tmp_path: Path) -> None:
+    """A ``--map`` file that isn't valid JSON yields exit 1 with a
+    ``not valid JSON`` diagnostic (cli.py render JSONDecodeError branch)."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ this is not json")
+    result = runner.invoke(app, ["render", "--map", str(bad)])
+    assert result.exit_code == 1
+    assert "not valid JSON" in result.output
+
+
+def test_render_well_formed_but_invalid_map_exits_1(tmp_path: Path) -> None:
+    """Valid JSON that isn't a v1.0 domain map trips ``RenderError`` →
+    exit 1 (cli.py render RenderError branch)."""
+    empty = tmp_path / "empty.json"
+    empty.write_text("{}")
+    result = runner.invoke(app, ["render", "--map", str(empty)])
+    assert result.exit_code == 1
+    assert "error:" in result.output
+
+
+def test_render_missing_map_is_usage_error() -> None:
+    """A nonexistent ``--map`` path is rejected by Typer (exit 2)."""
+    result = runner.invoke(app, ["render", "--map", "/no/such/map.json"])
+    assert result.exit_code == 2
+
+
+# --- version -----------------------------------------------------------------
+
+
+def test_version_reports_tool_and_yosys_status() -> None:
+    """``version`` always prints the tool line, a yosys status line (the
+    binary is absent in CI so it reads ``not found``), and a pyslang
+    status line."""
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert "rtl-buddy-cdc" in result.stdout
+    assert "yosys" in result.stdout
+    assert "pyslang:" in result.stdout

--- a/tests/test_cov_clock_pulse.py
+++ b/tests/test_cov_clock_pulse.py
@@ -1,0 +1,924 @@
+"""Coverage tests for ``clock_network.py`` and ``pulse.py``.
+
+Two structural surfaces sit downstream of the rule pack:
+
+* :func:`rtl_buddy_cdc.clock_network.find_clock_network_crossings` mirrors
+  CDC-010's clock-network walk but emits one record per ``(src_flop,
+  dst_flop)`` pair so a renderer can draw the edge CDC-010 only reports
+  per control triple.
+* :mod:`rtl_buddy_cdc.pulse` classifies a flop's ``D``-pin comb cone for
+  CDC-009 (``classify_d_pin_shape`` — the edge-detector ``A & ~A_d``
+  pulse) and CDC-013 (``classify_toggle_d_pin`` — the ``mux(Q, ~Q, en)``
+  toggle).
+
+The committed Yosys-JSON fixtures drive the happy paths
+(``netlist.load`` reads JSON, no yosys binary). The many guard / skip
+branches in the helpers are exercised by hand-built
+:class:`~rtl_buddy_cdc.netlist.Module` objects so each ``continue`` /
+early ``return`` is hit deterministically and asserted on by behaviour
+(the returned crossing list, the classifier verdict), not coverage
+theater.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.clock_network import (
+    ClockNetworkCrossing,
+    _bit_drivers_with_idx,
+    _cell_clock_input_domains,
+    _cell_to_downstream_flops,
+    _control_kind_for,
+    find_clock_network_crossings,
+)
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.netlist import Cell, Module, Port
+from rtl_buddy_cdc.pulse import classify_d_pin_shape, classify_toggle_d_pin
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+def _module(cells: dict[str, Cell], ports: dict[str, Port] | None = None) -> Module:
+    """Tiny synthetic module so helper-level branches are reachable
+    without round-tripping through yosys."""
+    return Module(name="syn", ports=ports or {}, cells=cells, netnames={})
+
+
+def _dff(name: str, clk: int, q: int, d: int = 7) -> Cell:
+    return Cell(
+        name=name, type="$dff", connections={"CLK": (clk,), "D": (d,), "Q": (q,)}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# clock_network.find_clock_network_crossings — fixture-driven happy paths
+# --------------------------------------------------------------------------- #
+
+
+def test_async_clock_mux_surfaces_one_mux_select_edge() -> None:
+    """``bad_async_clock_mux``: the ``$mux`` whose ``S`` is driven by a
+    foreign-domain flop yields exactly one clock-network crossing,
+    classified as a mux-select edge from ck1 into ck0."""
+    name = "bad_async_clock_mux"
+    module = netlist.load(FIX / name / f"{name}.json")
+    spec = sdc_mod.parse_file(FIX / name / f"{name}.sdc")
+
+    crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=spec.clock_for_port
+    )
+    assert len(crossings) == 1
+    c = crossings[0]
+    assert isinstance(c, ClockNetworkCrossing)
+    assert c.src_clock == "ck1"
+    assert c.dst_clock == "ck0"
+    assert c.control_pin == "S"
+    assert c.control_cell_type == "$mux"
+    assert c.control_kind == "mux-select"
+    # src drives the select; dst is clocked by the gated output.
+    assert c.src_flop.cell.connections.get("Q", ()) == module.netnames["sel_q"].bits
+    assert c.dst_flop.cell.connections.get("Q", ()) == module.netnames["q_out"].bits
+
+
+def test_techmap_mux_select_uses_gate_level_mux_cell() -> None:
+    """``bad_techmap_async_clock_mux``: the simplemap'd ``$_MUX_`` is
+    still recognised as a clock-network select cell (explicit-map path
+    for the gate-level mux family)."""
+    name = "bad_techmap_async_clock_mux"
+    module = netlist.load(FIX / name / f"{name}.json")
+    spec = sdc_mod.parse_file(FIX / name / f"{name}.sdc")
+
+    crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=spec.clock_for_port
+    )
+    assert len(crossings) == 1
+    c = crossings[0]
+    assert c.control_cell_type == "$_MUX_"
+    assert c.control_pin == "S"
+    assert c.control_kind == "mux-select"
+    assert c.src_clock == "ck1"
+    assert c.dst_clock == "ck0"
+
+
+def test_raw_and_clock_gates_surface_no_clock_network_crossing() -> None:
+    """``bad_clock_gating`` / ``bad_clock_gating_async_enable``: a bare
+    ``$and`` clock gate has no named control pin, so the walk finds the
+    cell on the clock network but ``_control_pins_for`` returns empty —
+    no crossing is emitted (mirrors the CDC-010 gap pinned in #177)."""
+    for name in ("bad_clock_gating", "bad_clock_gating_async_enable"):
+        module = netlist.load(FIX / name / f"{name}.json")
+        spec = sdc_mod.parse_file(FIX / name / f"{name}.sdc")
+        crossings = find_clock_network_crossings(
+            module, spec, clock_for_port=spec.clock_for_port
+        )
+        assert crossings == [], (
+            f"{name}: a raw-$and clock gate carries no recognised control "
+            f"pin, so no clock-network crossing should surface; got {crossings!r}"
+        )
+
+
+def test_clock_as_data_has_no_clock_network_crossing() -> None:
+    """``bad_clock_as_data`` is a CDC-008 shape (clock on a data pin),
+    not a control-pin glitch — the clock-network surface stays empty."""
+    name = "bad_clock_as_data"
+    module = netlist.load(FIX / name / f"{name}.json")
+    spec = sdc_mod.parse_file(FIX / name / f"{name}.sdc")
+    crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=spec.clock_for_port
+    )
+    assert crossings == []
+
+
+# --------------------------------------------------------------------------- #
+# clock_network — synthetic gate-enable / async / domain branches
+# --------------------------------------------------------------------------- #
+
+
+def _gate_enable_module() -> Module:
+    """``F_src`` (clkA) drives the EN of a ``$dffe`` ICG whose clock
+    input is ``F_clkgen`` (clkB); the ICG's Q clocks ``F_dst``. Both
+    domains trace to distinct top-level clock ports."""
+    ports = {
+        "clkA": Port("clkA", "input", (1,)),
+        "clkB": Port("clkB", "input", (3,)),
+        "din": Port("din", "input", (7,)),
+    }
+    cells = {
+        "F_src": _dff("F_src", clk=1, q=2),
+        "F_clkgen": _dff("F_clkgen", clk=3, q=4),
+        "icg": Cell("icg", "$dffe", {"CLK": (4,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    return _module(cells, ports)
+
+
+def test_gate_enable_crossing_without_clock_spec() -> None:
+    """No clock_spec / no clock_for_port: domains are the raw clock-port
+    names and ``_async`` falls back to plain inequality. The ``$dffe``
+    EN driven by an async-domain flop produces one gate-enable
+    crossing."""
+    module = _gate_enable_module()
+    crossings = find_clock_network_crossings(module)  # clock_spec=None
+    assert len(crossings) == 1
+    c = crossings[0]
+    assert c.control_pin == "EN"
+    assert c.control_kind == "gate-enable"
+    assert c.control_cell == "icg"
+    assert c.control_cell_type == "$dffe"
+    assert c.src_flop.cell.name == "F_src"
+    assert c.dst_flop.cell.name == "F_dst"
+    assert {c.src_clock, c.dst_clock} == {"clkA", "clkB"}
+
+
+def test_gate_enable_crossing_with_spec_via_port_clock_input() -> None:
+    """clock_spec supplied and the ICG's clock input comes straight from
+    a top-level clock port: ``_cell_clock_input_domains`` resolves it via
+    ``ClockSpec.clock_for_port`` and ``are_async`` confirms the pair is
+    async (per ``set_clock_groups``)."""
+    ports = {
+        "clkA": Port("clkA", "input", (1,)),
+        "clkB": Port("clkB", "input", (3,)),
+        "din": Port("din", "input", (7,)),
+    }
+    cells = {
+        "F_src": _dff("F_src", clk=1, q=2),
+        # ICG clock input is the clkB port directly (bit 3).
+        "icg": Cell("icg", "$dffe", {"CLK": (3,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    spec = sdc_mod.parse(
+        "create_clock -name clkA -period 10 [get_ports clkA]\n"
+        "create_clock -name clkB -period 10 [get_ports clkB]\n"
+        "set_clock_groups -asynchronous -group {clkA} -group {clkB}\n"
+    )
+    crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=spec.clock_for_port
+    )
+    assert len(crossings) == 1
+    c = crossings[0]
+    assert c.src_clock == "clkA"
+    assert c.dst_clock == "clkB"
+    assert c.control_kind == "gate-enable"
+
+
+def test_no_crossing_when_control_flop_shares_cell_clock_domain() -> None:
+    """If the control flop sits in the *same* domain as the cell's
+    clock-input domain, the rule (and this surface) must stay silent —
+    driving an enable with a same-domain flop is the safe case
+    (``src_clk in cell_clock_domains``)."""
+    ports = {"clkB": Port("clkB", "input", (3,)), "din": Port("din", "input", (7,))}
+    cells = {
+        # ICG clock input traces to F_clkgen.Q (clkB domain).
+        "F_clkgen": _dff("F_clkgen", clk=3, q=4),
+        # Control flop is also clkB -> same domain as the cell's clock input.
+        "F_src": _dff("F_src", clk=3, q=2),
+        "icg": Cell("icg", "$dffe", {"CLK": (4,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    assert find_clock_network_crossings(module) == []
+
+
+def test_unclassifiable_cell_clock_domain_stays_silent() -> None:
+    """End-to-end: the control pin has a valid source flop, but the
+    cell's own clock input is a dangling net — ``cell_clock_domains``
+    comes back empty, so the walk stays silent (``not cell_clock_domains``
+    guard) rather than firing blind."""
+    ports = {"clkA": Port("clkA", "input", (1,)), "din": Port("din", "input", (7,))}
+    cells = {
+        "F_src": _dff("F_src", clk=1, q=2),
+        # ICG clock input (bit 99) is dangling -> domain unclassifiable.
+        "icg": Cell("icg", "$dffe", {"CLK": (99,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    assert find_clock_network_crossings(module) == []
+
+
+def test_cell_clock_input_depth_limit_gives_up() -> None:
+    """A long combinational chain (>12 hops) between the clock-source
+    flop's Q and the cell's clock input exceeds ``max_depth``; the walk
+    gives up and classifies no domain."""
+    cells = {
+        "F_clkgen": _dff("F_clkgen", clk=3, q=100),
+        "F_src": _dff("F_src", clk=1, q=2),
+    }
+    prev = 100
+    for i in range(14):  # 14 comb hops, beyond the depth-12 budget
+        out = 200 + i
+        cells[f"b{i}"] = Cell(
+            f"b{i}", "$and", {"A": (prev,), "B": (prev,), "Y": (out,)}
+        )
+        prev = out
+    cells["icg"] = Cell(
+        "icg", "$dffe", {"CLK": (prev,), "EN": (2,), "D": (7,), "Q": (5,)}
+    )
+    module = _module(
+        cells,
+        {"clkA": Port("clkA", "input", (1,)), "clkB": Port("clkB", "input", (3,))},
+    )
+    drivers = _bit_drivers_with_idx(module)
+    domains = _cell_clock_input_domains(
+        module,
+        module.cells["icg"],
+        drivers,
+        {"F_src": "clkA", "F_clkgen": "clkB"},
+        None,
+        frozenset({"EN"}),
+    )
+    assert domains == set()
+
+
+def test_constant_bits_on_clock_network_are_ignored() -> None:
+    """Constant bits sprinkled through the clock network (a const on a
+    gate input, a const on the cell's data pin, a const lane in a wide
+    output) are skipped by the int-only filters; the real flop-Q clock
+    source still classifies and the crossing still surfaces."""
+    ports = {
+        "clkA": Port("clkA", "input", (1,)),
+        "clkB": Port("clkB", "input", (3,)),
+        "din": Port("din", "input", (7,)),
+    }
+    cells = {
+        "F_src": _dff("F_src", clk=1, q=2),
+        "F_clkgen": _dff("F_clkgen", clk=3, q=30),
+        # comb gate with a constant operand feeding the ICG clock input.
+        "buf": Cell("buf", "$and", {"A": (30,), "B": ("0",), "Y": (4,)}),
+        # ICG data pin is a constant (non-control input that is non-int).
+        "icg": Cell("icg", "$dffe", {"CLK": (4,), "EN": (2,), "D": ("1",), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+        # a wide output with one constant lane exercises the driver-map filter.
+        "wide": Cell("wide", "$add", {"A": (7,), "B": (7,), "Y": (8, "0")}),
+    }
+    module = _module(cells, ports)
+    crossings = find_clock_network_crossings(module)
+    assert len(crossings) == 1
+    assert {crossings[0].src_clock, crossings[0].dst_clock} == {"clkA", "clkB"}
+    assert crossings[0].control_kind == "gate-enable"
+
+
+def test_cell_clock_input_q_with_unknown_domain_is_skipped() -> None:
+    """When a non-control input traces to a flop Q whose own domain is
+    None (untraceable clock), nothing is collected from that branch."""
+    cells = {
+        "F_clkgen": Cell("F_clkgen", "$dff", {"CLK": (4,), "D": (7,), "Q": (40,)}),
+        "icg": Cell("icg", "$dffe", {"CLK": (40,), "EN": (2,), "D": (7,), "Q": (5,)}),
+    }
+    module = _module(cells)
+    drivers = _bit_drivers_with_idx(module)
+    domains = _cell_clock_input_domains(
+        module,
+        module.cells["icg"],
+        drivers,
+        {"F_clkgen": None},  # the clock-source flop has no known domain
+        None,
+        frozenset({"EN"}),
+    )
+    assert domains == set()
+
+
+def test_cell_clock_input_with_dangling_input_classifies_nothing() -> None:
+    """A cell whose non-control input bit has neither a driver nor a
+    top-level port (a dangling net) contributes no domain even with a
+    clock_spec present — the ``port_of_bit is None`` branch."""
+    ports = {"clkA": Port("clkA", "input", (1,)), "din": Port("din", "input", (7,))}
+    cells = {
+        "F_src": _dff("F_src", clk=1, q=2),
+        # CLK bit 99 is dangling: no driver, no owning port.
+        "icg": Cell("icg", "$dffe", {"CLK": (99,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    spec = sdc_mod.parse("create_clock -name clkA -period 10 [get_ports clkA]\n")
+    drivers = _bit_drivers_with_idx(module)
+    domains = _cell_clock_input_domains(
+        module, module.cells["icg"], drivers, {"F_src": "clkA"}, spec, frozenset({"EN"})
+    )
+    assert domains == set()
+
+
+def test_no_crossing_when_async_to_only_one_of_two_clock_inputs() -> None:
+    """A clock mux selecting between two gated legs (clkA, clkB). The
+    select flop is in clkC, declared async to clkA but synchronous to
+    clkB. Because the source is *not* async to every clock-input domain,
+    no crossing is emitted (the all-async guard)."""
+    ports = {
+        "clkA": Port("clkA", "input", (1,)),
+        "clkB": Port("clkB", "input", (11,)),
+        "clkC": Port("clkC", "input", (3,)),
+        "din": Port("din", "input", (7,)),
+    }
+    cells = {
+        "F_clkA": _dff("F_clkA", clk=1, q=20),
+        "F_clkB": _dff("F_clkB", clk=11, q=21),
+        "F_src": _dff("F_src", clk=3, q=2),
+        "cmux": Cell("cmux", "$mux", {"A": (20,), "B": (21,), "S": (2,), "Y": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    spec = sdc_mod.parse(
+        "create_clock -name clkA -period 10 [get_ports clkA]\n"
+        "create_clock -name clkB -period 10 [get_ports clkB]\n"
+        "create_clock -name clkC -period 10 [get_ports clkC]\n"
+        "set_clock_groups -asynchronous -group {clkA} -group {clkB clkC}\n"
+    )
+    crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=spec.clock_for_port
+    )
+    assert crossings == []
+
+
+def test_fires_when_select_async_to_every_clock_input() -> None:
+    """Same mux as above, but now clkC is async to both clkA and clkB.
+    The all-async guard passes; exactly one crossing surfaces (the
+    deterministic representative dst_clock is the first sorted member)."""
+    ports = {
+        "clkA": Port("clkA", "input", (1,)),
+        "clkB": Port("clkB", "input", (11,)),
+        "clkC": Port("clkC", "input", (3,)),
+        "din": Port("din", "input", (7,)),
+    }
+    cells = {
+        "F_clkA": _dff("F_clkA", clk=1, q=20),
+        "F_clkB": _dff("F_clkB", clk=11, q=21),
+        "F_src": _dff("F_src", clk=3, q=2),
+        "cmux": Cell("cmux", "$mux", {"A": (20,), "B": (21,), "S": (2,), "Y": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    spec = sdc_mod.parse(
+        "create_clock -name clkA -period 10 [get_ports clkA]\n"
+        "create_clock -name clkB -period 10 [get_ports clkB]\n"
+        "create_clock -name clkC -period 10 [get_ports clkC]\n"
+        "set_clock_groups -asynchronous -group {clkA} -group {clkB} -group {clkC}\n"
+    )
+    crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=spec.clock_for_port
+    )
+    assert len(crossings) == 1
+    c = crossings[0]
+    assert c.src_clock == "clkC"
+    # sorted(["clkA","clkB"])[0] is the stable representative.
+    assert c.dst_clock == "clkA"
+    assert c.control_kind == "mux-select"
+
+
+def test_control_pin_driven_by_top_level_port_yields_no_crossing() -> None:
+    """When the control pin's fanin has no source flop (driven by a
+    top-level port / constant), ``_backward_flop_fanin`` is empty and the
+    cell is skipped — same posture CDC-010 takes."""
+    ports = {
+        "clkB": Port("clkB", "input", (3,)),
+        "sel": Port("sel", "input", (2,)),
+        "din": Port("din", "input", (7,)),
+    }
+    cells = {
+        "F_clkgen": _dff("F_clkgen", clk=3, q=4),
+        # EN is the top-level 'sel' port (bit 2), not a flop Q.
+        "icg": Cell("icg", "$dffe", {"CLK": (4,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    assert find_clock_network_crossings(module) == []
+
+
+def test_no_clock_network_cells_returns_empty() -> None:
+    """A design with no clock-distribution logic (every flop clocked
+    straight from a port) has no clock-network cells: early-out empty."""
+    ports = {"clk": Port("clk", "input", (1,)), "din": Port("din", "input", (7,))}
+    module = _module({"F": _dff("F", clk=1, q=2)}, ports)
+    assert find_clock_network_crossings(module) == []
+
+
+def test_clock_input_traced_through_comb_cell_to_flop_q() -> None:
+    """The ICG's clock input reaches the source flop's Q through a
+    combinational buffer/gate, exercising the multi-hop comb traversal
+    in ``_cell_clock_input_domains`` (not a direct Q driver)."""
+    ports = {
+        "clkA": Port("clkA", "input", (1,)),
+        "clkB": Port("clkB", "input", (3,)),
+        "din": Port("din", "input", (7,)),
+    }
+    cells = {
+        "F_src": _dff("F_src", clk=1, q=2),
+        "F_clkgen": _dff("F_clkgen", clk=3, q=30),
+        # comb cell between the clkB flop's Q and the ICG clock input.
+        "buf": Cell("buf", "$and", {"A": (30,), "B": (30,), "Y": (4,)}),
+        "icg": Cell("icg", "$dffe", {"CLK": (4,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    crossings = find_clock_network_crossings(module)
+    assert len(crossings) == 1
+    assert {crossings[0].src_clock, crossings[0].dst_clock} == {"clkA", "clkB"}
+
+
+def test_spec_without_clock_for_port_keeps_raw_names() -> None:
+    """clock_spec supplied but ``clock_for_port`` left None: ``_resolve``
+    returns the raw name and ``are_async`` is consulted on it. The async
+    pair still surfaces one crossing."""
+    module = _gate_enable_module()
+    spec = sdc_mod.parse(
+        "create_clock -name clkA -period 10 [get_ports clkA]\n"
+        "create_clock -name clkB -period 10 [get_ports clkB]\n"
+        "set_clock_groups -asynchronous -group {clkA} -group {clkB}\n"
+    )
+    crossings = find_clock_network_crossings(module, spec)  # no clock_for_port
+    assert len(crossings) == 1
+    assert {crossings[0].src_clock, crossings[0].dst_clock} == {"clkA", "clkB"}
+
+
+def test_empty_control_pin_connection_yields_no_crossing() -> None:
+    """A ``$mux`` whose ``S`` connection is the empty tuple has no
+    control bits to walk; the cell is skipped."""
+    ports = {"clkB": Port("clkB", "input", (3,)), "din": Port("din", "input", (7,))}
+    cells = {
+        "F_clkgen": _dff("F_clkgen", clk=3, q=4),
+        "cmux": Cell("cmux", "$mux", {"A": (4,), "B": (4,), "S": (), "Y": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    assert find_clock_network_crossings(module) == []
+
+
+def test_untraceable_control_flop_clock_is_skipped() -> None:
+    """The control flop's CLK traces to a constant-fed comb cell, so its
+    domain is None — the per-source ``src_clk is None`` guard skips it."""
+    ports = {"clkB": Port("clkB", "input", (3,)), "din": Port("din", "input", (7,))}
+    cells = {
+        # F_src.CLK comes off a constant-driven gate -> no clock root.
+        "gen": Cell("gen", "$and", {"A": ("1",), "B": ("1",), "Y": (50,)}),
+        "F_src": _dff("F_src", clk=50, q=2),
+        "F_clkgen": _dff("F_clkgen", clk=3, q=4),
+        "icg": Cell("icg", "$dffe", {"CLK": (4,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    assert find_clock_network_crossings(module) == []
+
+
+def test_multi_select_mux_dedups_to_one_crossing() -> None:
+    """A ``$_MUX4_`` carries selects on both ``S`` and ``T``. With both
+    driven by the same source flop reaching the same dst flop, the
+    second control port hits the ``seen`` set and only one crossing is
+    emitted."""
+    ports = {
+        "clkA": Port("clkA", "input", (1,)),
+        "clkC": Port("clkC", "input", (3,)),
+        "din": Port("din", "input", (7,)),
+    }
+    cells = {
+        "F_clkA": _dff("F_clkA", clk=1, q=20),
+        "F_src": _dff("F_src", clk=3, q=2),
+        "m4": Cell(
+            "m4",
+            "$_MUX4_",
+            {
+                "A": (20,),
+                "B": (20,),
+                "C": (20,),
+                "D": (20,),
+                "S": (2,),
+                "T": (2,),
+                "Y": (5,),
+            },
+        ),
+        "F_dst": _dff("F_dst", clk=5, q=6),
+    }
+    module = _module(cells, ports)
+    spec = sdc_mod.parse(
+        "create_clock -name clkA -period 10 [get_ports clkA]\n"
+        "create_clock -name clkC -period 10 [get_ports clkC]\n"
+        "set_clock_groups -asynchronous -group {clkA} -group {clkC}\n"
+    )
+    crossings = find_clock_network_crossings(
+        module, spec, clock_for_port=spec.clock_for_port
+    )
+    assert len(crossings) == 1
+    assert crossings[0].src_clock == "clkC"
+    assert crossings[0].dst_clock == "clkA"
+
+
+# --------------------------------------------------------------------------- #
+# clock_network — helper-level units
+# --------------------------------------------------------------------------- #
+
+
+def test_cell_to_downstream_flops_dedups_shared_gated_clock() -> None:
+    """Two flops sharing one gated-clock net both map to the host ICG;
+    the bit-revisit guard keeps the walk terminating."""
+    ports = {"clkB": Port("clkB", "input", (3,)), "din": Port("din", "input", (7,))}
+    cells = {
+        "F_src": _dff("F_src", clk=3, q=2),
+        "icg": Cell("icg", "$dffe", {"CLK": (3,), "EN": (2,), "D": (7,), "Q": (5,)}),
+        "F_dst1": _dff("F_dst1", clk=5, q=6),
+        "F_dst2": _dff("F_dst2", clk=5, q=8),
+    }
+    module = _module(cells, ports)
+    mapping = _cell_to_downstream_flops(module, _bit_drivers_with_idx(module))
+    assert mapping["icg"] == {"F_dst1", "F_dst2"}
+
+
+def test_cell_to_downstream_flops_skips_non_int_clk() -> None:
+    """A flop whose CLK is a constant (non-int bit) is skipped — no
+    downstream mapping is produced for it."""
+    module = _module({"F": Cell("F", "$dff", {"CLK": ("0",), "D": (7,), "Q": (9,)})})
+    assert _cell_to_downstream_flops(module, _bit_drivers_with_idx(module)) == {}
+
+
+def test_cell_clock_input_domains_resolves_flop_q_source() -> None:
+    """When a cell's non-control input traces to a flop's Q, that flop's
+    domain is collected (the Q-output branch)."""
+    cells = {
+        "F_clkgen": _dff("F_clkgen", clk=3, q=4),
+        "icg": Cell("icg", "$dffe", {"CLK": (4,), "EN": (2,), "D": (7,), "Q": (5,)}),
+    }
+    module = _module(cells, {"clkB": Port("clkB", "input", (3,))})
+    drivers = _bit_drivers_with_idx(module)
+    domains = _cell_clock_input_domains(
+        module,
+        module.cells["icg"],
+        drivers,
+        {"F_clkgen": "clkB"},
+        None,
+        frozenset({"EN"}),
+    )
+    assert domains == {"clkB"}
+
+
+def test_cell_clock_input_domains_empty_without_spec_on_port_source() -> None:
+    """With clock_spec None, a clock input that traces only to a
+    top-level port (no driving flop) cannot be classified — the domain
+    set stays empty (the false-negative-biased posture)."""
+    cells = {
+        "icg": Cell("icg", "$dffe", {"CLK": (3,), "EN": (2,), "D": (7,), "Q": (5,)}),
+    }
+    module = _module(cells, {"clkB": Port("clkB", "input", (3,))})
+    drivers = _bit_drivers_with_idx(module)
+    domains = _cell_clock_input_domains(
+        module, module.cells["icg"], drivers, {}, None, frozenset({"EN"})
+    )
+    assert domains == set()
+
+
+def test_control_kind_classifier() -> None:
+    """``_control_kind_for``: mux families are mux-select, enable-style
+    pins are gate-enable, and the catch-all falls back to mux-select."""
+    assert _control_kind_for("S", "$mux") == "mux-select"
+    assert _control_kind_for("S", "$_MUX_") == "mux-select"
+    assert _control_kind_for("EN", "$dffe") == "gate-enable"
+    assert _control_kind_for("ce", "ICG_CELL") == "gate-enable"  # case-insensitive
+    assert _control_kind_for("GATE", "SOME_ICG") == "gate-enable"
+    # Unknown cell type + non-enable pin name -> mux-select fallback.
+    assert _control_kind_for("FOO", "$weird") == "mux-select"
+
+
+# --------------------------------------------------------------------------- #
+# pulse.classify_d_pin_shape — CDC-009 edge-detector classifier
+# --------------------------------------------------------------------------- #
+
+
+def _edge_detector_module(*, delay_d: int = 2, not_type: str = "$not") -> Module:
+    """D = F1.Q & ~F2.Q where F2 is the 1-cycle delay of F1 (F2.D ==
+    F1.Q). ``delay_d`` lets a test break the F2.D == F1.Q invariant."""
+    cells = {
+        "F1": _dff("F1", clk=1, q=2),
+        "F2": Cell("F2", "$dff", {"CLK": (1,), "D": (delay_d,), "Q": (3,)}),
+        "inv": Cell("inv", not_type, {"A": (3,), "Y": (4,)}),
+        "and": Cell("and", "$and", {"A": (2,), "B": (4,), "Y": (10,)}),
+    }
+    return _module(cells)
+
+
+def _drivers(module: Module) -> dict:
+    return _bit_drivers_with_idx(module)
+
+
+def test_pulse_shape_matches_edge_detector() -> None:
+    """The textbook ``A & ~A_d`` edge-detector cone classifies as a
+    pulse."""
+    module = _edge_detector_module()
+    assert (
+        classify_d_pin_shape(
+            10, "clk", module, _drivers(module), {"F1": "clk", "F2": "clk"}
+        )
+        == "pulse"
+    )
+
+
+def test_pulse_shape_non_int_d_bit_is_other() -> None:
+    """A constant D bit can't be a pulse cone."""
+    module = _edge_detector_module()
+    assert (
+        classify_d_pin_shape(
+            "0", "clk", module, _drivers(module), {"F1": "clk", "F2": "clk"}
+        )
+        == "other"
+    )
+
+
+def test_pulse_shape_multibit_and_input_is_other() -> None:
+    """The edge detector AND must have single-bit inputs; a 2-bit A pin
+    disqualifies it."""
+    cells = {
+        "F1": _dff("F1", clk=1, q=2),
+        "and": Cell("and", "$and", {"A": (2, 3), "B": (4,), "Y": (10,)}),
+    }
+    module = _module(cells)
+    assert classify_d_pin_shape(10, "clk", module, _drivers(module), {}) == "other"
+
+
+def test_pulse_shape_constant_and_operand_is_other() -> None:
+    """A constant on the AND's A pin (non-int) can't be a flop Q."""
+    cells = {"and": Cell("and", "$and", {"A": ("1",), "B": (4,), "Y": (10,)})}
+    module = _module(cells)
+    assert classify_d_pin_shape(10, "clk", module, _drivers(module), {}) == "other"
+
+
+def test_pulse_shape_inverted_operand_not_a_not_cell_is_other() -> None:
+    """If the supposedly-inverted operand isn't a NOT cell, the pair
+    doesn't match the edge detector."""
+    module = _edge_detector_module(not_type="$and")
+    assert (
+        classify_d_pin_shape(
+            10, "clk", module, _drivers(module), {"F1": "clk", "F2": "clk"}
+        )
+        == "other"
+    )
+
+
+def test_pulse_shape_delay_flop_d_mismatch_is_other() -> None:
+    """F2 must be F1's 1-cycle delay (F2.D == F1.Q). Break that and the
+    cone is no longer an edge detector."""
+    module = _edge_detector_module(delay_d=99)
+    assert (
+        classify_d_pin_shape(
+            10, "clk", module, _drivers(module), {"F1": "clk", "F2": "clk"}
+        )
+        == "other"
+    )
+
+
+def test_pulse_shape_wrong_domain_source_flop_is_other() -> None:
+    """The source flops must be in ``src_clock``'s domain; tag them with
+    a different clock and the classifier bails (the domain mismatch
+    branch of ``_src_flop_d_pin``)."""
+    module = _edge_detector_module()
+    assert (
+        classify_d_pin_shape(
+            10, "src", module, _drivers(module), {"F1": "other", "F2": "other"}
+        )
+        == "other"
+    )
+
+
+def test_pulse_shape_d_bit_without_driver_is_other() -> None:
+    """``d_bit`` is an int but nothing drives it: ``_matches_edge_detector``
+    bails at the no-driver guard."""
+    module = _module({})
+    assert classify_d_pin_shape(10, "clk", module, _drivers(module), {}) == "other"
+
+
+def test_pulse_shape_d_bit_from_non_and_cell_is_other() -> None:
+    """``d_bit`` is the Y of a non-AND cell: the cell-type guard rejects
+    it."""
+    cells = {"or": Cell("or", "$or", {"A": (2,), "B": (4,), "Y": (10,)})}
+    module = _module(cells)
+    assert classify_d_pin_shape(10, "clk", module, _drivers(module), {}) == "other"
+
+
+def test_pulse_shape_inverted_operand_without_driver_is_other() -> None:
+    """The direct operand is a valid src flop Q, but the would-be
+    inverted operand has no driver — the pair check fails."""
+    cells = {
+        "F1": _dff("F1", clk=1, q=2),
+        # B (bit 4) is undriven; A=F1.Q.
+        "and": Cell("and", "$and", {"A": (2,), "B": (4,), "Y": (10,)}),
+    }
+    module = _module(cells)
+    assert (
+        classify_d_pin_shape(10, "clk", module, _drivers(module), {"F1": "clk"})
+        == "other"
+    )
+
+
+def test_pulse_shape_not_cell_multibit_input_is_other() -> None:
+    """The NOT cell in the inverted leg must have a single-bit input."""
+    cells = {
+        "F1": _dff("F1", clk=1, q=2),
+        "F2": Cell("F2", "$dff", {"CLK": (1,), "D": (2,), "Q": (3,)}),
+        "inv": Cell("inv", "$not", {"A": (3, 99), "Y": (4,)}),
+        "and": Cell("and", "$and", {"A": (2,), "B": (4,), "Y": (10,)}),
+    }
+    module = _module(cells)
+    assert (
+        classify_d_pin_shape(
+            10, "clk", module, _drivers(module), {"F1": "clk", "F2": "clk"}
+        )
+        == "other"
+    )
+
+
+def test_pulse_shape_delay_leg_not_a_flop_is_other() -> None:
+    """The inverted leg's NOT input must be a flop Q (the delay flop);
+    here it is a comb output, so ``_src_flop_d_pin`` returns None."""
+    cells = {
+        "F1": _dff("F1", clk=1, q=2),
+        "combd": Cell("combd", "$and", {"A": (7,), "B": (7,), "Y": (40,)}),
+        "inv": Cell("inv", "$not", {"A": (40,), "Y": (4,)}),
+        "and": Cell("and", "$and", {"A": (2,), "B": (4,), "Y": (10,)}),
+    }
+    module = _module(cells)
+    assert (
+        classify_d_pin_shape(10, "clk", module, _drivers(module), {"F1": "clk"})
+        == "other"
+    )
+
+
+def test_pulse_shape_direct_operand_from_non_flop_q_is_other() -> None:
+    """The direct operand traces to a ``Q`` port of a non-flop cell;
+    ``_src_flop_d_pin`` rejects it at the ``is_ff_cell`` guard."""
+    cells = {
+        "weird": Cell("weird", "$lut", {"Q": (2,)}),
+        "inv": Cell("inv", "$not", {"A": (3,), "Y": (4,)}),
+        "and": Cell("and", "$and", {"A": (2,), "B": (4,), "Y": (10,)}),
+    }
+    module = _module(cells)
+    assert classify_d_pin_shape(10, "clk", module, _drivers(module), {}) == "other"
+
+
+def test_pulse_shape_source_flop_multibit_d_is_other() -> None:
+    """A single-bit flop is required; a 2-bit D pin disqualifies the
+    direct operand's source flop."""
+    cells = {
+        "F1": Cell("F1", "$dff", {"CLK": (1,), "D": (7, 8), "Q": (2,)}),
+        "inv": Cell("inv", "$not", {"A": (3,), "Y": (4,)}),
+        "and": Cell("and", "$and", {"A": (2,), "B": (4,), "Y": (10,)}),
+    }
+    module = _module(cells)
+    assert (
+        classify_d_pin_shape(10, "clk", module, _drivers(module), {"F1": "clk"})
+        == "other"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# pulse.classify_toggle_d_pin — CDC-013 toggle classifier
+# --------------------------------------------------------------------------- #
+
+
+def _toggle_module(
+    *, a: int = 2, b: int = 3, not_a_src: int = 2, mux_type: str = "$mux"
+):
+    """D = mux(A=a, B=b, S=en); ``b`` is ``~not_a_src`` via a NOT cell.
+    Defaults form the canonical toggle ``mux(Q, ~Q, en)`` with Q=bit 2."""
+    cells = {
+        "inv": Cell("inv", "$not", {"A": (not_a_src,), "Y": (3,)}),
+        "mux": Cell("mux", mux_type, {"A": (a,), "B": (b,), "S": (9,), "Y": (10,)}),
+    }
+    return _module(cells)
+
+
+def test_toggle_shape_matches_canonical_mux() -> None:
+    """``mux(A=Q, B=~Q, S=en)`` classifies as a toggle."""
+    module = _toggle_module()
+    assert classify_toggle_d_pin(10, 2, module, _drivers(module)) == "toggle"
+
+
+def test_toggle_shape_matches_mirror_ordering() -> None:
+    """``mux(A=~Q, B=Q, S=en)`` (operands swapped) is still a toggle."""
+    module = _toggle_module(a=3, b=2)
+    assert classify_toggle_d_pin(10, 2, module, _drivers(module)) == "toggle"
+
+
+def test_toggle_shape_non_int_inputs_are_other() -> None:
+    module = _toggle_module()
+    assert classify_toggle_d_pin("0", 2, module, _drivers(module)) == "other"
+    assert classify_toggle_d_pin(10, "1", module, _drivers(module)) == "other"
+
+
+def test_toggle_shape_no_driver_is_other() -> None:
+    module = _toggle_module()
+    assert classify_toggle_d_pin(777, 2, module, _drivers(module)) == "other"
+
+
+def test_toggle_shape_non_mux_cell_is_other() -> None:
+    """Only ``$mux`` is the toggle shape; an adder is not."""
+    module = _toggle_module(mux_type="$add")
+    assert classify_toggle_d_pin(10, 2, module, _drivers(module)) == "other"
+
+
+def test_toggle_shape_multibit_mux_input_is_other() -> None:
+    cells = {
+        "mux": Cell("mux", "$mux", {"A": (2, 99), "B": (3,), "S": (9,), "Y": (10,)})
+    }
+    module = _module(cells)
+    assert classify_toggle_d_pin(10, 2, module, _drivers(module)) == "other"
+
+
+def test_toggle_shape_constant_mux_operand_is_other() -> None:
+    cells = {
+        "mux": Cell("mux", "$mux", {"A": ("1",), "B": (3,), "S": (9,), "Y": (10,)})
+    }
+    module = _module(cells)
+    assert classify_toggle_d_pin(10, 2, module, _drivers(module)) == "other"
+
+
+def test_toggle_shape_neither_operand_is_src_q_is_other() -> None:
+    """Neither mux data input equals the source flop's Q (src_q=5 here),
+    so the loop never enters the inverted-operand check."""
+    module = _toggle_module()
+    assert classify_toggle_d_pin(10, 5, module, _drivers(module)) == "other"
+
+
+def test_toggle_shape_inverted_operand_without_driver_is_other() -> None:
+    """A=Q matches but B has no driver — can't be ~Q."""
+    cells = {
+        "mux": Cell("mux", "$mux", {"A": (2,), "B": (888,), "S": (9,), "Y": (10,)})
+    }
+    module = _module(cells)
+    assert classify_toggle_d_pin(10, 2, module, _drivers(module)) == "other"
+
+
+def test_toggle_shape_inverted_operand_not_a_not_cell_is_other() -> None:
+    cells = {
+        "x": Cell("x", "$and", {"A": (2,), "Y": (3,)}),
+        "mux": Cell("mux", "$mux", {"A": (2,), "B": (3,), "S": (9,), "Y": (10,)}),
+    }
+    module = _module(cells)
+    assert classify_toggle_d_pin(10, 2, module, _drivers(module)) == "other"
+
+
+def test_toggle_shape_not_input_not_src_q_is_other() -> None:
+    """The NOT cell's input must be the source Q; here it inverts a
+    different net, so the inner branch falls through and the loop
+    continues without matching."""
+    module = _toggle_module(not_a_src=99)
+    assert classify_toggle_d_pin(10, 2, module, _drivers(module)) == "other"
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: CDC-009 firing through the pulse classifier on a fixture
+# --------------------------------------------------------------------------- #
+
+
+def test_cdc_009_fires_on_pulse_width_fixture() -> None:
+    """``bad_pulse_width_fast_to_slow``: the rule pack drives
+    ``classify_d_pin_shape`` and the single fast→slow pulse crossing
+    surfaces as one CDC-009 warning."""
+    name = "bad_pulse_width_fast_to_slow"
+    module = netlist.load(FIX / name / f"{name}.json")
+    spec = sdc_mod.parse_file(FIX / name / f"{name}.sdc")
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+
+    violations = run_all_rules(module, crossings, spec)
+    cdc_009 = [v for v in violations if v.rule_id == "CDC-009"]
+    assert len(cdc_009) == 1
+    v = cdc_009[0]
+    assert v.severity == "warning"
+    assert "pulse-width risk" in v.message

--- a/tests/test_cov_misc.py
+++ b/tests/test_cov_misc.py
@@ -1,0 +1,1302 @@
+"""Coverage tests for the small support modules around the analyzer core.
+
+These exercise edge branches in the data-model and plumbing layers that
+the end-to-end fixture suite doesn't reach directly:
+
+- ``netlist.load`` error / multi-module / parsing paths (tiny JSON dicts
+  written into ``tmp_path`` — no Yosys binary needed),
+- ``domain.trace_clock_root`` / ``domain.find_crossings`` structural
+  branches (buffer / mux / divider tracing, port-sourced crossings),
+  driven from hand-built :class:`Module` objects,
+- ``domain_map`` serialization of generated clocks, exclusive groups,
+  port-sourced crossings, and clock-network crossings,
+- ``flops`` FF-zoo edge cases (malformed CLK, ``Flop.width``),
+- ``frontend`` enum dispatch and the ``auto`` resolution line,
+- ``frontends.yosys`` guard / error branches, reached by monkeypatching
+  ``shutil.which`` / ``subprocess.run`` so no real Yosys is invoked.
+
+Everything here is deterministic and toolchain-free except the single
+``auto``-dispatch test, which is gated on pyslang (present in the
+coverage CI job).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import domain_map, frontend as frontend_mod, netlist
+from rtl_buddy_cdc.clock_network import ClockNetworkCrossing
+from rtl_buddy_cdc.domain import (
+    Crossing,
+    FlopDomain,
+    assign_domains,
+    find_crossings,
+    trace_clock_root,
+)
+from rtl_buddy_cdc.flops import Flop, find_flops, flop_clk_pin, is_ff_cell
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.frontends import yosys as yosys_fe
+from rtl_buddy_cdc.frontends.yosys import YosysError
+from rtl_buddy_cdc.netlist import Cell, Module, Netname, Port
+from rtl_buddy_cdc.sdc import UNCONSTRAINED_SENTINEL, Clock, ClockSpec
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+
+
+# --------------------------------------------------------------------------
+# netlist.load — error and parsing edge cases (tiny JSON in tmp_path)
+# --------------------------------------------------------------------------
+
+
+def _write_json(tmp_path: Path, data: dict) -> Path:
+    p = tmp_path / "design.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def test_load_empty_modules_raises(tmp_path: Path) -> None:
+    """A JSON with no ``modules`` key is unusable — load must reject it
+    with a message naming the offending file (netlist.py:83)."""
+    path = _write_json(tmp_path, {"modules": {}})
+    with pytest.raises(ValueError, match="no modules in JSON"):
+        netlist.load(path)
+
+
+def test_load_picks_single_non_dollar_module(tmp_path: Path) -> None:
+    """With more than one module, the loader keeps the single user module
+    and discards ``$``-prefixed paramod/blackbox stubs (netlist.py:87-93,
+    happy multi-module branch)."""
+    data = {
+        "modules": {
+            "$paramod$abc\\stub": {"ports": {}, "cells": {}, "netnames": {}},
+            "top": {
+                "ports": {
+                    "clk": {"direction": "input", "bits": [2]},
+                },
+                "cells": {},
+                "netnames": {},
+            },
+        }
+    }
+    module = netlist.load(_write_json(tmp_path, data))
+    assert module.name == "top"
+    assert module.ports["clk"].direction == "input"
+    assert module.ports["clk"].bits == (2,)
+
+
+def test_load_ambiguous_multi_module_raises(tmp_path: Path) -> None:
+    """Two non-``$`` modules after flatten is ambiguous — the loader
+    can't know which is the design top, so it raises (netlist.py:88-92)."""
+    data = {
+        "modules": {
+            "alpha": {"ports": {}, "cells": {}, "netnames": {}},
+            "beta": {"ports": {}, "cells": {}, "netnames": {}},
+        }
+    }
+    with pytest.raises(ValueError, match="expected exactly one user module"):
+        netlist.load(_write_json(tmp_path, data))
+
+
+def test_load_parses_cells_and_netnames(tmp_path: Path) -> None:
+    """Full port/cell/netname parsing path: parameters, attributes, and
+    bit tuples are all carried through (netlist.py cell/netname comps)."""
+    data = {
+        "modules": {
+            "m": {
+                "ports": {
+                    "a": {"direction": "input", "bits": [2, 3]},
+                    "y": {"direction": "output", "bits": [4]},
+                },
+                "cells": {
+                    "u_and": {
+                        "type": "$and",
+                        "connections": {"A": [2], "B": [3], "Y": [4]},
+                        "parameters": {"WIDTH": "1"},
+                        "attributes": {"src": "m.sv:1"},
+                    }
+                },
+                "netnames": {
+                    "sig": {"bits": [4], "attributes": {"keep": "1"}},
+                },
+            }
+        }
+    }
+    module = netlist.load(_write_json(tmp_path, data))
+    cell = module.cells["u_and"]
+    assert cell.type == "$and"
+    assert cell.connections == {"A": (2,), "B": (3,), "Y": (4,)}
+    assert cell.parameters == {"WIDTH": "1"}
+    assert cell.attributes == {"src": "m.sv:1"}
+    nn = module.netnames["sig"]
+    assert nn.bits == (4,)
+    assert nn.attributes == {"keep": "1"}
+
+
+def test_module_port_of_bit_const_returns_none() -> None:
+    """A constant bit (string ``"0"``) is never owned by a port; the
+    lookup short-circuits before scanning ports (netlist.py:58)."""
+    port = Port(name="a", direction="input", bits=(2,))
+    module = Module(name="m", ports={"a": port}, cells={}, netnames={})
+    assert module.port_of_bit("0") is None
+    assert module.port_of_bit(2) is port
+    assert module.port_of_bit(99) is None
+
+
+def test_module_cells_of_type_filters() -> None:
+    """``cells_of_type`` returns only cells whose type is in the wanted
+    set (netlist.py:65-66)."""
+    c1 = Cell(name="g0", type="$and", connections={})
+    c2 = Cell(name="g1", type="$or", connections={})
+    c3 = Cell(name="g2", type="$and", connections={})
+    module = Module(
+        name="m", ports={}, cells={"g0": c1, "g1": c2, "g2": c3}, netnames={}
+    )
+    ands = module.cells_of_type(["$and"])
+    assert {c.name for c in ands} == {"g0", "g2"}
+    assert module.cells_of_type(["$xor"]) == []
+
+
+# --------------------------------------------------------------------------
+# flops — FF zoo edge cases
+# --------------------------------------------------------------------------
+
+
+def test_is_ff_cell_gate_level_prefix_and_negative() -> None:
+    """Prefix matching recognises the gate-level explosion variants but
+    rejects non-FF cells (flops.py is_ff_cell)."""
+    assert is_ff_cell("$dff")
+    assert is_ff_cell("$_DFFE_PP0P_")
+    assert is_ff_cell("$_SDFFCE_NN1N_")
+    assert not is_ff_cell("$and")
+    assert not is_ff_cell("$dlatch")
+
+
+def test_is_latch_cell_recognises_latch_families() -> None:
+    """``is_latch_cell`` recognises both the higher-level ``$dlatch`` and
+    the gate-level ``$_DLATCH_*`` family, rejecting flops (flops.py:95)."""
+    from rtl_buddy_cdc.flops import is_latch_cell
+
+    assert is_latch_cell("$dlatch")
+    assert is_latch_cell("$_DLATCH_P_")
+    assert is_latch_cell("$_DLATCH_PP0_")
+    assert not is_latch_cell("$dff")
+    assert not is_latch_cell("$and")
+
+
+def test_flop_clk_pin_prefers_uppercase_clk_then_c() -> None:
+    """``flop_clk_pin`` is family-portable: ``CLK`` for higher-level
+    cells, ``C`` for gate-level; ``None`` when neither connects."""
+    hi = Cell(name="f0", type="$dff", connections={"CLK": (2,)})
+    lo = Cell(name="f1", type="$_DFF_P_", connections={"C": (3,)})
+    none = Cell(name="f2", type="$dff", connections={"D": (4,)})
+    assert flop_clk_pin(hi) == (2,)
+    assert flop_clk_pin(lo) == (3,)
+    assert flop_clk_pin(none) is None
+
+
+def test_find_flops_skips_malformed_clk_width() -> None:
+    """A flop whose CLK pin is a multi-bit vector is malformed; the
+    analyzer skips it defensively rather than raising (flops.py:141).
+    A well-formed single-bit-CLK flop in the same module is kept."""
+    bad = Cell(name="f_bad", type="$dff", connections={"CLK": (2, 3), "Q": (5,)})
+    good = Cell(
+        name="f_good", type="$dff", connections={"CLK": (2,), "D": (6,), "Q": (7,)}
+    )
+    module = Module(
+        name="m", ports={}, cells={"f_bad": bad, "f_good": good}, netnames={}
+    )
+    flops = find_flops(module)
+    assert [f.name for f in flops] == ["f_good"]
+    assert flops[0].clk == 2
+    assert flops[0].d == (6,)
+
+
+def test_flop_width_property() -> None:
+    """``Flop.width`` is the count of Q bits (flops.py:123)."""
+    cell = Cell(name="f", type="$dff", connections={"CLK": (2,), "Q": (5, 6, 7)})
+    flop = Flop(cell=cell, clk=2, d=(8, 9, 10), q=(5, 6, 7))
+    assert flop.width == 3
+    assert flop.name == "f"
+
+
+# --------------------------------------------------------------------------
+# domain.trace_clock_root — structural tracing branches
+# --------------------------------------------------------------------------
+
+
+def _mod(ports: dict, cells: dict, netnames: dict | None = None) -> Module:
+    return Module(name="m", ports=ports, cells=cells, netnames=netnames or {})
+
+
+def test_trace_root_direct_input_port() -> None:
+    """The trivial case: the CLK bit is a top-level input port bit, so
+    the trace returns the port name immediately."""
+    module = _mod(
+        ports={"clk": Port("clk", "input", (10,))},
+        cells={},
+    )
+    assert trace_clock_root(module, 10) == "clk"
+
+
+def test_trace_root_through_buffer_and_inverter() -> None:
+    """Single-input buffers / inverters are transparent: the trace walks
+    A back to the clock port (domain.py:196-199)."""
+    module = _mod(
+        ports={"clk": Port("clk", "input", (10,))},
+        cells={
+            "inv": Cell("inv", "$_NOT_", {"A": (10,), "Y": (11,)}),
+            "buf": Cell("buf", "$buf", {"A": (11,), "Y": (12,)}),
+        },
+    )
+    assert trace_clock_root(module, 12) == "clk"
+
+
+def test_trace_root_buffer_without_input_returns_none() -> None:
+    """A buffer with no ``A`` connection cannot be followed back; the
+    trace gives up (domain.py:199, the empty-A return)."""
+    module = _mod(
+        ports={},
+        cells={"buf": Cell("buf", "$buf", {"Y": (12,)})},
+    )
+    assert trace_clock_root(module, 12) is None
+
+
+def test_trace_root_clock_gate_one_side_resolves() -> None:
+    """A two-input clock gate where only A traces to a clock port returns
+    that port; the unresolved enable leg (B) is ignored."""
+    module = _mod(
+        ports={"clk": Port("clk", "input", (10,)), "en": Port("en", "input", (20,))},
+        cells={"icg": Cell("icg", "$and", {"A": (10,), "B": (99,), "Y": (30,)})},
+    )
+    # A resolves to clk; B (bit 99) has no driver and no port → None.
+    assert trace_clock_root(module, 30) == "clk"
+
+
+def test_trace_root_mux_first_side_none_then_second_resolves() -> None:
+    """A clock mux explores A then B; when A is unresolvable the trace
+    falls through to B (domain.py mux loop, both legs)."""
+    module = _mod(
+        ports={"clk": Port("clk", "input", (10,))},
+        # A is a dangling bit (no driver, no port) → None; B is the clock.
+        cells={"mux": Cell("mux", "$mux", {"A": (88,), "B": (10,), "Y": (40,)})},
+    )
+    assert trace_clock_root(module, 40) == "clk"
+
+
+def test_trace_root_mux_empty_a_falls_through_to_b() -> None:
+    """A clock mux with no ``A`` connection skips that leg and resolves
+    via ``B`` (domain.py mux loop, empty-input-port branch 225->223)."""
+    module = _mod(
+        ports={"clk": Port("clk", "input", (10,))},
+        # A is absent entirely; B carries the clock.
+        cells={"mux": Cell("mux", "$mux", {"B": (10,), "Y": (40,)})},
+    )
+    assert trace_clock_root(module, 40) == "clk"
+
+
+def test_trace_root_unknown_driver_cell_returns_none() -> None:
+    """A driver cell that is neither buffer, gate, mux, nor FF on its Q
+    output falls through all clock-network shapes to the final None
+    (domain.py:236->241 false branch)."""
+    module = _mod(
+        ports={},
+        # An adder drives bit 40 on Y — not a recognised clock-network
+        # cell, so the trace can't continue.
+        cells={"add": Cell("add", "$add", {"A": (1,), "B": (2,), "Y": (40,)})},
+    )
+    assert trace_clock_root(module, 40) is None
+
+
+def test_trace_root_mux_both_unresolved_returns_none() -> None:
+    """When neither mux leg resolves to a clock port the trace returns
+    None (domain.py:231)."""
+    module = _mod(
+        ports={},
+        cells={"mux": Cell("mux", "$mux", {"A": (88,), "B": (89,), "Y": (40,)})},
+    )
+    assert trace_clock_root(module, 40) is None
+
+
+def test_trace_root_clock_divider_follows_flop_clk() -> None:
+    """A clock-divider flop's Q is followed back to that flop's own CLK
+    pin, which is the upstream clock root (domain.py divider branch)."""
+    module = _mod(
+        ports={"clk": Port("clk", "input", (10,))},
+        cells={
+            "div": Cell("div", "$dff", {"CLK": (10,), "D": (51,), "Q": (50,)}),
+            # consumer flop clocked off the divided clock (bit 50)
+        },
+    )
+    assert trace_clock_root(module, 50) == "clk"
+
+
+def test_trace_root_divider_flop_without_clk_returns_none() -> None:
+    """A divider flop whose Q is followed but which has no connected CLK
+    pin cannot be traced further; the divider branch returns None
+    (domain.py:241)."""
+    module = _mod(
+        ports={},
+        # A flop driving bit 50 on Q but with no CLK/C connection at all.
+        cells={"div": Cell("div", "$dff", {"D": (51,), "Q": (50,)})},
+    )
+    assert trace_clock_root(module, 50) is None
+
+
+def test_find_crossings_port_walk_skips_untraceable_dst() -> None:
+    """A typed input port fanning into a flop whose clock is untraceable
+    yields no port-sourced crossing (domain.py:462 None-clock skip)."""
+    module = _mod(
+        ports={"din": Port("din", "input", (10,))},
+        cells={
+            # dst flop's CLK (bit 88) has no driver and no port → clock None.
+            "f_dst": Cell("f_dst", "$dff", {"CLK": (88,), "D": (10,), "Q": (11,)}),
+        },
+    )
+    crossings = find_crossings(module, port_clock={"din": "ck_in"})
+    assert [c for c in crossings if c.is_port_sourced] == []
+
+
+def test_trace_root_non_int_bit_returns_none() -> None:
+    """A constant bit ("1") is not a net; the recursive walk bails at the
+    isinstance guard (domain.py:174)."""
+    module = _mod(ports={}, cells={})
+    assert trace_clock_root(module, "1") is None
+
+
+def test_trace_root_undriven_bit_returns_none() -> None:
+    """A net with no driver and no owning port can't be resolved
+    (domain.py:189)."""
+    module = _mod(ports={}, cells={})
+    assert trace_clock_root(module, 7) is None
+
+
+def test_trace_root_stops_at_generated_pin_clock() -> None:
+    """When ``bit_to_clock`` declares a generated clock at an internal
+    pin, the walk stops there and returns the generated name rather than
+    continuing to the top input port."""
+    module = _mod(
+        ports={"clk": Port("clk", "input", (10,))},
+        cells={"buf": Cell("buf", "$buf", {"A": (10,), "Y": (11,)})},
+    )
+    # Bit 11 is declared as the generated clock "gen_clk".
+    root = trace_clock_root(module, 11, bit_to_clock={11: "gen_clk"})
+    assert root == "gen_clk"
+
+
+# --------------------------------------------------------------------------
+# domain.assign_domains / find_crossings — clock_for_port + port crossings
+# --------------------------------------------------------------------------
+
+
+def _two_domain_module() -> Module:
+    """A direct flop→flop crossing: f_src on clk_a, f_dst on clk_b, Q(f_src)
+    wired straight to D(f_dst)."""
+    return _mod(
+        ports={
+            "clk_a": Port("clk_a", "input", (1,)),
+            "clk_b": Port("clk_b", "input", (2,)),
+            "din": Port("din", "input", (10,)),
+        },
+        cells={
+            "f_src": Cell("f_src", "$dff", {"CLK": (1,), "D": (10,), "Q": (20,)}),
+            "f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (20,), "Q": (21,)}),
+        },
+    )
+
+
+def test_assign_domains_normalizes_via_clock_for_port() -> None:
+    """``clock_for_port`` rewrites the raw traced port name to the
+    SDC-canonical clock (domain.py assign_domains normalisation)."""
+    module = _two_domain_module()
+    mapping = {"clk_a": "ck0", "clk_b": "ck1"}
+    domains = assign_domains(module, clock_for_port=lambda p: mapping.get(p))
+    by_name = {fd.flop.name: fd.clock for fd in domains}
+    assert by_name == {"f_src": "ck0", "f_dst": "ck1"}
+
+
+def test_assign_domains_pin_clocks_via_netname() -> None:
+    """``pin_clocks`` flows through ``_build_bit_to_clock``: the SDC pin
+    path (``u/clk_out``) is normalised to the Yosys netname form
+    (``u.clk_out``), its bits harvested, and the trace stops at that
+    generated-clock identity (domain.py:261 bit harvest)."""
+    module = _mod(
+        ports={"clk": Port("clk", "input", (1,))},
+        cells={
+            "buf": Cell("buf", "$buf", {"A": (1,), "Y": (5,)}),
+            "f": Cell("f", "$dff", {"CLK": (5,), "D": (8,), "Q": (9,)}),
+        },
+        # Netname carries a constant bit ("0") alongside the real net so
+        # the int-guard skip branch is exercised too.
+        netnames={"u.clk_out": Netname("u.clk_out", ("0", 5))},
+    )
+    # Second entry has no matching netname → the missing-netname continue
+    # is exercised; it contributes no bit-to-clock mapping.
+    domains = assign_domains(
+        module,
+        pin_clocks={"u/clk_out": "gen_ck", "absent/pin": "nope"},
+    )
+    by_name = {fd.flop.name: fd.clock for fd in domains}
+    assert by_name == {"f": "gen_ck"}
+
+
+def test_assign_domains_clock_for_port_returns_none_keeps_raw() -> None:
+    """When ``clock_for_port`` returns ``None`` (no SDC mapping for the
+    traced port), the raw traced name is kept unchanged (domain.py:296
+    skip branch)."""
+    module = _two_domain_module()
+    # Mapping covers clk_a only; clk_b -> None so its raw name survives.
+    domains = assign_domains(module, clock_for_port=lambda p: {"clk_a": "ck0"}.get(p))
+    by_name = {fd.flop.name: fd.clock for fd in domains}
+    assert by_name == {"f_src": "ck0", "f_dst": "clk_b"}
+
+
+def test_find_crossings_direct_flop_to_flop() -> None:
+    """A direct flop→flop wire in distinct domains is one crossing of
+    width 1 and min_hops 0."""
+    module = _two_domain_module()
+    crossings = find_crossings(module)
+    assert len(crossings) == 1
+    c = crossings[0]
+    assert c.src_flop is not None and c.src_flop.name == "f_src"
+    assert c.dst_flop.name == "f_dst"
+    assert c.src_clock == "clk_a"
+    assert c.dst_clock == "clk_b"
+    assert c.min_hops == 0
+    assert c.width == 1
+    assert not c.is_port_sourced
+    # Flop-sourced crossings report the source flop's name (domain.py:87).
+    assert c.src_name == "f_src"
+
+
+def test_find_crossings_port_sourced(tmp_path: Path) -> None:
+    """With ``port_clock`` supplied, a typed input port that fans into a
+    flop in a different domain produces a port-sourced crossing
+    (domain.py port-walk branches)."""
+    module = _mod(
+        ports={
+            "clk_b": Port("clk_b", "input", (2,)),
+            "din": Port("din", "input", (10,)),
+        },
+        cells={
+            # din feeds a comb buffer then the flop's D, clocked on clk_b.
+            "buf": Cell("buf", "$buf", {"A": (10,), "Y": (11,)}),
+            "f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (11,), "Q": (21,)}),
+        },
+    )
+    crossings = find_crossings(module, port_clock={"din": "clk_in"})
+    port_cross = [c for c in crossings if c.is_port_sourced]
+    assert len(port_cross) == 1
+    c = port_cross[0]
+    assert c.src_port == "din"
+    assert c.src_name == "port din"
+    assert c.src_clock == "clk_in"
+    assert c.dst_clock == "clk_b"
+    # din → buf → f_dst.D is one comb hop.
+    assert c.min_hops == 1
+
+
+def test_find_crossings_skips_untraceable_self_and_same_domain() -> None:
+    """The flop walk skips three non-crossings: a source flop whose clock
+    is untraceable (domain.py:372), a flop feeding its own D pin
+    (self-loop, 390), and a same-domain destination (393). Only the
+    genuine cross-domain edge survives."""
+    module = _mod(
+        ports={
+            "clk_a": Port("clk_a", "input", (1,)),
+            "clk_b": Port("clk_b", "input", (2,)),
+        },
+        cells={
+            # f_dangle's CLK (bit 77) has no driver and no port → clock
+            # untraceable → it's skipped as a crossing source.
+            "f_dangle": Cell(
+                "f_dangle", "$dff", {"CLK": (77,), "D": (40,), "Q": (40,)}
+            ),
+            # f_self feeds its own D (Q == D == bit 30): self-loop skip.
+            "f_self": Cell("f_self", "$dff", {"CLK": (1,), "D": (30,), "Q": (30,)}),
+            # f_same shares clk_a with f_src2; same-domain → no crossing.
+            "f_src2": Cell("f_src2", "$dff", {"CLK": (1,), "D": (9,), "Q": (31,)}),
+            "f_same": Cell("f_same", "$dff", {"CLK": (1,), "D": (31,), "Q": (32,)}),
+            # The one real crossing: f_src2 (clk_a) → f_cross (clk_b).
+            "f_cross": Cell("f_cross", "$dff", {"CLK": (2,), "D": (31,), "Q": (33,)}),
+        },
+    )
+    crossings = find_crossings(module)
+    flop_cross = [c for c in crossings if not c.is_port_sourced]
+    assert len(flop_cross) == 1
+    c = flop_cross[0]
+    assert c.src_flop is not None and c.src_flop.name == "f_src2"
+    assert c.dst_flop.name == "f_cross"
+    assert c.src_clock == "clk_a"
+    assert c.dst_clock == "clk_b"
+
+
+def test_find_crossings_port_walk_skips_missing_and_output_ports() -> None:
+    """The port walk skips ports that aren't real input ports: an output
+    port and a name absent from the module are both ignored
+    (domain.py:451 missing/wrong-direction guard)."""
+    module = _mod(
+        ports={
+            "clk_b": Port("clk_b", "input", (2,)),
+            "qout": Port("qout", "output", (10,)),
+            "din": Port("din", "input", (11,)),
+        },
+        cells={"f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (11,), "Q": (12,)})},
+    )
+    # qout is an output (skipped), "ghost" isn't a port at all (skipped),
+    # only din yields a port-sourced crossing.
+    crossings = find_crossings(
+        module,
+        port_clock={"qout": "ck_o", "ghost": "ck_g", "din": "ck_in"},
+    )
+    port_cross = [c for c in crossings if c.is_port_sourced]
+    assert [c.src_port for c in port_cross] == ["din"]
+    assert port_cross[0].dst_clock == "clk_b"
+
+
+def test_find_crossings_respects_max_hops() -> None:
+    """With ``max_hops=1`` a destination two comb cells deep is never
+    reached, so no crossing is reported — the frontier stops at the hop
+    limit (domain.py:410 / 482 hop-limit guard)."""
+    module = _mod(
+        ports={
+            "clk_a": Port("clk_a", "input", (1,)),
+            "clk_b": Port("clk_b", "input", (2,)),
+            "din": Port("din", "input", (50,)),
+        },
+        cells={
+            "f_src": Cell("f_src", "$dff", {"CLK": (1,), "D": (9,), "Q": (20,)}),
+            "b0": Cell("b0", "$buf", {"A": (20,), "Y": (21,)}),
+            "b1": Cell("b1", "$buf", {"A": (21,), "Y": (22,)}),
+            # dst is 2 comb hops from f_src.Q (20 -> 21 -> 22).
+            "f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (22,), "Q": (23,)}),
+        },
+    )
+    # max_hops=1 cannot reach a 2-hop-deep destination.
+    assert find_crossings(module, max_hops=1) == []
+    # max_hops=2 does.
+    deep = find_crossings(module, max_hops=2)
+    assert len(deep) == 1
+    assert deep[0].min_hops == 2
+
+
+def test_find_crossings_non_int_output_bit_skipped() -> None:
+    """A comb cell whose output vector contains a constant bit ("0")
+    propagates only the integer net, skipping the constant — both the
+    flop walk (domain.py:424) and the port walk (domain.py:492) take the
+    isinstance-skip branch."""
+    module = _mod(
+        ports={
+            "clk_a": Port("clk_a", "input", (1,)),
+            "clk_b": Port("clk_b", "input", (2,)),
+            "din": Port("din", "input", (60,)),
+        },
+        cells={
+            "f_src": Cell("f_src", "$dff", {"CLK": (1,), "D": (9,), "Q": (20,)}),
+            # Comb cell driving a 2-bit Y where one bit is the constant 0.
+            "mix": Cell("mix", "$buf", {"A": (20,), "Y": ("0", 21)}),
+            "f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (21,), "Q": (22,)}),
+            # Port path: din through a cell with a constant output bit too.
+            "pmix": Cell("pmix", "$buf", {"A": (60,), "Y": ("0", 61)}),
+            "f_pdst": Cell("f_pdst", "$dff", {"CLK": (2,), "D": (61,), "Q": (62,)}),
+        },
+    )
+    crossings = find_crossings(module, port_clock={"din": "clk_in"})
+    flop_cross = [c for c in crossings if not c.is_port_sourced]
+    port_cross = [c for c in crossings if c.is_port_sourced]
+    assert len(flop_cross) == 1
+    assert flop_cross[0].dst_flop.name == "f_dst"
+    assert len(port_cross) == 1
+    assert port_cross[0].dst_flop.name == "f_pdst"
+
+
+def test_find_crossings_port_same_domain_no_crossing() -> None:
+    """When the typed port's clock equals the destination flop's clock,
+    the port-walk emits nothing (domain.py:465 same-domain skip)."""
+    module = _mod(
+        ports={
+            "clk_b": Port("clk_b", "input", (2,)),
+            "din": Port("din", "input", (10,)),
+        },
+        cells={"f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (10,), "Q": (21,)})},
+    )
+    # Port typed to the SAME clock domain as the destination flop.
+    crossings = find_crossings(module, port_clock={"din": "clk_b"})
+    assert [c for c in crossings if c.is_port_sourced] == []
+
+
+def test_find_crossings_multibit_bus_collapses_to_one() -> None:
+    """A 2-bit bus from one source flop to one destination flop collapses
+    to a single Crossing of width 2 — the second bit takes the
+    bus-merge branch on the same (src, dst) key (domain.py:406-408)."""
+    module = _mod(
+        ports={
+            "clk_a": Port("clk_a", "input", (1,)),
+            "clk_b": Port("clk_b", "input", (2,)),
+            "din": Port("din", "input", (10, 11)),
+        },
+        cells={
+            # 2-bit source flop on clk_a, Q = bits {20, 21}.
+            "f_src": Cell("f_src", "$dff", {"CLK": (1,), "D": (10, 11), "Q": (20, 21)}),
+            # 2-bit destination flop on clk_b, D = {20, 21}.
+            "f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (20, 21), "Q": (30, 31)}),
+        },
+    )
+    crossings = find_crossings(module)
+    flop_cross = [c for c in crossings if not c.is_port_sourced]
+    assert len(flop_cross) == 1
+    c = flop_cross[0]
+    assert c.width == 2
+    assert c.min_hops == 0
+    assert c.src_clock == "clk_a"
+    assert c.dst_clock == "clk_b"
+
+
+def test_find_crossings_skips_scopeinfo_transit_cell() -> None:
+    """A ``$scopeinfo`` pseudo-cell on a fanout net is skipped as a
+    transit node; the real comb cell behind it still propagates the
+    crossing (domain.py:416 scopeinfo continue)."""
+    module = _mod(
+        ports={
+            "clk_a": Port("clk_a", "input", (1,)),
+            "clk_b": Port("clk_b", "input", (2,)),
+        },
+        cells={
+            "f_src": Cell("f_src", "$dff", {"CLK": (1,), "D": (9,), "Q": (20,)}),
+            # $scopeinfo also reads bit 20 but produces nothing usable.
+            "scope": Cell("scope", "$scopeinfo", {"A": (20,)}),
+            # Real comb buffer carries bit 20 → bit 21.
+            "buf": Cell("buf", "$buf", {"A": (20,), "Y": (21,)}),
+            "f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (21,), "Q": (22,)}),
+        },
+    )
+    crossings = find_crossings(module)
+    flop_cross = [c for c in crossings if not c.is_port_sourced]
+    assert len(flop_cross) == 1
+    # src → buf → dst is one comb hop (the $scopeinfo dead-ends).
+    assert flop_cross[0].min_hops == 1
+
+
+def test_find_crossings_port_walk_multibit_and_scopeinfo() -> None:
+    """The port-sourced walk mirrors the flop walk: a 2-bit typed port
+    fanning into a 2-bit destination flop collapses to width 2, and a
+    ``$scopeinfo`` transit cell on the port net is skipped
+    (domain.py:479-498)."""
+    module = _mod(
+        ports={
+            "clk_b": Port("clk_b", "input", (2,)),
+            "din": Port("din", "input", (10, 11)),
+        },
+        cells={
+            "scope": Cell("scope", "$scopeinfo", {"A": (10,)}),
+            # 2-bit destination flop in clk_b domain reads din bits directly.
+            "f_dst": Cell("f_dst", "$dff", {"CLK": (2,), "D": (10, 11), "Q": (30, 31)}),
+        },
+    )
+    crossings = find_crossings(module, port_clock={"din": "clk_in"})
+    port_cross = [c for c in crossings if c.is_port_sourced]
+    assert len(port_cross) == 1
+    c = port_cross[0]
+    assert c.src_port == "din"
+    assert c.width == 2
+    assert c.min_hops == 0
+    assert c.src_clock == "clk_in"
+    assert c.dst_clock == "clk_b"
+
+
+def test_crossing_src_name_unknown() -> None:
+    """A degenerate Crossing with neither a source flop nor a source port
+    reports ``<unknown>`` (domain.py:90)."""
+    dst_cell = Cell("f_dst", "$dff", {"CLK": (2,), "D": (1,), "Q": (3,)})
+    dst = Flop(cell=dst_cell, clk=2, d=(1,), q=(3,))
+    c = Crossing(
+        src_clock="ck0",
+        dst_flop=dst,
+        dst_clock="ck1",
+        min_hops=0,
+        width=1,
+    )
+    assert c.src_name == "<unknown>"
+
+
+# --------------------------------------------------------------------------
+# domain_map serialization — generated clocks, exclusive groups, ports,
+# port-sourced + clock-network crossings, leaf-name helpers
+# --------------------------------------------------------------------------
+
+
+def test_build_domain_map_generated_clock_with_ports() -> None:
+    """A port-targeted generated clock serializes with its ``ports`` list,
+    a real (non-generated) clock under ``clocks``, and an exclusive group
+    under ``clock_groups`` (domain_map.py:96-106, 128-129)."""
+    spec = ClockSpec()
+    spec.clocks["sys"] = Clock(name="sys", period=10.0, ports=("clk",))
+    spec.clocks["genck"] = Clock(
+        name="genck",
+        period=20.0,
+        ports=("div_out",),
+        master="sys",
+        is_generated=True,
+    )
+    spec.exclusive_groups.append([{"ck0"}, {"ck1"}])
+    module = _mod(ports={"clk": Port("clk", "input", (1,))}, cells={})
+    dm = domain_map.build_domain_map(module, [], [], spec)
+
+    assert dm["clocks"] == [
+        {"name": "sys", "period": 10.0, "source": "create_clock", "ports": ["clk"]}
+    ]
+    gen = dm["generated_clocks"]
+    assert gen == [
+        {"name": "genck", "master": "sys", "period": 20.0, "ports": ["div_out"]}
+    ]
+    grp = dm["clock_groups"]
+    assert grp == [{"kind": "exclusive", "members": [["ck0"], ["ck1"]]}]
+
+
+def test_build_domain_map_async_group_and_flop_crossing_with_location() -> None:
+    """An ``asynchronous`` clock group serializes under ``clock_groups``
+    (domain_map.py:125-126); a flop-sourced crossing serializes with a
+    ``src_flop`` field (232-233); the destination flop's ``src``
+    attribute yields a ``location`` (160); and passing the crossing in
+    ``async_crossings`` flips ``async_per_sdc`` true via ``_crossing_keys``
+    (309-310)."""
+    spec = ClockSpec()
+    spec.async_groups.append([{"ck0"}, {"ck1"}])
+
+    src_cell = Cell(
+        "f_src",
+        "$dff",
+        {"CLK": (1,), "D": (8,), "Q": (20,)},
+        attributes={"src": "m.sv:5.1-5.9"},
+    )
+    dst_cell = Cell(
+        "f_dst",
+        "$dff",
+        {"CLK": (2,), "D": (20,), "Q": (21,)},
+        attributes={"src": "m.sv:9.1-9.9"},
+    )
+    src = Flop(cell=src_cell, clk=1, d=(8,), q=(20,))
+    dst = Flop(cell=dst_cell, clk=2, d=(20,), q=(21,))
+    crossing = Crossing(
+        src_clock="ck0",
+        dst_flop=dst,
+        dst_clock="ck1",
+        min_hops=0,
+        width=1,
+        src_flop=src,
+    )
+    fd_src = FlopDomain(flop=src, clock="ck0")
+    fd_dst = FlopDomain(flop=dst, clock="ck1")
+    module = _mod(ports={}, cells={"f_src": src_cell, "f_dst": dst_cell})
+    dm = domain_map.build_domain_map(
+        module,
+        [fd_src, fd_dst],
+        [crossing],
+        spec,
+        async_crossings=[crossing],
+    )
+
+    assert dm["clock_groups"] == [
+        {"kind": "asynchronous", "members": [["ck0"], ["ck1"]]}
+    ]
+    cross = dm["crossings"]
+    assert len(cross) == 1
+    e = cross[0]
+    assert e["src_flop"] == "m.f_src"
+    assert e["dst_flop"] == "m.f_dst"
+    assert e["async_per_sdc"] is True
+    # Destination flop's src attribute surfaces as a location on its
+    # flop-domains entry.
+    flop_entries = {fe["instance_path"]: fe for fe in dm["flop_domains"]}
+    assert "location" in flop_entries["m.f_dst"]
+
+
+def test_crossing_keys_handles_port_source() -> None:
+    """``_crossing_keys`` builds a stable key for a port-sourced crossing
+    using ``src_port`` (domain_map.py:309-310 port branch). Passing it in
+    ``async_crossings`` marks the matching serialized entry async."""
+    dst_cell = Cell("f_dst", "$dff", {"CLK": (2,), "D": (1,), "Q": (3,)})
+    dst = Flop(cell=dst_cell, clk=2, d=(1,), q=(3,))
+    crossing = Crossing(
+        src_clock="ck_in",
+        dst_flop=dst,
+        dst_clock="ck1",
+        min_hops=1,
+        width=1,
+        src_port="din",
+    )
+    module = _mod(ports={}, cells={"f_dst": dst_cell})
+    dm = domain_map.build_domain_map(
+        module, [], [crossing], None, async_crossings=[crossing]
+    )
+    e = dm["crossings"][0]
+    assert e["src_port"] == "din"
+    assert e["async_per_sdc"] is True
+
+
+def test_build_domain_map_pin_targeted_generated_clock_no_ports() -> None:
+    """A pin-targeted generated clock (the common case) carries no
+    ``ports`` list, so the serialized entry omits the key
+    (domain_map.py:104->106 false branch)."""
+    spec = ClockSpec()
+    spec.clocks["gen"] = Clock(
+        name="gen",
+        period=8.0,
+        ports=(),  # pin-targeted → no port list
+        master="sys",
+        is_generated=True,
+    )
+    module = _mod(ports={}, cells={})
+    dm = domain_map.build_domain_map(module, [], [], spec)
+    assert dm["generated_clocks"] == [{"name": "gen", "master": "sys", "period": 8.0}]
+
+
+def test_build_domain_map_port_domains_filters_sentinel() -> None:
+    """``port_domains`` lists SDC-typed ports but drops the
+    unconstrained sentinel and any port not present in the module
+    (domain_map.py:190 continue)."""
+    spec = ClockSpec()
+    spec.port_clock["data_in"] = "ck0"
+    spec.port_clock["unc"] = UNCONSTRAINED_SENTINEL
+    spec.port_clock["ghost"] = "ck1"  # not declared as a module port
+    module = _mod(
+        ports={"data_in": Port("data_in", "input", (5,))},
+        cells={},
+    )
+    dm = domain_map.build_domain_map(module, [], [], spec)
+    assert dm["port_domains"] == [
+        {"module": "m", "port": "data_in", "clock": "ck0", "kind": "input"}
+    ]
+
+
+def test_build_domain_map_port_sourced_crossing_entry() -> None:
+    """A port-sourced crossing serializes with a ``src_port`` field and no
+    ``src_flop`` (domain_map.py:237)."""
+    dst_cell = Cell("f_dst", "$dff", {"CLK": (2,), "D": (1,), "Q": (3,)})
+    dst = Flop(cell=dst_cell, clk=2, d=(1,), q=(3,))
+    crossing = Crossing(
+        src_clock="ck_in",
+        dst_flop=dst,
+        dst_clock="ck1",
+        min_hops=1,
+        width=1,
+        src_port="din",
+    )
+    module = _mod(ports={}, cells={"f_dst": dst_cell}, netnames={})
+    dm = domain_map.build_domain_map(module, [], [crossing], None)
+    entries = dm["crossings"]
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["src_port"] == "din"
+    assert "src_flop" not in e
+    assert e["src_clock"] == "ck_in"
+    assert e["dst_clock"] == "ck1"
+    # No SDC (None) → nothing is async_per_sdc.
+    assert e["async_per_sdc"] is False
+
+
+def test_build_domain_map_clock_network_crossings() -> None:
+    """The additive ``clock_network_crossings`` list carries the gating
+    cell metadata and is always ``async_per_sdc: true``
+    (domain_map.py:268-)."""
+    src_cell = Cell("f_src", "$dff", {"CLK": (1,), "Q": (10,)})
+    dst_cell = Cell("f_dst", "$dff", {"CLK": (11,), "Q": (12,)})
+    src = Flop(cell=src_cell, clk=1, d=(), q=(10,))
+    dst = Flop(cell=dst_cell, clk=11, d=(), q=(12,))
+    cnc = ClockNetworkCrossing(
+        src_flop=src,
+        src_clock="ck0",
+        dst_flop=dst,
+        dst_clock="ck1",
+        control_cell="u_mux",
+        control_cell_type="$mux",
+        control_pin="S",
+        control_kind="mux-select",
+    )
+    module = _mod(ports={}, cells={"f_src": src_cell, "f_dst": dst_cell})
+    dm = domain_map.build_domain_map(
+        module, [], [], None, clock_network_crossings=[cnc]
+    )
+    cn = dm["clock_network_crossings"]
+    assert len(cn) == 1
+    e = cn[0]
+    assert e["control_cell"] == "u_mux"
+    assert e["control_cell_type"] == "$mux"
+    assert e["control_pin"] == "S"
+    assert e["control_kind"] == "mux-select"
+    assert e["src_clock"] == "ck0"
+    assert e["dst_clock"] == "ck1"
+    assert e["async_per_sdc"] is True
+
+
+def test_serialize_flop_domains_source_instance_path() -> None:
+    """A flop instantiated at top gets ``source_instance_path`` equal to
+    the top module name and an empty parent chain (domain_map flop
+    serialization)."""
+    cell = Cell("f0", "$dff", {"CLK": (1,), "Q": (2,)})
+    flop = Flop(cell=cell, clk=1, d=(), q=(2,))
+    fd = FlopDomain(flop=flop, clock="ck0")
+    module = _mod(ports={}, cells={"f0": cell})
+    dm = domain_map.build_domain_map(module, [fd], [], None)
+    entries = dm["flop_domains"]
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["clock"] == "ck0"
+    assert e["instance_path"] == "m.f0"
+    assert e["source_instance_path"] == "m"
+
+
+def test_cell_leaf_name_flatten_and_slang_dotted() -> None:
+    """``_cell_leaf_name`` strips Yosys ``$flatten\\`` prefixes back to the
+    leaf and trims the slang dotted path to its trailing component
+    (domain_map.py:371, 373)."""
+    # slang dotted, non-$ prefix → trailing component (line 373).
+    assert domain_map._cell_leaf_name("u_a.u_b.q") == "q"
+    # flatten prefix with a $-leaf token → leaf captured.
+    assert domain_map._cell_leaf_name("$flatten\\u_a.$procdff$7") == "$procdff$7"
+    # flatten prefix whose body has no $-token → rsplit fallback (line 371).
+    assert domain_map._cell_leaf_name("$flatten\\u_a.\\plain") == "plain"
+
+
+def test_source_instance_path_none() -> None:
+    """A ``None`` cell name yields ``None`` (domain_map.py:350)."""
+    module = _mod(ports={}, cells={})
+    assert domain_map._source_instance_path(module, None) is None
+
+
+# --------------------------------------------------------------------------
+# frontend — enum + dispatch
+# --------------------------------------------------------------------------
+
+
+def test_frontend_enum_str_values() -> None:
+    """The enum members are stable string values the CLI surfaces."""
+    assert Frontend.yosys.value == "yosys"
+    assert Frontend.slang.value == "slang"
+    assert Frontend.auto.value == "auto"
+
+
+def test_elaborate_unknown_frontend_raises() -> None:
+    """A non-enum frontend value is a programmer error and surfaces as a
+    ValueError (frontend.py:88)."""
+    with pytest.raises(ValueError, match="unknown frontend"):
+        elaborate([Path("x.sv")], "top", frontend="bogus")  # type: ignore[arg-type]
+
+
+def test_resolve_auto_probes_pyslang() -> None:
+    """``resolve_auto`` returns a concrete frontend based on whether
+    pyslang is importable (frontend.py:51-53). In the coverage CI job
+    pyslang is present, so it resolves to slang."""
+    from rtl_buddy_cdc.frontend import resolve_auto
+
+    resolved = resolve_auto()
+    assert resolved in (Frontend.slang, Frontend.yosys)
+    if PYSLANG_INSTALLED:
+        assert resolved is Frontend.slang
+
+
+def test_elaborate_yosys_dispatch_passes_options(monkeypatch, tmp_path: Path):
+    """The ``Frontend.yosys`` branch forwards sources, top, and the
+    yosys-specific keyword options to the yosys frontend (frontend.py:74-83).
+    We stub the concrete frontend so no real yosys binary runs."""
+    seen: dict[str, object] = {}
+
+    def _fake_elaborate(sources, top, *, yosys_bin, keep_json, plugin_path):
+        seen.update(
+            sources=sources,
+            top=top,
+            yosys_bin=yosys_bin,
+            keep_json=keep_json,
+            plugin_path=plugin_path,
+        )
+        return Module(name=top, ports={}, cells={}, netnames={})
+
+    monkeypatch.setattr(yosys_fe, "elaborate", _fake_elaborate)
+    src = tmp_path / "a.sv"
+    keep = tmp_path / "k.json"
+    module = elaborate(
+        [src],
+        "topmod",
+        frontend=Frontend.yosys,
+        yosys_bin="/opt/yosys",
+        keep_json=keep,
+        yosys_plugin="/opt/slang.so",
+    )
+    assert module.name == "topmod"
+    assert seen["sources"] == [src]
+    assert seen["top"] == "topmod"
+    assert seen["yosys_bin"] == "/opt/yosys"
+    assert seen["keep_json"] == keep
+    # frontend.elaborate maps ``yosys_plugin`` -> ``plugin_path``.
+    assert seen["plugin_path"] == "/opt/slang.so"
+
+
+@pytest.mark.skipif(not PYSLANG_INSTALLED, reason="pyslang not installed")
+def test_elaborate_auto_resolves_then_dispatches(tmp_path: Path, monkeypatch) -> None:
+    """``Frontend.auto`` calls ``resolve_auto`` (frontend.py:73) and then
+    dispatches to the resolved concrete frontend. We pin the resolution
+    to slang and elaborate a trivial design through pyslang."""
+    monkeypatch.setattr(frontend_mod, "resolve_auto", lambda: Frontend.slang)
+    sv = tmp_path / "m.sv"
+    sv.write_text(
+        "module m(input logic clk, input logic d, output logic q);\n"
+        "  always_ff @(posedge clk) q <= d;\n"
+        "endmodule\n"
+    )
+    module = elaborate([sv], "m", frontend=Frontend.auto)
+    assert module.name == "m"
+    # The single always_ff lowers to a flop cell.
+    assert any(is_ff_cell(c.type) for c in module.cells.values())
+
+
+# --------------------------------------------------------------------------
+# frontends.yosys — guard / error branches (no real yosys; monkeypatch)
+# --------------------------------------------------------------------------
+
+
+def test_yosys_missing_binary_raises(monkeypatch) -> None:
+    """When yosys is not on PATH the frontend raises a YosysError with an
+    actionable hint (yosys.py:51)."""
+    monkeypatch.setattr(yosys_fe.shutil, "which", lambda name: None)
+    with pytest.raises(YosysError, match="yosys not found on PATH"):
+        yosys_fe.elaborate([Path("x.sv")], "top")
+
+
+def test_yosys_explicit_bin_not_existing_raises(monkeypatch) -> None:
+    """An explicit ``yosys_bin`` that doesn't exist on disk is rejected by
+    the existence guard (yosys.py:50-51)."""
+    # which() returning a path is irrelevant when yosys_bin is explicit;
+    # the path simply doesn't exist.
+    with pytest.raises(YosysError, match="yosys not found on PATH"):
+        yosys_fe.elaborate([Path("x.sv")], "top", yosys_bin="/nonexistent/yosys-binary")
+
+
+def test_yosys_plugin_missing_raises(monkeypatch, tmp_path: Path) -> None:
+    """A configured plugin path that doesn't exist is rejected before any
+    subprocess runs (yosys.py:54)."""
+    fake_yosys = tmp_path / "yosys"
+    fake_yosys.write_text("#!/bin/sh\n")
+    with pytest.raises(YosysError, match="yosys plugin not found"):
+        yosys_fe.elaborate(
+            [Path("x.sv")],
+            "top",
+            yosys_bin=str(fake_yosys),
+            plugin_path="/nonexistent/slang.so",
+        )
+
+
+def test_yosys_elaboration_failure_surfaces_streams(monkeypatch, tmp_path: Path):
+    """A non-zero return code from the (fake) yosys subprocess is turned
+    into a YosysError that surfaces both stderr and stdout
+    (yosys.py:77-85)."""
+    fake_yosys = tmp_path / "yosys"
+    fake_yosys.write_text("#!/bin/sh\n")
+
+    class _Proc:
+        returncode = 1
+        stderr = "ERROR: syntax error near token"
+        stdout = "1. Executing Verilog frontend"
+
+    def _fake_run(cmd, capture_output, text):  # noqa: ANN001
+        # Sanity-check the dispatch wired through to the binary we passed.
+        assert cmd[0] == str(fake_yosys)
+        return _Proc()
+
+    monkeypatch.setattr(yosys_fe.subprocess, "run", _fake_run)
+    with pytest.raises(YosysError) as exc:
+        yosys_fe.elaborate([Path("x.sv")], "top", yosys_bin=str(fake_yosys))
+    msg = str(exc.value)
+    assert "yosys elaboration failed" in msg
+    assert "syntax error near token" in msg
+    assert "Executing Verilog frontend" in msg
+
+
+def test_yosys_failure_stderr_only(monkeypatch, tmp_path: Path) -> None:
+    """When yosys fails with stderr but no stdout, the error message
+    carries only the stderr text — the stdout-append branch is skipped
+    (yosys.py:81->83)."""
+    fake_yosys = tmp_path / "yosys"
+    fake_yosys.write_text("#!/bin/sh\n")
+
+    class _Proc:
+        returncode = 1
+        stderr = "ERROR: top module not found"
+        stdout = "   "  # whitespace only → .strip() is falsy
+
+    monkeypatch.setattr(yosys_fe.subprocess, "run", lambda *a, **k: _Proc())
+    with pytest.raises(YosysError) as exc:
+        yosys_fe.elaborate([Path("x.sv")], "top", yosys_bin=str(fake_yosys))
+    msg = str(exc.value)
+    assert "top module not found" in msg
+    # No stdout body was appended.
+    assert "\n" not in msg.split("top module not found", 1)[1]
+
+
+def test_yosys_failure_empty_streams(monkeypatch, tmp_path: Path) -> None:
+    """When yosys fails with both streams empty the error message is the
+    bare headline — neither the stderr nor the stdout append branch fires
+    (yosys.py:81->83 false branch)."""
+    fake_yosys = tmp_path / "yosys"
+    fake_yosys.write_text("#!/bin/sh\n")
+
+    class _Proc:
+        returncode = 2
+        stderr = ""
+        stdout = ""
+
+    monkeypatch.setattr(yosys_fe.subprocess, "run", lambda *a, **k: _Proc())
+    with pytest.raises(YosysError) as exc:
+        yosys_fe.elaborate([Path("x.sv")], "top", yosys_bin=str(fake_yosys))
+    assert str(exc.value) == "yosys elaboration failed"
+
+
+def test_yosys_success_without_keep_json(monkeypatch, tmp_path: Path) -> None:
+    """On success with ``keep_json=None`` the module loads and no copy is
+    made (yosys.py:88->90 false branch)."""
+    fake_yosys = tmp_path / "yosys"
+    fake_yosys.write_text("#!/bin/sh\n")
+    payload = json.dumps(
+        {"modules": {"topmod": {"ports": {}, "cells": {}, "netnames": {}}}}
+    )
+
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def _fake_run(cmd, capture_output, text):  # noqa: ANN001
+        target = cmd[3].rsplit("write_json ", 1)[1].strip().strip("'")
+        Path(target).write_text(payload)
+        return _Proc()
+
+    monkeypatch.setattr(yosys_fe.subprocess, "run", _fake_run)
+    module = yosys_fe.elaborate([Path("a.sv")], "topmod", yosys_bin=str(fake_yosys))
+    assert module.name == "topmod"
+
+
+def test_yosys_temp_unlink_missing_is_swallowed(monkeypatch, tmp_path: Path):
+    """If the intermediate JSON is already gone when the ``finally`` block
+    runs, the ``FileNotFoundError`` on unlink is swallowed rather than
+    masking the real outcome (yosys.py:94-95)."""
+    fake_yosys = tmp_path / "yosys"
+    fake_yosys.write_text("#!/bin/sh\n")
+
+    class _Proc:
+        returncode = 1
+        stderr = "boom"
+        stdout = ""
+
+    def _fake_run(cmd, capture_output, text):  # noqa: ANN001
+        # Delete the temp file the loader's finally-block expects, forcing
+        # the FileNotFoundError branch.
+        target = cmd[3].rsplit("write_json ", 1)[1].strip().strip("'")
+        Path(target).unlink()
+        return _Proc()
+
+    monkeypatch.setattr(yosys_fe.subprocess, "run", _fake_run)
+    # The YosysError still propagates; the missing temp file must not turn
+    # into an unhandled FileNotFoundError.
+    with pytest.raises(YosysError, match="boom"):
+        yosys_fe.elaborate([Path("x.sv")], "top", yosys_bin=str(fake_yosys))
+
+
+def test_yosys_plugin_path_builds_read_slang_command(monkeypatch, tmp_path: Path):
+    """With a real (existing) plugin path the frontend builds a
+    ``read_slang`` script instead of ``read_verilog`` (yosys.py:62). We
+    intercept the subprocess to inspect the generated script without
+    invoking a real yosys."""
+    fake_yosys = tmp_path / "yosys"
+    fake_yosys.write_text("#!/bin/sh\n")
+    fake_plugin = tmp_path / "slang.so"
+    fake_plugin.write_text("")
+
+    captured: dict[str, str] = {}
+
+    class _Proc:
+        returncode = 1  # fail fast after we capture the script
+        stderr = "stop"
+        stdout = ""
+
+    def _fake_run(cmd, capture_output, text):  # noqa: ANN001
+        # cmd == [yosys, "-q", "-p", script]
+        captured["script"] = cmd[3]
+        return _Proc()
+
+    monkeypatch.setattr(yosys_fe.subprocess, "run", _fake_run)
+    with pytest.raises(YosysError):
+        yosys_fe.elaborate(
+            [Path("a.sv")],
+            "topmod",
+            yosys_bin=str(fake_yosys),
+            plugin_path=str(fake_plugin),
+        )
+    script = captured["script"]
+    assert "read_slang" in script
+    assert "read_verilog" not in script
+    assert "--top topmod" in script
+    assert str(fake_plugin) in script
+
+
+def test_yosys_success_path_with_keep_json(monkeypatch, tmp_path: Path) -> None:
+    """On a zero return code the frontend loads the JSON yosys "wrote" and
+    honours ``keep_json`` by copying the intermediate file
+    (yosys.py:87-90 success branch, exercised without a real yosys)."""
+    fake_yosys = tmp_path / "yosys"
+    fake_yosys.write_text("#!/bin/sh\n")
+    keep = tmp_path / "kept.json"
+
+    json_payload = json.dumps(
+        {
+            "modules": {
+                "topmod": {
+                    "ports": {"clk": {"direction": "input", "bits": [1]}},
+                    "cells": {},
+                    "netnames": {},
+                }
+            }
+        }
+    )
+
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def _fake_run(cmd, capture_output, text):  # noqa: ANN001
+        # The script's final write_json target is the temp file path; the
+        # fake yosys "writes" our payload there so netlist.load succeeds.
+        script = cmd[3]
+        target = script.rsplit("write_json ", 1)[1].strip().strip("'")
+        Path(target).write_text(json_payload)
+        return _Proc()
+
+    monkeypatch.setattr(yosys_fe.subprocess, "run", _fake_run)
+    module = yosys_fe.elaborate(
+        [Path("a.sv")], "topmod", yosys_bin=str(fake_yosys), keep_json=keep
+    )
+    assert module.name == "topmod"
+    assert module.ports["clk"].direction == "input"
+    # keep_json copy was made.
+    assert keep.exists()
+    assert json.loads(keep.read_text())["modules"]["topmod"]
+
+
+# --------------------------------------------------------------------------
+# package entry point
+# --------------------------------------------------------------------------
+
+
+def test_package_main_invokes_app(monkeypatch) -> None:
+    """``rtl_buddy_cdc.main`` is the console-script entry point: it calls
+    the Typer ``app`` (``__init__.py`` body). We stub ``app`` so the call
+    is observed without parsing the live argv, exercising the delegation
+    line."""
+    import rtl_buddy_cdc
+
+    calls: list[bool] = []
+    monkeypatch.setattr(rtl_buddy_cdc, "app", lambda: calls.append(True))
+    rtl_buddy_cdc.main()
+    assert calls == [True]

--- a/tests/test_cov_reporter.py
+++ b/tests/test_cov_reporter.py
@@ -1,0 +1,607 @@
+"""Coverage-focused tests for ``reporter.py`` and ``render.py``.
+
+These exercise rendering branches the canonical ``test_reporter.py`` /
+``test_render.py`` suites leave uncovered:
+
+* reporter: the ``spec is None`` SKIP path, the ``_Style.for_stream``
+  tri-state (``NO_COLOR`` / non-tty / forced-on), the verbose
+  per-crossing listing, the ``info`` severity tally, the baseline
+  carryover text block, ``src_port`` in the JSON crossing dict, and the
+  ``_source_location`` guard branches (unknown cell / no ``src`` attr /
+  unparsable ``src``).
+* render: ports parked outside every cluster, the orphan-clock
+  subgraph + legend label, the no-period legend label, port-sourced and
+  malformed crossings, malformed clock-network crossings, the
+  ``_clock_header`` no-period path, and ``_safe_id`` escaping.
+
+Everything builds ``AnalysisResult`` / ``Violation`` objects directly
+or from a committed Yosys-JSON fixture (loaded with ``netlist.load`` —
+no compiled toolchain binary needed), plus synthetic v1.0 domain-map
+dicts for the renderer.  No frontend, no subprocess, no network.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import assign_domains, find_crossings
+from rtl_buddy_cdc.render import (
+    RenderError,
+    _clock_header,
+    _safe_id,
+    render_mermaid,
+)
+from rtl_buddy_cdc.reporter import (
+    AnalysisResult,
+    _source_location,
+    render_json,
+    render_sarif,
+    render_text,
+)
+from rtl_buddy_cdc.rules import Violation
+from rtl_buddy_cdc.rules import run_all as run_all_rules
+
+FIX_ROOT = Path(__file__).parent / "fixtures"
+
+_BAD_FIX = FIX_ROOT / "bad_single_ff_sync"
+_BAD_JSON = _BAD_FIX / "bad_single_ff_sync.json"
+_BAD_SDC = _BAD_FIX / "bad_single_ff_sync.sdc"
+
+_PORT_FIX = FIX_ROOT / "good_port_typed_sync"
+_PORT_JSON = _PORT_FIX / "good_port_typed_sync.json"
+_PORT_SDC = _PORT_FIX / "good_port_typed_sync.sdc"
+
+
+def _build_result(json_path: Path, sdc_path: Path | None) -> AnalysisResult:
+    """Load a committed fixture and assemble a populated AnalysisResult.
+
+    Passing ``sdc_path=None`` yields a spec-less result so the SKIP
+    rendering path can be exercised without inventing a fake spec.
+    """
+    module = netlist.load(json_path)
+    if sdc_path is None:
+        return AnalysisResult(
+            module=module,
+            domains=assign_domains(module),
+            crossings=find_crossings(module),
+            async_crossings=[],
+            spec=None,
+            violations=[],
+        )
+    spec = sdc_mod.parse_file(sdc_path)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    async_crossings = [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+    violations = run_all_rules(module, async_crossings, spec)
+    return AnalysisResult(
+        module=module,
+        domains=assign_domains(module),
+        crossings=crossings,
+        async_crossings=async_crossings,
+        spec=spec,
+        violations=list(violations),
+    )
+
+
+@pytest.fixture(scope="module")
+def bad_result() -> AnalysisResult:
+    if not _BAD_JSON.exists():
+        pytest.skip(f"fixture not built: {_BAD_JSON}")
+    return _build_result(_BAD_JSON, _BAD_SDC)
+
+
+@pytest.fixture(scope="module")
+def port_result() -> AnalysisResult:
+    if not _PORT_JSON.exists():
+        pytest.skip(f"fixture not built: {_PORT_JSON}")
+    return _build_result(_PORT_JSON, _PORT_SDC)
+
+
+# --- reporter: text SKIP path (spec is None) --------------------------------
+
+
+def test_text_skip_banner_when_no_spec() -> None:
+    """With ``spec=None`` the header verdict is ``SKIP`` and the body is
+    a single yellow-free (color off) advisory; rule checks never run so
+    no Violations block is emitted."""
+    if not _BAD_JSON.exists():
+        pytest.skip(f"fixture not built: {_BAD_JSON}")
+    result = _build_result(_BAD_JSON, None)
+    buf = io.StringIO()
+    render_text(result, buf, color=False)
+    text = buf.getvalue()
+    assert "SKIP" in text
+    collapsed = " ".join(text.split())
+    assert "No SDC supplied" in collapsed
+    assert "rule checks are skipped" in collapsed
+    # The SKIP path returns before rendering any Violations section.
+    assert "Violations" not in text
+    assert "No rule violations." not in text
+
+
+# --- reporter: _Style.for_stream tri-state ----------------------------------
+
+
+def test_style_no_color_env_disables_ansi(
+    bad_result: AnalysisResult, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``NO_COLOR`` set (any value) forces plain text even on a TTY-like
+    stream — the no-color.org convention. No ANSI escape bytes leak."""
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    class _FakeTTY(io.StringIO):
+        def isatty(self) -> bool:  # pragma: no cover - trivial
+            return True
+
+    buf = _FakeTTY()
+    # color=None -> the for_stream tri-state consults NO_COLOR + isatty.
+    render_text(bad_result, buf, color=None)
+    text = buf.getvalue()
+    assert "\033[" not in text  # no ANSI escapes
+    assert "FAIL" in text
+
+
+def test_style_non_tty_stream_disables_ansi(
+    bad_result: AnalysisResult, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-TTY stream (default ``io.StringIO`` reports ``isatty``
+    False) yields plain text when ``color`` is left at its ``None``
+    default."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    buf = io.StringIO()  # isatty() -> False
+    render_text(bad_result, buf, color=None)
+    assert "\033[" not in buf.getvalue()
+
+
+def test_style_forced_color_emits_ansi(
+    bad_result: AnalysisResult, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``color=True`` overrides the stream/env heuristic and emits ANSI
+    even into a plain StringIO. The FAIL verdict is wrapped in the red
+    + bold sequences."""
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    buf = io.StringIO()
+    render_text(bad_result, buf, color=True)
+    text = buf.getvalue()
+    assert "\033[31m" in text  # red (FAIL verdict)
+    assert "\033[1m" in text  # bold
+
+
+# --- reporter: verbose per-crossing listing ---------------------------------
+
+
+def test_text_verbose_lists_each_crossing(port_result: AnalysisResult) -> None:
+    """``verbose=True`` appends a ``Crossings:`` section with one line
+    per structural crossing. ``good_port_typed_sync`` has a single
+    port-sourced crossing, so the line carries the ``(port-sourced)``
+    tag and the ``src_clock → dst_clock`` arrow."""
+    assert port_result.crossings, "fixture should have at least one crossing"
+    buf = io.StringIO()
+    render_text(port_result, buf, verbose=True, color=False)
+    text = buf.getvalue()
+    assert "Crossings:" in text
+    c = port_result.crossings[0]
+    assert f"{c.src_clock} → {c.dst_clock}" in text
+    # The single crossing is port-sourced (src is a typed input port).
+    assert "(port-sourced)" in text
+    assert "port d_in" in text  # Crossing.src_name for a port source
+    assert f"width={c.width}" in text
+
+
+# --- reporter: info severity tally + baseline carryover text ----------------
+
+
+def test_text_info_severity_counted_in_summary(bad_result: AnalysisResult) -> None:
+    """An ``info`` violation is tallied in the cyan summary segment.
+    Built synthetically (no shipping rule emits ``info`` today) so the
+    ``counts['info']`` branch in ``_render_violations`` is exercised."""
+    info_v = Violation(
+        rule_id="CDC-099",
+        severity="info",
+        message="informational only — nothing actionable",
+    )
+    result = AnalysisResult(
+        module=bad_result.module,
+        domains=bad_result.domains,
+        crossings=bad_result.crossings,
+        async_crossings=bad_result.async_crossings,
+        spec=bad_result.spec,
+        violations=[info_v],
+    )
+    buf = io.StringIO()
+    render_text(result, buf, color=False)
+    text = buf.getvalue()
+    assert "1 info" in text
+    collapsed = " ".join(text.split())
+    assert "informational only" in collapsed
+
+
+def test_text_renders_baseline_carryover_block(bad_result: AnalysisResult) -> None:
+    """A ``baseline_carryover`` entry renders under a dedicated
+    ``Carried over from baseline`` header with the rule id and the
+    first line of its message — and never inflates the FAIL verdict
+    (carryover doesn't drive a verdict change here because there's also
+    a kept violation)."""
+    carried = Violation(
+        rule_id="CDC-002",
+        severity="warning",
+        message="insufficient synchronizer depth\nsecond detail line",
+    )
+    result = AnalysisResult(
+        module=bad_result.module,
+        domains=bad_result.domains,
+        crossings=bad_result.crossings,
+        async_crossings=bad_result.async_crossings,
+        spec=bad_result.spec,
+        violations=list(bad_result.violations),
+        baseline_carryover=[carried],
+    )
+    buf = io.StringIO()
+    render_text(result, buf, color=False)
+    text = buf.getvalue()
+    assert "Carried over from baseline (1)" in text
+    assert "CDC-002" in text
+    # Only the first line of the multi-line message is shown.
+    assert "insufficient synchronizer depth" in text
+    assert "second detail line" not in text
+
+
+# --- reporter: JSON src_port + crossing dict --------------------------------
+
+
+def test_json_crossing_carries_src_port(port_result: AnalysisResult) -> None:
+    """A port-sourced crossing serialises with a ``src_port`` key and no
+    ``src_flop`` key (the ``_crossing_to_dict`` branch keyed on
+    ``c.src_port is not None``)."""
+    buf = io.StringIO()
+    render_json(port_result, buf)
+    payload = json.loads(buf.getvalue())
+    assert payload["crossings"], "expected at least one crossing in the payload"
+    port_crossings = [c for c in payload["crossings"] if "src_port" in c]
+    assert len(port_crossings) == 1
+    pc = port_crossings[0]
+    assert pc["src_port"] == "d_in"
+    assert "src_flop" not in pc  # exactly one source endpoint is set
+    assert pc["dst_flop"]  # destination flop is always present
+    assert pc["width"] == 1
+
+
+# --- reporter: _source_location guard branches ------------------------------
+
+
+def test_source_location_none_cell_name(bad_result: AnalysisResult) -> None:
+    """A ``None`` cell name short-circuits to ``None`` (no anchor cell
+    means no source location)."""
+    assert _source_location(bad_result.module, None) is None
+
+
+def test_source_location_unknown_cell(bad_result: AnalysisResult) -> None:
+    """A cell name absent from the module resolves to ``None`` rather
+    than raising a KeyError."""
+    assert _source_location(bad_result.module, "no_such_cell$999") is None
+
+
+def test_source_location_cell_without_src_attr() -> None:
+    """A cell that exists but carries no ``src`` attribute yields
+    ``None`` — there's nothing to point at. Drop the ``src`` key off a
+    real cell so the ``if not src`` guard runs deterministically."""
+    if not _BAD_JSON.exists():
+        pytest.skip(f"fixture not built: {_BAD_JSON}")
+    module = netlist.load(_BAD_JSON)
+    cell_name = next(iter(module.cells))
+    attrs = {k: v for k, v in module.cells[cell_name].attributes.items() if k != "src"}
+    object.__setattr__(module.cells[cell_name], "attributes", attrs)
+    assert _source_location(module, cell_name) is None
+
+
+def test_source_location_unparsable_src_returns_file_only() -> None:
+    """When the ``src`` attribute doesn't match the
+    ``file:line.col-line.col`` grammar, the location degrades to a
+    bare ``{'file': <raw>}`` with no line/column fields."""
+    module = netlist.load(_BAD_JSON) if _BAD_JSON.exists() else None
+    if module is None:
+        pytest.skip(f"fixture not built: {_BAD_JSON}")
+    # Pick any real cell and overwrite its src with a non-conforming
+    # value so the regex misses and the fallback branch runs.
+    cell_name = next(iter(module.cells))
+    object.__setattr__(
+        module.cells[cell_name],
+        "attributes",
+        {**module.cells[cell_name].attributes, "src": "weird_source_no_line_info"},
+    )
+    loc = _source_location(module, cell_name)
+    assert loc == {"file": "weird_source_no_line_info"}
+    assert "start_line" not in loc
+
+
+# --- reporter: SARIF rule defaultConfiguration level ------------------------
+
+
+def test_sarif_rule_default_level_maps_info_to_note() -> None:
+    """SARIF's ``defaultConfiguration.level`` is derived from the first
+    violation's severity for each rule id. An ``info`` severity maps to
+    SARIF ``note`` (per ``_SARIF_LEVEL``)."""
+    module = netlist.load(_BAD_JSON) if _BAD_JSON.exists() else None
+    if module is None:
+        pytest.skip(f"fixture not built: {_BAD_JSON}")
+    info_v = Violation(rule_id="CDC-099", severity="info", message="fyi")
+    result = AnalysisResult(
+        module=module,
+        domains=assign_domains(module),
+        crossings=[],
+        async_crossings=[],
+        spec=None,
+        violations=[info_v],
+    )
+    buf = io.StringIO()
+    render_sarif(result, buf)
+    data = json.loads(buf.getvalue())
+    rules = data["runs"][0]["tool"]["driver"]["rules"]
+    cdc_099 = next(r for r in rules if r["id"] == "CDC-099")
+    assert cdc_099["defaultConfiguration"]["level"] == "note"
+    assert data["runs"][0]["results"][0]["level"] == "note"
+
+
+# --- render: ports outside clusters + orphan / no-period / undeclared -------
+
+
+def test_render_unclocked_and_mystery_ports_outside_clusters() -> None:
+    """Ports with no ``clock`` (or a clock unknown to ``clock_class``)
+    are emitted outside every subgraph with the fallback grey class.
+    A port whose clock matches an orphan flop's undeclared clock is
+    pulled INTO that orphan subgraph instead."""
+    out = render_mermaid(
+        {
+            "schema_version": "1.0",
+            "design": {"top": "t"},
+            "clocks": [{"name": "ca", "period": 10.0}],
+            "generated_clocks": [],
+            "flop_domains": [
+                {"instance_path": "t.fa", "clock": "ca"},
+                {"instance_path": "t.forphan", "clock": "orphan_clk"},
+            ],
+            "port_domains": [
+                # No clock at all -> outside cluster, fallback grey.
+                {"port": "p_unclk", "kind": "input"},
+                # Clock unknown to clock_class -> also outside.
+                {"port": "p_mystery", "clock": "nope", "kind": "output"},
+                # Clock matches the orphan flop's clock -> inside the
+                # synthetic orphan subgraph.
+                {"port": "p_orphan", "clock": "orphan_clk", "kind": "input"},
+            ],
+            "crossings": [],
+        }
+    )
+    # Orphan flop's clock gets an "(undeclared)" subgraph.
+    assert "orphan_clk (undeclared)" in out
+    # The orphan-clocked port sits inside that subgraph's block.
+    assert "p_in_p_orphan" in out
+    # Unclocked + mystery ports rendered with the fallback class.
+    assert ":::port_unassigned" in out
+    assert "p_in_p_unclk" in out
+    assert "p_ou_p_mystery" in out
+    # The mystery-clock port is *not* tucked into any clock subgraph,
+    # so its line is emitted at the 2-space top-level indent.
+    assert "  p_ou_p_mystery" in out
+
+
+def test_render_orphan_clock_subgraph_and_legend_label() -> None:
+    """An orphan clock (referenced by a flop but absent from
+    ``clocks``/``generated_clocks``) renders both an ``(undeclared)``
+    subgraph AND, because there are ≥2 palette entries, a legend entry
+    labelled ``flop · <clk> (undeclared)``."""
+    out = render_mermaid(
+        {
+            "schema_version": "1.0",
+            "design": {"top": "t"},
+            "clocks": [{"name": "ca", "period": 10.0}],
+            "generated_clocks": [],
+            "flop_domains": [
+                {"instance_path": "t.fa", "clock": "ca"},
+                {"instance_path": "t.fb", "clock": "weird_clk"},
+            ],
+            "port_domains": [],
+            "crossings": [],
+        }
+    )
+    # The orphan-clock subgraph.
+    assert 'subgraph clk_weird_clk["weird_clk (undeclared)"]' in out
+    # And the legend's orphan label (line 206 branch).
+    assert "flop · weird_clk (undeclared)" in out
+
+
+def test_render_legend_label_for_clock_without_period() -> None:
+    """A declared clock with no ``period`` falls through to the bare
+    ``flop · <name>`` legend label (neither the orphan branch nor the
+    ``period``-bearing branch)."""
+    out = render_mermaid(
+        {
+            "schema_version": "1.0",
+            "design": {"top": "t"},
+            "clocks": [
+                {"name": "ca", "period": 10.0},
+                {"name": "cb"},  # no period
+            ],
+            "generated_clocks": [],
+            "flop_domains": [
+                {"instance_path": "t.fa", "clock": "ca"},
+                {"instance_path": "t.fb", "clock": "cb"},
+            ],
+            "port_domains": [],
+            "crossings": [],
+        }
+    )
+    # Two clocks => legend emitted. The period-less clock gets a plain
+    # label, while the period-bearing one shows its ns.
+    assert "flop · cb\n" in out or 'flop · cb"' in out
+    assert "flop · ca (10.0 ns)" in out
+
+
+# --- render: crossing source branches ---------------------------------------
+
+
+def test_render_port_sourced_crossing_edge() -> None:
+    """A crossing whose source is a typed input port (``src_port``, no
+    ``src_flop``) draws its edge from the port node id."""
+    out = render_mermaid(
+        {
+            "schema_version": "1.0",
+            "design": {"top": "t"},
+            "clocks": [
+                {"name": "ca", "period": 10.0},
+                {"name": "cb", "period": 10.0},
+            ],
+            "generated_clocks": [],
+            "flop_domains": [{"instance_path": "t.fb", "clock": "cb"}],
+            "port_domains": [{"port": "in0", "clock": "ca", "kind": "input"}],
+            "crossings": [
+                {
+                    "src_clock": "ca",
+                    "dst_clock": "cb",
+                    "src_port": "in0",
+                    "dst_flop": "t.fb",
+                    "width": 1,
+                    "async_per_sdc": True,
+                }
+            ],
+        }
+    )
+    # The async edge originates at the port node (p_in_in0), not a flop.
+    edge = next(
+        line
+        for line in out.splitlines()
+        if "⚠ async" in line and "lg_async" not in line
+    )
+    assert edge.lstrip().startswith("p_in_in0")
+    assert ".-> f_" in edge  # to the hashed destination-flop node
+
+
+def test_render_skips_crossing_without_dst_or_source() -> None:
+    """Malformed crossings are silently dropped: one with no
+    ``dst_flop`` and one with neither ``src_flop`` nor ``src_port``
+    produce no edges, leaving only the single well-formed crossing."""
+    out = render_mermaid(
+        {
+            "schema_version": "1.0",
+            "design": {"top": "t"},
+            "clocks": [
+                {"name": "ca", "period": 10.0},
+                {"name": "cb", "period": 10.0},
+            ],
+            "generated_clocks": [],
+            "flop_domains": [
+                {"instance_path": "t.fa", "clock": "ca"},
+                {"instance_path": "t.fb", "clock": "cb"},
+            ],
+            "port_domains": [],
+            "crossings": [
+                # No dst_flop -> dropped.
+                {"src_clock": "ca", "src_flop": "t.fa", "width": 1},
+                # Neither src_flop nor src_port -> dropped.
+                {"dst_flop": "t.fb", "src_clock": "ca", "dst_clock": "cb"},
+                # Well-formed sync crossing -> a single plain link.
+                {
+                    "src_clock": "ca",
+                    "dst_clock": "cb",
+                    "src_flop": "t.fa",
+                    "dst_flop": "t.fb",
+                    "width": 1,
+                    "async_per_sdc": False,
+                },
+            ],
+        }
+    )
+    plain_links = [line for line in out.splitlines() if " --- " in line]
+    # Exactly the one well-formed sync crossing survives (the legend's
+    # demonstrator link uses lg_sync_* ids).
+    real_links = [line for line in plain_links if "lg_sync" not in line]
+    assert len(real_links) == 1
+    # No real async edge survives — the only ⚠ async motif left is the
+    # legend's demonstrator (placeholder lg_async_* ids).
+    real_async = [
+        line
+        for line in out.splitlines()
+        if "⚠ async" in line and "lg_async" not in line
+    ]
+    assert real_async == []
+
+
+def test_render_skips_malformed_clock_network_crossing() -> None:
+    """A ``clock_network_crossings`` entry missing ``src_flop``/
+    ``dst_flop`` is dropped — no thick ``==>`` arrow, no ``linkStyle``
+    amber directive (the index list stays empty)."""
+    out = render_mermaid(
+        {
+            "schema_version": "1.1",
+            "design": {"top": "t"},
+            "clocks": [
+                {"name": "ck0", "period": 10.0},
+                {"name": "ck1", "period": 13.3},
+            ],
+            "generated_clocks": [],
+            "flop_domains": [
+                {"instance_path": "t.fa", "clock": "ck1"},
+                {"instance_path": "t.fb", "clock": "ck0"},
+            ],
+            "port_domains": [],
+            "crossings": [],
+            "clock_network_crossings": [
+                # Missing both endpoints -> dropped.
+                {"control_cell": "$mux$1", "control_pin": "S"},
+            ],
+        }
+    )
+    assert "==>" not in out
+    assert "clk-ctrl" not in out
+    assert "linkStyle" not in out
+
+
+# --- render: pure helpers ---------------------------------------------------
+
+
+def test_clock_header_without_period_returns_name() -> None:
+    """``_clock_header`` returns the bare name when ``period`` is absent
+    or non-numeric (the ``isinstance(period, (int, float))`` guard
+    fails)."""
+    assert _clock_header({"name": "ck"}) == "ck"
+    assert _clock_header({"name": "ck", "period": None}) == "ck"
+    assert _clock_header({"name": "ck", "period": "fast"}) == "ck"
+    # With a numeric period the formatted form is used.
+    assert _clock_header({"name": "ck", "period": 12.5}) == "ck · 12.5 ns"
+
+
+def test_safe_id_escapes_special_chars_and_leading_digit() -> None:
+    """``_safe_id`` maps each non-alnum/underscore char to ``_`` and
+    prepends a leading underscore when the result wouldn't start with a
+    letter or underscore."""
+    # Slash -> underscore; still starts with a letter.
+    assert _safe_id("clk/0") == "clk_0"
+    # Several specials collapse to underscores.
+    assert _safe_id("a.b/c-d") == "a_b_c_d"
+    # Leading digit -> a leading underscore is inserted.
+    assert _safe_id("0clk") == "_0clk"
+    # Empty / all-special -> the inserted leading underscore keeps it
+    # id-like.
+    assert _safe_id("").startswith("_")
+    assert _safe_id("$$").startswith("_")
+
+
+def test_render_rejects_non_v1_schema() -> None:
+    """The schema guard raises ``RenderError`` for a major-version
+    mismatch, mirrored here so this file is self-contained."""
+    with pytest.raises(RenderError, match="unsupported"):
+        render_mermaid({"schema_version": "3.0"})

--- a/tests/test_cov_reset.py
+++ b/tests/test_cov_reset.py
@@ -1,0 +1,640 @@
+"""Coverage-raising tests for the reset analysis modules.
+
+Three modules under one roof, each exercised on a path the existing
+suite leaves uncovered:
+
+* :mod:`rtl_buddy_cdc.reset_hints` — the strict YAML loader's error
+  and edge branches (wrong container types at each nesting level,
+  ``None``-valued list slots, bad ``clock`` / ``role`` types) plus the
+  ``synchronizer_cell_names`` resolver's exact-match and glob-match
+  arms against a hand-built :class:`Module`.
+* :mod:`rtl_buddy_cdc.reset_domain` — the defensive arms of the
+  per-flop classifier (constant-driven reset, untracked-driver reset,
+  reset-bearing cell missing its pin), the ``_polarity_from_param``
+  empty-string default, the ``iter_reset_sync_chains`` walk on the
+  ``bad_reset_sync_deassert_polarity`` fixture, and the
+  ``find_reset_crossings`` reset-less skip.
+* :mod:`rtl_buddy_cdc.reset_domain_map` — the serializer's
+  reset-less / unknown-cell skips and the ``_reset_source_location``
+  port/constant fallbacks (including a netname ``src`` attr that the
+  reporter regex can't parse).
+
+YAML-dependent loader tests gate per-test on ``find_spec("yaml")``
+the same way :mod:`tests.test_reset_hints_loader` does, so the
+no-extras CI jobs stay green while the coverage job (which has the
+``[hints]`` extra) runs them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist
+from rtl_buddy_cdc.netlist import Cell, Module, Netname, Port
+from rtl_buddy_cdc.reset_domain import (
+    ResetSource,
+    _classify_reset_source,
+    _polarity_from_param,
+    assign_reset_domains,
+    find_reset_crossings,
+    iter_reset_sync_chains,
+)
+from rtl_buddy_cdc.reset_domain_map import (
+    _parse_src_attr,
+    _reset_source_location,
+    build_reset_domain_map,
+)
+from rtl_buddy_cdc.reset_hints import (
+    PortHint,
+    ResetHints,
+    ResetHintsError,
+    SynchronizerHint,
+    load,
+)
+
+PYYAML_INSTALLED = importlib.util.find_spec("yaml") is not None
+
+FIX_ROOT = Path(__file__).parent / "fixtures"
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    """Write a hints YAML body to a temp file and return its path."""
+    p = tmp_path / "hints.yaml"
+    p.write_text(body)
+    return p
+
+
+# === reset_hints: loader error / edge branches =============================
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_missing_reset_hints_top_key_errors(tmp_path: Path) -> None:
+    """A mapping whose only key is in the allow-set but is not
+    ``reset-hints`` itself fails the "missing top-level key" guard.
+
+    ``_ALLOWED_TOP_KEYS`` only contains ``reset-hints``, so the
+    sole way to pass the unknown-key check yet still miss the key is
+    an empty mapping ``{}``."""
+    p = _write(tmp_path, "{}\n")
+    with pytest.raises(ResetHintsError, match="missing 'reset-hints' top-level key"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_reset_hints_block_not_mapping_errors(tmp_path: Path) -> None:
+    """``reset-hints:`` whose value is a scalar (not a mapping) is
+    rejected with the block-type message."""
+    p = _write(tmp_path, "reset-hints: just-a-string\n")
+    with pytest.raises(ResetHintsError, match="'reset-hints' must be a mapping"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_schema_version_non_string_errors(tmp_path: Path) -> None:
+    """A numeric ``schema_version`` (YAML parses ``1.0`` as a float)
+    must be rejected — the field is documented as a string."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          schema_version: 1.0
+          ports: []
+        """,
+    )
+    with pytest.raises(ResetHintsError, match="schema_version must be a string"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_ports_null_is_empty(tmp_path: Path) -> None:
+    """An explicit null ``ports:`` collapses to the empty tuple rather
+    than erroring — same as omitting the key."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          ports:
+          synchronizers:
+        """,
+    )
+    hints = load(p)
+    assert hints.ports == ()
+    assert hints.synchronizers == ()
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_ports_not_a_list_errors(tmp_path: Path) -> None:
+    """A mapping where a list is expected under ``ports`` is rejected."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          ports:
+            name: rst_n
+        """,
+    )
+    with pytest.raises(ResetHintsError, match="'ports' must be a list"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_port_item_not_mapping_errors(tmp_path: Path) -> None:
+    """A bare scalar list item under ``ports`` is rejected with the
+    per-item ``ports[idx]`` context prefix."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          ports:
+            - rst_n
+        """,
+    )
+    with pytest.raises(ResetHintsError, match=r"ports\[0\]: expected mapping"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_port_clock_non_string_errors(tmp_path: Path) -> None:
+    """``clock`` is optional but, when present, must be a string. A
+    numeric value trips the type guard."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          ports:
+            - { name: srst, polarity: high, type: sync, clock: 5 }
+        """,
+    )
+    with pytest.raises(ResetHintsError, match="clock must be a string when set"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_synchronizers_null_is_empty(tmp_path: Path) -> None:
+    """An explicit null ``synchronizers:`` collapses to an empty tuple."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          ports:
+            - { name: rst_n, polarity: low }
+          synchronizers:
+        """,
+    )
+    hints = load(p)
+    assert hints.synchronizers == ()
+    assert hints.ports == (PortHint(name="rst_n", polarity="low"),)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_synchronizers_not_a_list_errors(tmp_path: Path) -> None:
+    """A mapping where a list is expected under ``synchronizers`` is
+    rejected."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          synchronizers:
+            instance: top.u_a
+        """,
+    )
+    with pytest.raises(ResetHintsError, match="'synchronizers' must be a list"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_synchronizer_item_not_mapping_errors(tmp_path: Path) -> None:
+    """A scalar list item under ``synchronizers`` is rejected with the
+    per-item context."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          synchronizers:
+            - top.u_a
+        """,
+    )
+    with pytest.raises(ResetHintsError, match=r"synchronizers\[0\]: expected mapping"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_synchronizer_unknown_key_errors(tmp_path: Path) -> None:
+    """An unknown key under a synchronizer item fails the allow-set
+    check before selector validation."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          synchronizers:
+            - { instance: top.u_a, depth: 2 }
+        """,
+    )
+    with pytest.raises(ResetHintsError, match=r"synchronizers\[0\]: unknown keys"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_synchronizer_selector_non_string_errors(tmp_path: Path) -> None:
+    """``instance`` must be a string when set; a numeric value trips
+    the selector-type guard before the exactly-one check."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          synchronizers:
+            - { instance: 5 }
+        """,
+    )
+    with pytest.raises(ResetHintsError, match="must be strings when set"):
+        load(p)
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_synchronizer_empty_role_errors(tmp_path: Path) -> None:
+    """An empty ``role`` string is rejected by the non-empty-string
+    guard (distinct from the unknown-role guard)."""
+    p = _write(
+        tmp_path,
+        """
+        reset-hints:
+          synchronizers:
+            - { instance: top.u_a, role: "" }
+        """,
+    )
+    with pytest.raises(ResetHintsError, match="'role' must be a non-empty string"):
+        load(p)
+
+
+# === reset_hints: synchronizer_cell_names resolver =========================
+
+
+def _module_with_two_cells() -> Module:
+    """A minimal flattened module with two flop cells whose decoded hier
+    paths are ``top.u_rstgen.$procdff$1`` and ``top.u_rstgen.$procdff$2``.
+
+    Yosys ``flatten`` encodes the nested instance path under the
+    ``$flatten\\`` prefix; the leaf cell is a ``$``-prefixed auto-name
+    (``$procdff$N``). ``_hier_path`` decodes that into the dotted form
+    ``synchronizer_cell_names`` matches against. The cells need no real
+    connectivity for the name-resolution path under test.
+    """
+    cells = {
+        "$flatten\\u_rstgen.$procdff$1": Cell(
+            name="$flatten\\u_rstgen.$procdff$1",
+            type="$adff",
+            connections={},
+        ),
+        "$flatten\\u_rstgen.$procdff$2": Cell(
+            name="$flatten\\u_rstgen.$procdff$2",
+            type="$adff",
+            connections={},
+        ),
+    }
+    return Module(name="top", ports={}, cells=cells, netnames={})
+
+
+def test_synchronizer_cell_names_empty_when_no_synchronizers() -> None:
+    """No synchronizer hints means the resolver short-circuits to an
+    empty set without walking the module's cells."""
+    hints = ResetHints(schema_version="1.0")
+    assert hints.synchronizer_cell_names(_module_with_two_cells()) == set()
+
+
+def test_synchronizer_cell_names_exact_match() -> None:
+    """An ``instance`` hint matches exactly one cell by its decoded
+    hierarchical path and returns that cell's raw name."""
+    module = _module_with_two_cells()
+    hints = ResetHints(
+        schema_version="1.0",
+        synchronizers=(SynchronizerHint(instance="top.u_rstgen.$procdff$1"),),
+    )
+    assert hints.synchronizer_cell_names(module) == {"$flatten\\u_rstgen.$procdff$1"}
+
+
+def test_synchronizer_cell_names_glob_match() -> None:
+    """An ``instance_glob`` hint matches every cell whose decoded path
+    satisfies the shell glob — both sync stages here."""
+    module = _module_with_two_cells()
+    hints = ResetHints(
+        schema_version="1.0",
+        synchronizers=(SynchronizerHint(instance_glob="top.u_rstgen.$procdff$*"),),
+    )
+    assert hints.synchronizer_cell_names(module) == {
+        "$flatten\\u_rstgen.$procdff$1",
+        "$flatten\\u_rstgen.$procdff$2",
+    }
+
+
+def test_synchronizer_cell_names_no_match_is_empty() -> None:
+    """A hint whose selector resolves to nothing yields an empty set —
+    a non-matching glob and a non-matching exact name both miss."""
+    module = _module_with_two_cells()
+    hints = ResetHints(
+        schema_version="1.0",
+        synchronizers=(
+            SynchronizerHint(instance="top.does_not_exist"),
+            SynchronizerHint(instance_glob="top.other.*"),
+        ),
+    )
+    assert hints.synchronizer_cell_names(module) == set()
+
+
+# === reset_domain: classifier defensive arms ==============================
+
+
+def test_classify_reset_source_constant() -> None:
+    """A non-int reset bit (Yosys constant char) classifies as a
+    constant source carrying the literal as its name."""
+    module = Module(name="top", ports={}, cells={}, netnames={})
+    name, kind = _classify_reset_source(module, "1", drivers={})
+    assert (name, kind) == ("1", "constant")
+
+
+def test_classify_reset_source_untracked_driver_is_comb() -> None:
+    """An int reset bit with no port owner and no entry in the
+    bit-drivers table is an untracked driver — classified ``comb``
+    with an empty name."""
+    module = Module(name="top", ports={}, cells={}, netnames={})
+    name, kind = _classify_reset_source(module, 42, drivers={})
+    assert (name, kind) == ("", "comb")
+
+
+def test_classify_reset_source_non_q_driver_is_comb() -> None:
+    """A bit driven by a cell's ``Y`` output (combinational) — not a
+    flop ``Q`` — is classified ``comb``."""
+    module = Module(name="top", ports={}, cells={}, netnames={})
+    name, kind = _classify_reset_source(module, 7, drivers={7: ("u_and", "Y")})
+    assert (name, kind) == ("", "comb")
+
+
+def test_polarity_from_param_empty_defaults_low() -> None:
+    """An empty polarity parameter defaults to the active-low idiom;
+    a trailing ``1`` is active-high; anything else is low."""
+    assert _polarity_from_param("") == "low"
+    assert _polarity_from_param("1") == "high"
+    assert _polarity_from_param("0") == "low"
+    assert _polarity_from_param("00000000000000000000000000000001") == "high"
+
+
+def test_assign_reset_domains_missing_pin_is_resetless() -> None:
+    """A cell typed as reset-bearing (``$adff``) but missing its
+    ``ARST`` pin connection is defensively treated as reset-less rather
+    than crashing the per-flop walk.
+
+    The flop needs the minimal pins ``find_flops`` keys on (``CLK``,
+    ``D``, ``Q``) but deliberately omits ``ARST``.
+    """
+    cell = Cell(
+        name="u_ff",
+        type="$adff",
+        connections={"CLK": (1,), "D": (2,), "Q": (3,)},
+        parameters={"WIDTH": "1", "ARST_POLARITY": "1"},
+    )
+    module = Module(name="top", ports={}, cells={"u_ff": cell}, netnames={})
+    domains = assign_reset_domains(module)
+    assert "u_ff" in domains
+    assert domains["u_ff"].reset is None
+
+
+def test_find_reset_crossings_skips_resetless_flop() -> None:
+    """A plain ``$dff`` (no reset pin) produces a ``ResetDomain`` whose
+    ``reset`` is ``None``; ``find_reset_crossings`` skips it entirely,
+    emitting no crossing for that flop."""
+    cell = Cell(
+        name="u_ff",
+        type="$dff",
+        connections={"CLK": (1,), "D": (2,), "Q": (3,)},
+        parameters={"WIDTH": "1"},
+    )
+    module = Module(name="top", ports={}, cells={"u_ff": cell}, netnames={})
+    crossings = find_reset_crossings(module, clock_domains={"u_ff": "clk"})
+    assert crossings == []
+
+
+# === reset_domain: iter_reset_sync_chains ==================================
+
+
+def _load(name: str) -> Module:
+    """Load a committed netlist-JSON fixture via the pure JSON reader."""
+    path = FIX_ROOT / name / f"{name}.json"
+    if not path.exists():
+        pytest.skip(f"fixture not built: {path}")
+    return netlist.load(path)
+
+
+def test_iter_reset_sync_chains_on_deassert_polarity_fixture() -> None:
+    """``bad_reset_sync_deassert_polarity`` is a real 2FF async-reset
+    synchroniser whose head ``D`` is tied to the *wrong* constant for
+    its polarity. ``iter_reset_sync_chains`` recognises the structural
+    chain and surfaces the head's literal D-constant plus the chain's
+    polarity — the facts RDC-007 compares.
+    """
+    from rtl_buddy_cdc.domain import assign_domains
+
+    module = _load("bad_reset_sync_deassert_polarity")
+    clock_domains = {fd.flop.cell.name: fd.clock for fd in assign_domains(module)}
+    chains = iter_reset_sync_chains(module, clock_domains)
+    assert len(chains) == 1, [c.flops for c in chains]
+    chain = chains[0]
+    # A 2FF synchroniser: head + tail.
+    assert len(chain.flops) == 2
+    assert chain.polarity in {"high", "low"}
+    # The head D constant is a Yosys-encoded literal string.
+    assert isinstance(chain.head_d_constant, str)
+    assert chain.head_d_constant in {"0", "1", "x", "z"}
+
+
+def test_iter_reset_sync_chains_empty_when_min_depth_too_high() -> None:
+    """Bumping ``min_depth`` past the chain length drops the chain — no
+    chain records survive the length filter."""
+    from rtl_buddy_cdc.domain import assign_domains
+
+    module = _load("bad_reset_sync_deassert_polarity")
+    clock_domains = {fd.flop.cell.name: fd.clock for fd in assign_domains(module)}
+    assert iter_reset_sync_chains(module, clock_domains, min_depth=5) == []
+
+
+def _two_flop_chain(head_arst_bit: int, head_reset_port: str) -> Module:
+    """A tail→head Q→D pair, both async-reset, in the same clock domain.
+
+    ``u_tail``'s ``D`` is driven by ``u_head``'s ``Q`` (Q→D), ``u_head``'s
+    ``D`` is tied to the constant ``1``. The head's ``ARST`` is wired to
+    ``head_reset_port`` (bit ``head_arst_bit``) so the caller can make the
+    two flops share — or *not* share — a reset source. The tail's ``ARST``
+    is always the top-level ``rst_a`` (bit 10).
+    """
+    tail = Cell(
+        name="u_tail",
+        type="$adff",
+        connections={"CLK": (1,), "D": (5,), "Q": (6,), "ARST": (10,)},
+        parameters={"WIDTH": "1", "ARST_POLARITY": "0"},
+    )
+    head = Cell(
+        name="u_head",
+        type="$adff",
+        connections={"CLK": (1,), "D": ("1",), "Q": (5,), "ARST": (head_arst_bit,)},
+        parameters={"WIDTH": "1", "ARST_POLARITY": "0"},
+    )
+    ports = {
+        "rst_a": Port(name="rst_a", direction="input", bits=(10,)),
+        head_reset_port: Port(
+            name=head_reset_port, direction="input", bits=(head_arst_bit,)
+        ),
+    }
+    return Module(
+        name="top", ports=ports, cells={"u_tail": tail, "u_head": head}, netnames={}
+    )
+
+
+def test_iter_reset_sync_chains_rejects_mismatched_reset_signature() -> None:
+    """The Q→D walk only follows flops that *share* the tail's reset
+    source. A head flop reset by a different top-level port breaks the
+    chain (reset_domain.py line 415): the walk rejects it and no chain
+    is recognised."""
+    # head reset by ``rst_b`` (bit 11) — different source than tail's rst_a.
+    module = _two_flop_chain(head_arst_bit=11, head_reset_port="rst_b")
+    clock_domains = {"u_tail": "clk", "u_head": "clk"}
+    assert iter_reset_sync_chains(module, clock_domains) == []
+
+
+def test_iter_reset_sync_chains_rejects_untraceable_driver_clock() -> None:
+    """When the upstream driver flop's clock is untraceable (absent from
+    ``clock_domains``), the walk refuses to follow it (reset_domain.py
+    line 411). Even though both flops share the same reset port, the
+    missing clock breaks recognition."""
+    # head and tail share rst_a, but the head's clock isn't in the map.
+    module = _two_flop_chain(head_arst_bit=10, head_reset_port="rst_a")
+    clock_domains: dict[str, str | None] = {"u_tail": "clk", "u_head": None}
+    assert iter_reset_sync_chains(module, clock_domains) == []
+
+
+# === reset_domain_map: serializer skips + location fallbacks ===============
+
+
+def test_serialize_synchronizers_skips_unknown_cell() -> None:
+    """A ``recognised_syncs`` name with no matching ``reset_domains``
+    entry is silently skipped — the resolver only emits members it can
+    look up. Here every other input is empty, so the synchronizers
+    section is empty despite the dangling name."""
+    module = Module(name="top", ports={}, cells={}, netnames={})
+    payload = build_reset_domain_map(
+        module,
+        reset_domains={},
+        clock_domains={},
+        recognised_syncs={"ghost_cell"},
+        polarity_overrides={},
+        reset_crossings=[],
+    )
+    assert payload["reset_synchronizers"] == []
+    assert payload["flop_resets"] == []
+    assert payload["reset_sources"] == []
+
+
+def test_serialize_flop_resets_skips_resetless_flop() -> None:
+    """The ``flop_resets`` section is a *reset* inventory: a plain
+    ``$dff`` (no reset pin) is omitted while a reset-bearing ``$adff``
+    is emitted. Only the reset-bearing flop survives the section.
+    """
+    plain = Cell(
+        name="u_plain",
+        type="$dff",
+        connections={"CLK": (1,), "D": (2,), "Q": (3,)},
+        parameters={"WIDTH": "1"},
+    )
+    rstd = Cell(
+        name="u_rstd",
+        type="$adff",
+        connections={"CLK": (1,), "D": (4,), "Q": (5,), "ARST": (6,)},
+        parameters={"WIDTH": "1", "ARST_POLARITY": "1"},
+    )
+    module = Module(
+        name="top",
+        ports={"arst": Port(name="arst", direction="input", bits=(6,))},
+        cells={"u_plain": plain, "u_rstd": rstd},
+        netnames={},
+    )
+    clock_domains = {"u_plain": "clk", "u_rstd": "clk"}
+    reset_domains = assign_reset_domains(module)
+    assert reset_domains["u_plain"].reset is None
+    assert reset_domains["u_rstd"].reset is not None
+    payload = build_reset_domain_map(
+        module,
+        reset_domains,
+        clock_domains,
+        recognised_syncs=set(),
+        polarity_overrides={},
+        reset_crossings=[],
+    )
+    # Only the reset-bearing flop appears in the reset inventory.
+    paths = [fr["instance_path"] for fr in payload["flop_resets"]]
+    assert paths == ["top.u_rstd"]
+    fr = payload["flop_resets"][0]
+    assert fr["reset"] == "arst"
+    assert fr["reset_kind"] == "port"
+    assert fr["polarity"] == "high"
+    assert fr["type"] == "async"
+
+
+def test_reset_source_location_port_without_src_returns_none() -> None:
+    """A ``port`` source whose netname is absent (or carries no ``src``
+    attribute) has no resolvable location."""
+    module = Module(name="top", ports={}, cells={}, netnames={})
+    assert _reset_source_location(module, "rst_n", "port") is None
+
+
+def test_reset_source_location_port_with_src_attr() -> None:
+    """A ``port`` source whose netname carries a parseable ``src``
+    attribute resolves to a file/line location."""
+    nn = Netname(
+        name="rst_n",
+        bits=(1,),
+        attributes={"src": "design.sv:12.5-12.20"},
+    )
+    module = Module(name="top", ports={}, cells={}, netnames={"rst_n": nn})
+    loc = _reset_source_location(module, "rst_n", "port")
+    assert loc == {
+        "file": "design.sv",
+        "start_line": 12,
+        "start_column": 5,
+        "end_line": 12,
+        "end_column": 20,
+    }
+
+
+def test_reset_source_location_constant_returns_none() -> None:
+    """A ``constant`` reset source has no source location."""
+    module = Module(name="top", ports={}, cells={}, netnames={})
+    assert _reset_source_location(module, "1", "constant") is None
+
+
+def test_parse_src_attr_unparseable_falls_back_to_file() -> None:
+    """A ``src`` attribute the reporter regex can't match (no
+    ``:line``) falls back to a file-only location."""
+    assert _parse_src_attr("plainname") == {"file": "plainname"}
+
+
+def test_parse_src_attr_empty_returns_none() -> None:
+    """An empty ``src`` attribute resolves to no location."""
+    assert _parse_src_attr("") is None
+
+
+def test_parse_src_attr_full_location() -> None:
+    """A fully-specified ``src`` attribute decodes every coordinate."""
+    assert _parse_src_attr("foo.sv:3.1-4.9") == {
+        "file": "foo.sv",
+        "start_line": 3,
+        "start_column": 1,
+        "end_line": 4,
+        "end_column": 9,
+    }
+
+
+def test_resetsource_frozen() -> None:
+    """The reset data model is frozen so consumers can hash/cache it."""
+    rs = ResetSource(name="rst_n", polarity="low", type="async", source="port")
+    with pytest.raises(Exception):
+        rs.name = "other"  # type: ignore[misc]

--- a/tests/test_cov_rules_a.py
+++ b/tests/test_cov_rules_a.py
@@ -1,0 +1,820 @@
+"""Coverage-focused tests for the CDC-001..CDC-010 rule pack and its
+shared structural helpers in :mod:`rtl_buddy_cdc.rules`.
+
+These tests exercise paths the committed paired fixtures don't reach on
+their own:
+
+* the **lazy-context** branch in every ``check_cdc_NNN`` (calling a rule
+  directly, with ``ctx=None``, so the rule builds its own
+  ``_RuleContext`` / ``reader_counts`` / ``d_bit_to_single_bit_flop``);
+* the early-return guards in ``_chain_has_inter_stage_comb`` and
+  ``_is_multibit_sync_first_stage``;
+* CDC-008's gate-level-FF ``C``-pin exemption and per-(bit,cell,pin)
+  dedupe;
+* CDC-010's empty-control-pin skip, the ``clock_spec is None``
+  ``_async`` fallback, and the ``(* glitchless_clock_mux *)``
+  suppression;
+* the ``"high"`` polarity branch and the reset-hints overlay in
+  ``user_reset_polarity_overrides``.
+
+Everything is built either from a committed Yosys-JSON fixture
+(``netlist.load`` — no toolchain) or from hand-constructed
+``Module`` / ``Cell`` / ``Netname`` dataclasses, mirroring the
+self-contained style of ``tests/test_rule_corners.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.flops import Flop, find_flops
+from rtl_buddy_cdc.netlist import Cell, Module, Netname, Port
+from rtl_buddy_cdc.rules import (
+    _build_context,  # noqa: PLC2701
+    _chain_has_inter_stage_comb,  # noqa: PLC2701
+    _is_multibit_sync_first_stage,  # noqa: PLC2701
+    _sync_chain_depth,  # noqa: PLC2701
+    check_cdc_001,
+    check_cdc_002,
+    check_cdc_003,
+    check_cdc_004,
+    check_cdc_005,
+    check_cdc_006,
+    check_cdc_008,
+    check_cdc_010,
+    run_all,
+    user_reset_polarity_overrides,
+)
+from rtl_buddy_cdc.sdc import parse as parse_sdc
+
+FIX_ROOT = Path(__file__).parent / "fixtures"
+
+PYYAML_INSTALLED = importlib.util.find_spec("yaml") is not None
+
+
+# --- shared helpers ---------------------------------------------------------
+
+
+def _load_fixture(name: str) -> tuple[Module, sdc_mod.ClockSpec]:
+    """Load a committed fixture's netlist + SDC. Skips if not built."""
+    fix_dir = FIX_ROOT / name
+    json_path = fix_dir / f"{name}.json"
+    sdc_path = fix_dir / f"{name}.sdc"
+    if not json_path.exists():
+        pytest.skip(f"fixture not built: {json_path}")
+    module = netlist.load(json_path)
+    spec = sdc_mod.parse_file(sdc_path)
+    return module, spec
+
+
+def _async_crossings(module: Module, spec: sdc_mod.ClockSpec) -> list:
+    """The async-filtered crossing list every fixture test re-derives."""
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    return [
+        c
+        for c in crossings
+        if spec.are_async(
+            spec.clock_for_port(c.src_clock) or c.src_clock,
+            spec.clock_for_port(c.dst_clock) or c.dst_clock,
+        )
+    ]
+
+
+# --- lazy-context branch in each rule ---------------------------------------
+#
+# Every ``check_cdc_NNN`` lazily builds its own ``_RuleContext`` when
+# called with ``ctx=None``. The fixture-driven tests always go through
+# ``run_all`` (which pre-builds the context), so the lazy branch — and,
+# transitively, ``_bit_reader_count`` and the lazy
+# ``d_bit_to_single_bit_flop`` build inside ``_sync_chain_depth`` — is
+# only reached on a direct call. We use ``bad_single_ff_sync`` because
+# it has a real single-bit flop→flop crossing that CDC-001 fires on.
+
+
+def test_check_cdc_001_lazy_context_fires() -> None:
+    """Calling ``check_cdc_001`` directly (``ctx=None``) builds its own
+    context and still fires on a single-flop crossing — exercising the
+    lazy ``_build_context`` / ``_bit_reader_count`` paths."""
+    module, spec = _load_fixture("bad_single_ff_sync")
+    crossings = _async_crossings(module, spec)
+    violations = check_cdc_001(module, crossings, spec)  # no ctx=
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.rule_id == "CDC-001"
+    assert v.severity == "error"
+    assert "unsynchronized control crossing" in v.message
+    assert "chain depth = 1" in v.message
+
+
+def test_check_cdc_002_lazy_context_fires_when_depth_raised() -> None:
+    """``check_cdc_002`` with ``required_depth=3`` and ``ctx=None`` must
+    build its own context and fire on a 2FF chain that's below the
+    raised bar."""
+    module, spec = _load_fixture("good_2ff_sync")
+    crossings = _async_crossings(module, spec)
+    silent = check_cdc_002(module, crossings, spec, 2)  # default bar
+    assert silent == []
+    raised = check_cdc_002(module, crossings, spec, 3)  # no ctx=
+    assert len(raised) == 1
+    assert raised[0].rule_id == "CDC-002"
+    assert raised[0].severity == "warning"
+    assert "required >= 3" in raised[0].message
+
+
+def test_check_cdc_002_skips_user_marked_synchronizer() -> None:
+    """At a raised ``required_depth`` of 3, a crossing whose destination
+    flop is a ``(* cdc_sync *)``-marked synchronizer is skipped (the
+    ``c.dst_flop ... in ctx.user_syncs`` branch, rules.py line 888).
+    The user vouches for the synchronizer shape regardless of measured
+    depth, so CDC-002 stays silent."""
+    module, spec = _load_fixture("marked_single_ff_sync")
+    crossings = _async_crossings(module, spec)
+    assert crossings, "fixture should expose the marked crossing"
+    violations = check_cdc_002(module, crossings, spec, 3)
+    assert [v for v in violations if v.rule_id == "CDC-002"] == []
+
+
+def test_check_cdc_002_skips_quasi_static_source() -> None:
+    """A 1-bit crossing whose *source* flop is ``(* cdc_static *)`` is
+    skipped at the static-source branch (rules.py line 890): the value
+    is held constant during operation, so cross-domain sampling is
+    coherent and synchronizer depth is moot."""
+    module, spec = _load_fixture("marked_quasi_static")
+    crossings = _async_crossings(module, spec)
+    one_bit = [c for c in crossings if c.width == 1]
+    assert one_bit, "fixture should expose a 1-bit quasi-static crossing"
+    violations = check_cdc_002(module, crossings, spec, 3)
+    assert [v for v in violations if v.rule_id == "CDC-002"] == []
+
+
+def test_check_cdc_002_skips_unconstrained_port_crossing() -> None:
+    """CDC-002's unconstrained-port skip (rules.py line 886): a 1-bit
+    crossing whose ``src_clock`` is the unconstrained sentinel belongs
+    to CDC-011, not CDC-002. Even with the depth bar raised to 3,
+    CDC-002 must stay silent on those crossings."""
+    module, spec = _load_fixture("bad_unconstrained_input_two_domains")
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    unconstrained = [
+        c for c in crossings if c.src_clock == sdc_mod.UNCONSTRAINED_SENTINEL
+    ]
+    assert unconstrained, "fixture should expose unconstrained-port crossings"
+    violations = check_cdc_002(module, crossings, spec, 3)
+    assert [v for v in violations if v.rule_id == "CDC-002"] == []
+
+
+def test_check_cdc_001_skips_quasi_static_source() -> None:
+    """CDC-001's static-source branch (rules.py line 824): the marked
+    1-bit quasi-static crossing must not be reported as an
+    unsynchronized control crossing."""
+    module, spec = _load_fixture("marked_quasi_static")
+    crossings = _async_crossings(module, spec)
+    violations = check_cdc_001(module, crossings, spec)
+    assert [v for v in violations if v.rule_id == "CDC-001"] == []
+
+
+def test_check_cdc_003_lazy_context() -> None:
+    """``check_cdc_003`` called directly fires on the comb-between-source
+    -and-synchronizer shape, building its own context."""
+    module, spec = _load_fixture("bad_comb_before_sync")
+    crossings = _async_crossings(module, spec)
+    violations = check_cdc_003(module, crossings, spec)  # no ctx=
+    cdc_003 = [v for v in violations if v.rule_id == "CDC-003"]
+    assert len(cdc_003) >= 1
+    assert cdc_003[0].severity == "error"
+    assert "combinational logic between source flop" in cdc_003[0].message
+
+
+def test_check_cdc_005_lazy_context() -> None:
+    """``check_cdc_005`` called directly fires on the reconvergent-sync
+    fixture, building its own context (covers the ``ctx is None``
+    branch and the grouped-walk code path)."""
+    module, spec = _load_fixture("bad_reconvergent_with_recombine")
+    crossings = _async_crossings(module, spec)
+    violations = check_cdc_005(module, crossings, spec)  # no ctx=
+    cdc_005 = [v for v in violations if v.rule_id == "CDC-005"]
+    assert len(cdc_005) >= 1
+    assert cdc_005[0].severity == "warning"
+    assert "reconvergent synchronizers" in cdc_005[0].message
+
+
+def test_check_cdc_006_lazy_context() -> None:
+    """``check_cdc_006`` called directly fires on the glitchy-comb-source
+    fixture, building its own context."""
+    module, spec = _load_fixture("bad_comb_source")
+    crossings = _async_crossings(module, spec)
+    violations = check_cdc_006(module, crossings, spec)  # no ctx=
+    cdc_006 = [v for v in violations if v.rule_id == "CDC-006"]
+    assert len(cdc_006) == 1
+    assert cdc_006[0].severity == "error"
+    assert "glitchy combinational source" in cdc_006[0].message
+
+
+def test_check_cdc_004_lazy_context_fires_on_binary_fifo_ptrs() -> None:
+    """The async-FIFO with *binary* pointers crosses two multi-bit buses
+    with no gating and a non-gray source — CDC-004 must fire on both.
+
+    Calling ``check_cdc_004`` directly exercises the lazy-context
+    branch; the binary pointers exercise the
+    ``_is_multibit_sync_first_stage`` ∧ ``_is_gray_encoded_source``
+    composite that *fails* the gray-coded-crossing exemption (the
+    source is binary, so ``_is_gray_encoded_source`` returns False)."""
+    module, spec = _load_fixture("bad_async_fifo_binary_ptrs")
+    crossings = _async_crossings(module, spec)
+    violations = check_cdc_004(module, crossings, spec)  # no ctx=
+    cdc_004 = [v for v in violations if v.rule_id == "CDC-004"]
+    assert len(cdc_004) == 2, (
+        f"expected both binary pointer crossings to fire CDC-004, got "
+        f"{[v.message for v in cdc_004]}"
+    )
+    for v in cdc_004:
+        assert v.severity == "error"
+        assert "unprotected bus crossing" in v.message
+
+
+# --- _sync_chain_depth lazy build (reader_counts / d_bit map None) ----------
+
+
+def test_sync_chain_depth_lazy_builds_internal_indexes() -> None:
+    """``_sync_chain_depth`` called with both ``reader_counts=None`` and
+    ``d_bit_to_single_bit_flop=None`` rebuilds them internally. On a
+    2FF chain the head flop reports depth 2."""
+    module, spec = _load_fixture("good_2ff_sync")
+    crossings = _async_crossings(module, spec)
+    assert crossings, "fixture should have at least one crossing"
+    c = crossings[0]
+    ctx = _build_context(module, spec)
+    # Call with the lazy-build path: omit reader_counts and the d-bit map.
+    depth = _sync_chain_depth(module, c.dst_flop, c.dst_clock, ctx.domains)
+    assert depth == 2, f"2FF synchronizer head should be depth 2, got {depth}"
+
+
+# --- _chain_has_inter_stage_comb guard branches -----------------------------
+#
+# The CDC-014-firing fixture exercises the *match* path; here we pin the
+# early-return guards with hand-built flops so a refactor can't silently
+# turn one of them into a false match.
+
+
+def _single_flop(name: str, clk: int, d: tuple[int, ...], q: tuple[int, ...]) -> Flop:
+    cell = Cell(
+        name=name,
+        type="$dff",
+        connections={"CLK": (clk,), "D": d, "Q": q},
+    )
+    return Flop(cell=cell, clk=clk, d=d, q=q)
+
+
+def test_chain_has_inter_stage_comb_returns_none_for_multibit_head() -> None:
+    """A width-2 head can't be a single-bit sync-chain stage; the helper
+    bails immediately (``len(head.q) != 1``)."""
+    head = _single_flop("head", clk=2, d=(3, 4), q=(5, 6))
+    module = Module(name="m", ports={}, cells={"head": head.cell}, netnames={})
+    ctx = _build_context(module, clock_spec=None)
+    assert _chain_has_inter_stage_comb(head, ctx) is None
+
+
+def test_chain_has_inter_stage_comb_returns_none_for_constant_q() -> None:
+    """A head whose single Q bit is a constant (string) can't drive a
+    follow-on stage; the ``not isinstance(head_q, int)`` guard fires."""
+    head = _single_flop("head", clk=2, d=(3,), q=("0",))
+    module = Module(name="m", ports={}, cells={"head": head.cell}, netnames={})
+    ctx = _build_context(module, clock_spec=None)
+    assert _chain_has_inter_stage_comb(head, ctx) is None
+
+
+def test_chain_has_inter_stage_comb_matches_gate_then_flop() -> None:
+    """Positive path on a hand-built module: head.Q feeds an ``$and``
+    whose Y drives a same-domain flop's D. The helper returns that
+    downstream flop — the structural shape CDC-014 reports and CDC-001
+    defers on."""
+    clk = 2
+    head = Cell(
+        name="head", type="$dff", connections={"CLK": (clk,), "D": (3,), "Q": (4,)}
+    )
+    gate = Cell(name="gate", type="$and", connections={"A": (4,), "B": (9,), "Y": (5,)})
+    follow = Cell(
+        name="follow", type="$dff", connections={"CLK": (clk,), "D": (5,), "Q": (6,)}
+    )
+    module = Module(
+        name="m",
+        ports={"clk": Port(name="clk", direction="input", bits=(clk,))},
+        cells={"head": head, "gate": gate, "follow": follow},
+        netnames={},
+    )
+    ctx = _build_context(module, clock_spec=None)
+    head_flop = next(f for f in find_flops(module) if f.cell.name == "head")
+    matched = _chain_has_inter_stage_comb(head_flop, ctx)
+    assert matched is not None
+    assert matched.cell.name == "follow"
+
+
+# --- _is_multibit_sync_first_stage guard branches ---------------------------
+
+
+def test_chain_has_inter_stage_comb_rejects_foreign_domain_followon() -> None:
+    """When the comb cell's output drives a flop in a *different* clock
+    domain, the inter-stage-comb pattern does not match — the follow-on
+    isn't a same-domain sync stage (the domain-mismatch ``continue``,
+    rules.py line 786)."""
+    clk_a, clk_b = 2, 3
+    head = Cell(
+        name="head", type="$dff", connections={"CLK": (clk_a,), "D": (4,), "Q": (5,)}
+    )
+    gate = Cell(name="gate", type="$or", connections={"A": (5,), "B": (10,), "Y": (6,)})
+    # Follow-on flop sits in the clk_b domain, not head's clk_a domain.
+    foreign = Cell(
+        name="foreign",
+        type="$dff",
+        connections={"CLK": (clk_b,), "D": (6,), "Q": (7,)},
+    )
+    module = Module(
+        name="m",
+        ports={
+            "clk_a": Port(name="clk_a", direction="input", bits=(clk_a,)),
+            "clk_b": Port(name="clk_b", direction="input", bits=(clk_b,)),
+        },
+        cells={"head": head, "gate": gate, "foreign": foreign},
+        netnames={},
+    )
+    ctx = _build_context(module, clock_spec=None)
+    head_flop = next(f for f in find_flops(module) if f.cell.name == "head")
+    assert _chain_has_inter_stage_comb(head_flop, ctx) is None
+
+
+def test_chain_has_inter_stage_comb_skips_direct_flop_and_dead_comb() -> None:
+    """Exercise the per-consumer guards in ``_chain_has_inter_stage_comb``:
+
+    * a direct flop consumer of ``head.Q`` is skipped (it's a plain
+      chain extension, not the inter-stage-comb shape — rules.py line
+      775);
+    * a comb cell whose ``Y`` drives a net with no single-bit flop
+      consumer yields no match (line 782);
+    * a comb cell whose ``Y`` feeds back to ``head`` itself is ignored
+      (line 784).
+
+    None of these constitute the gate-then-stage shape, so the helper
+    returns ``None``.
+    """
+    clk = 2
+    head_q = 4
+    dead_y = 6
+    fb_y = 3  # feedback gate output wired back into head's own D
+    head = Cell(
+        name="head",
+        type="$dff",
+        connections={"CLK": (clk,), "D": (fb_y,), "Q": (head_q,)},
+    )
+    # Direct flop consumer of head.Q (line 775 continue).
+    direct = Cell(
+        name="direct",
+        type="$dff",
+        connections={"CLK": (clk,), "D": (head_q,), "Q": (9,)},
+    )
+    # Comb cell whose Y (dead_y) has no flop consumer (line 782).
+    dead_gate = Cell(
+        name="dead_gate",
+        type="$not",
+        connections={"A": (head_q,), "Y": (dead_y,)},
+    )
+    # Comb cell whose Y feeds back into head's own D (line 784).
+    fb_gate = Cell(
+        name="fb_gate",
+        type="$not",
+        connections={"A": (head_q,), "Y": (fb_y,)},
+    )
+    module = Module(
+        name="m",
+        ports={"clk": Port(name="clk", direction="input", bits=(clk,))},
+        cells={
+            "head": head,
+            "direct": direct,
+            "dead_gate": dead_gate,
+            "fb_gate": fb_gate,
+        },
+        netnames={},
+    )
+    ctx = _build_context(module, clock_spec=None)
+    head_flop = next(f for f in find_flops(module) if f.cell.name == "head")
+    assert _chain_has_inter_stage_comb(head_flop, ctx) is None
+
+
+def test_is_multibit_sync_first_stage_rejects_single_bit() -> None:
+    """A 1-bit flop is never a *multi-bit* sync first stage (the
+    ``len(dst_flop.q) < 2`` guard)."""
+    flop = _single_flop("f", clk=2, d=(3,), q=(4,))
+    module = Module(name="m", ports={}, cells={"f": flop.cell}, netnames={})
+    assert not _is_multibit_sync_first_stage(module, flop, "clk", {"f": "clk"})
+
+
+def test_is_multibit_sync_first_stage_rejects_mismatched_d_width() -> None:
+    """A flop whose D width differs from its Q width can't be a clean
+    lane-aligned sync stage (the ``len(dst_flop.d) != width`` guard)."""
+    flop = _single_flop("f", clk=2, d=(3,), q=(4, 5))
+    module = Module(name="m", ports={}, cells={"f": flop.cell}, netnames={})
+    assert not _is_multibit_sync_first_stage(module, flop, "clk", {"f": "clk"})
+
+
+def test_is_multibit_sync_first_stage_rejects_constant_q_bit() -> None:
+    """A width-2 flop one of whose Q bits is a constant string can't be a
+    lane-aligned sync stage (the ``not all(isinstance(b, int) ...)``
+    guard, rules.py line 1216)."""
+    flop = _single_flop("f", clk=2, d=(3, 4), q=(5, "0"))
+    module = Module(name="m", ports={}, cells={"f": flop.cell}, netnames={})
+    assert not _is_multibit_sync_first_stage(module, flop, "clk", {"f": "clk"})
+
+
+def test_is_multibit_sync_first_stage_accepts_lane_aligned_pair() -> None:
+    """Two width-2 flops in the same domain wired lane-for-lane
+    (stage0.Q == stage1.D) are recognised as a multi-bit sync chain."""
+    clk = 2
+    stage0 = Cell(
+        name="stage0",
+        type="$dff",
+        connections={"CLK": (clk,), "D": (3, 4), "Q": (5, 6)},
+    )
+    stage1 = Cell(
+        name="stage1",
+        type="$dff",
+        connections={"CLK": (clk,), "D": (5, 6), "Q": (7, 8)},
+    )
+    module = Module(
+        name="m",
+        ports={"clk": Port(name="clk", direction="input", bits=(clk,))},
+        cells={"stage0": stage0, "stage1": stage1},
+        netnames={},
+    )
+    stage0_flop = next(f for f in find_flops(module) if f.cell.name == "stage0")
+    domains = {"stage0": "clk", "stage1": "clk"}
+    assert _is_multibit_sync_first_stage(module, stage0_flop, "clk", domains)
+
+
+# --- CDC-008: gate-level-FF C-pin exemption + dedupe + no-clock-bits ---------
+
+
+def _gate_level_clock_as_data_module() -> Module:
+    """A gate-level ``$_DFF_P_`` flop (clock on pin ``C``) whose clock net
+    is ALSO wired into a comb cell's data pin AND into a second flop's
+    ``C`` pin.
+
+    Layout (clk net = bit 2)::
+
+        clk ── leak.A   (data use → CDC-008 must fire here)
+        clk ── ff_a.C   (clock use on gate-level flop → exempt, line 1641)
+        clk ── ff_b.C   (second clock-net flop → C-pin exempt too)
+
+    The single clock net read on two different ``C`` pins also drives
+    the per-(bit,cell,pin) dedupe in the rule body.
+    """
+    clk = 2
+    a_d = 3
+    a_q = 4
+    b_d = 5
+    b_q = 6
+    leak_y = 7
+    ports = {
+        "clk": Port(name="clk", direction="input", bits=(clk,)),
+        "a_d": Port(name="a_d", direction="input", bits=(a_d,)),
+        "b_d": Port(name="b_d", direction="input", bits=(b_d,)),
+        "leak_q": Port(name="leak_q", direction="output", bits=(leak_y,)),
+    }
+    cells = {
+        "ff_a": Cell(
+            name="ff_a",
+            type="$_DFF_P_",
+            connections={"C": (clk,), "D": (a_d,), "Q": (a_q,)},
+        ),
+        "ff_b": Cell(
+            name="ff_b",
+            type="$_DFF_P_",
+            connections={"C": (clk,), "D": (b_d,), "Q": (b_q,)},
+        ),
+        # Reads the clock net on a data pin — the genuine CDC-008 hazard.
+        "leak": Cell(
+            name="leak",
+            type="$or",
+            connections={"A": (clk,), "B": (a_q,), "Y": (leak_y,)},
+        ),
+    }
+    return Module(name="gate_clk_as_data", ports=ports, cells=cells, netnames={})
+
+
+def test_cdc_008_exempts_gate_level_ff_c_pin() -> None:
+    """The clock net feeds two gate-level flops on their ``C`` pin and one
+    comb cell on a data pin. CDC-008 must fire exactly once — on the
+    comb data read — and must NOT false-fire on either ``C`` pin
+    (the gate-level-FF exemption, rules.py line 1641)."""
+    module = _gate_level_clock_as_data_module()
+    spec = parse_sdc("create_clock -name clk -period 10.0 [get_ports clk]\n")
+    violations = check_cdc_008(module, [], spec)  # no ctx= → lazy build
+    cdc_008 = [v for v in violations if v.rule_id == "CDC-008"]
+    assert len(cdc_008) == 1, (
+        f"expected exactly one CDC-008 (the comb data read); got "
+        f"{[v.message for v in cdc_008]}"
+    )
+    v = cdc_008[0]
+    assert v.cell_name == "leak"
+    assert "used as data" in v.message
+    assert "$or" in v.message
+
+
+def test_cdc_008_dedupes_repeated_clock_bit_on_same_pin() -> None:
+    """A comb cell whose multi-bit ``A`` pin reads the same clock net on
+    two lane indices yields a single CDC-008 finding, not two — the
+    per-(bit, cell, pin) dedupe (rules.py line 1647)."""
+    clk = 2
+    ff_q = 3
+    y0, y1 = 4, 5
+    ports = {
+        "clk": Port(name="clk", direction="input", bits=(clk,)),
+        "y": Port(name="y", direction="output", bits=(y0, y1)),
+    }
+    cells = {
+        "ff": Cell(
+            name="ff",
+            type="$dff",
+            connections={"CLK": (clk,), "D": (ff_q,), "Q": (ff_q,)},
+        ),
+        # The clock net (bit 2) appears on BOTH lanes of the A pin.
+        "leak": Cell(
+            name="leak",
+            type="$xor",
+            connections={"A": (clk, clk), "B": (ff_q, ff_q), "Y": (y0, y1)},
+        ),
+    }
+    module = Module(name="dup_clk", ports=ports, cells=cells, netnames={})
+    spec = parse_sdc("create_clock -name clk -period 10.0 [get_ports clk]\n")
+    violations = check_cdc_008(module, [], spec)
+    cdc_008 = [v for v in violations if v.rule_id == "CDC-008"]
+    assert len(cdc_008) == 1, (
+        f"the duplicate clock-bit read on one pin must dedupe to a "
+        f"single finding; got {[v.message for v in cdc_008]}"
+    )
+    assert cdc_008[0].cell_name == "leak"
+
+
+def test_cdc_008_tolerates_sdc_clock_port_absent_from_module() -> None:
+    """An SDC ``create_clock`` that names a port not present on the
+    module is skipped when building the clock-bit set (rules.py line
+    1606) — the analyzer doesn't crash on a stale SDC. A real flop
+    clock still seeds the set, and the comb read of it still fires."""
+    clk = 2
+    ff_q = 3
+    leak_y = 4
+    ports = {
+        "clk": Port(name="clk", direction="input", bits=(clk,)),
+        "leak_q": Port(name="leak_q", direction="output", bits=(leak_y,)),
+    }
+    cells = {
+        "ff": Cell(
+            name="ff",
+            type="$dff",
+            connections={"CLK": (clk,), "D": (ff_q,), "Q": (ff_q,)},
+        ),
+        "leak": Cell(
+            name="leak",
+            type="$or",
+            connections={"A": (clk,), "B": (ff_q,), "Y": (leak_y,)},
+        ),
+    }
+    module = Module(name="stale_sdc", ports=ports, cells=cells, netnames={})
+    # ``ghost_clk`` is declared on a port the module doesn't have.
+    spec = parse_sdc(
+        "create_clock -name clk -period 10.0 [get_ports clk]\n"
+        "create_clock -name ghost_clk -period 5.0 [get_ports ghost_clk]\n"
+    )
+    violations = check_cdc_008(module, [], spec)
+    cdc_008 = [v for v in violations if v.rule_id == "CDC-008"]
+    assert len(cdc_008) == 1
+    assert cdc_008[0].cell_name == "leak"
+
+
+def test_cdc_008_silent_when_no_clock_bits() -> None:
+    """With no flops and no SDC clocks, the clock-bit set is empty and
+    CDC-008 returns early (rules.py line 1611)."""
+    module = Module(
+        name="empty",
+        ports={"a": Port(name="a", direction="input", bits=(2,))},
+        cells={
+            "g": Cell(name="g", type="$not", connections={"A": (2,), "Y": (3,)}),
+        },
+        netnames={},
+    )
+    assert check_cdc_008(module, [], clock_spec=None) == []
+
+
+# --- CDC-010: lazy ctx, clock_spec-None _async, empty control pin -----------
+
+
+def test_cdc_010_lazy_context_no_sdc_async_fallback() -> None:
+    """``check_cdc_010`` with ``ctx=None`` and ``clock_spec=None`` builds
+    its own context and uses the ``a != b`` async fallback (rules.py
+    line 1890).
+
+    The gated clocks are produced by two divider flops on distinct
+    clock-net domains (``ck_a`` / ``ck_b``) so ``_clock_input_domains_for``
+    can classify them without an SDC; the mux select comes from a third
+    flop on ``ck_sel``. Without an SDC every distinct domain is async,
+    so CDC-010 fires::
+
+        ck_a ── div_a.CLK ; div_a.Q ── mux.B ─┐
+        ck_b ── div_b.CLK ; div_b.Q ── mux.A ─┤ ($mux Y = ck_out) ── out_ff.CLK
+                                              │ S = sel_ff.Q  (clocked by ck_sel)
+    """
+    ck_a, ck_b, ck_sel = 2, 3, 4
+    div_a_q, div_b_q = 5, 6
+    sel_d, sel_q = 7, 8
+    ck_out, d_in, q_out = 9, 10, 11
+    ports = {
+        "ck_a": Port(name="ck_a", direction="input", bits=(ck_a,)),
+        "ck_b": Port(name="ck_b", direction="input", bits=(ck_b,)),
+        "ck_sel": Port(name="ck_sel", direction="input", bits=(ck_sel,)),
+        "sel_d": Port(name="sel_d", direction="input", bits=(sel_d,)),
+        "d_in": Port(name="d_in", direction="input", bits=(d_in,)),
+        "q_out": Port(name="q_out", direction="output", bits=(q_out,)),
+    }
+    cells = {
+        # Divider flops give the mux's gated clocks a classifiable
+        # (flop-domain) source even without an SDC.
+        "div_a": Cell(
+            name="div_a",
+            type="$dff",
+            connections={"CLK": (ck_a,), "D": (div_a_q,), "Q": (div_a_q,)},
+        ),
+        "div_b": Cell(
+            name="div_b",
+            type="$dff",
+            connections={"CLK": (ck_b,), "D": (div_b_q,), "Q": (div_b_q,)},
+        ),
+        "sel_ff": Cell(
+            name="sel_ff",
+            type="$dff",
+            connections={"CLK": (ck_sel,), "D": (sel_d,), "Q": (sel_q,)},
+        ),
+        "clk_mux": Cell(
+            name="clk_mux",
+            type="$mux",
+            connections={
+                "A": (div_b_q,),
+                "B": (div_a_q,),
+                "S": (sel_q,),
+                "Y": (ck_out,),
+            },
+        ),
+        "out_ff": Cell(
+            name="out_ff",
+            type="$dff",
+            connections={"CLK": (ck_out,), "D": (d_in,), "Q": (q_out,)},
+        ),
+    }
+    module = Module(name="async_clk_mux", ports=ports, cells=cells, netnames={})
+    violations = check_cdc_010(module, [], clock_spec=None)  # lazy ctx + a!=b
+    cdc_010 = [v for v in violations if v.rule_id == "CDC-010"]
+    assert len(cdc_010) == 1
+    v = cdc_010[0]
+    assert v.cell_name == "clk_mux"
+    assert v.severity == "error"
+    assert "control pin S" in v.message
+    assert "sel_ff" in v.message
+
+
+def test_cdc_010_skips_empty_control_pin() -> None:
+    """A clock-network ``$mux`` whose ``S`` pin is present but carries no
+    bits is skipped at the ``if not ctrl_bits`` guard (rules.py line
+    1907) — no violation, no crash."""
+    ck_a, ck_b = 2, 3
+    ck_out, d_in, q_out = 7, 8, 9
+    ports = {
+        "ck_a": Port(name="ck_a", direction="input", bits=(ck_a,)),
+        "ck_b": Port(name="ck_b", direction="input", bits=(ck_b,)),
+        "d_in": Port(name="d_in", direction="input", bits=(d_in,)),
+        "q_out": Port(name="q_out", direction="output", bits=(q_out,)),
+    }
+    cells = {
+        "clk_mux": Cell(
+            name="clk_mux",
+            type="$mux",
+            connections={"A": (ck_b,), "B": (ck_a,), "S": (), "Y": (ck_out,)},
+        ),
+        "out_ff": Cell(
+            name="out_ff",
+            type="$dff",
+            connections={"CLK": (ck_out,), "D": (d_in,), "Q": (q_out,)},
+        ),
+    }
+    module = Module(name="empty_sel_mux", ports=ports, cells=cells, netnames={})
+    assert check_cdc_010(module, [], clock_spec=None) == []
+
+
+def test_cdc_010_suppressed_by_glitchless_clock_mux_attr() -> None:
+    """The ``good_glitchless_mux_marked`` fixture has its clock-mux select
+    wire tagged ``(* glitchless_clock_mux *)``. CDC-010 must walk the
+    select bit, recognise it as a user-vouched glitchless mux, and stay
+    silent (rules.py lines 1908-1916)."""
+    module, spec = _load_fixture("good_glitchless_mux_marked")
+    ctx = _build_context(module, spec)
+    # The select wire's bit is in the glitchless set — sanity-pins the
+    # suppression precondition.
+    assert ctx.user_glitchless_mux_bits, "fixture should mark a glitchless select"
+    violations = check_cdc_010(module, [], spec, ctx=ctx)
+    assert [v for v in violations if v.rule_id == "CDC-010"] == []
+
+
+def test_cdc_010_fires_without_the_glitchless_attr() -> None:
+    """Companion negative: the same clock-mux topology without the
+    attribute (``bad_async_clock_mux``) DOES fire CDC-010 — proving the
+    suppression above is the attribute's doing, not a structural
+    accident."""
+    module, spec = _load_fixture("bad_async_clock_mux")
+    crossings = _async_crossings(module, spec)
+    violations = run_all(module, crossings, spec)
+    cdc_010 = [v for v in violations if v.rule_id == "CDC-010"]
+    assert len(cdc_010) >= 1
+    assert cdc_010[0].severity == "error"
+
+
+# --- user_reset_polarity_overrides: "high" branch + hints overlay -----------
+
+
+def test_reset_polarity_override_high_value() -> None:
+    """A top-level input port whose netname carries
+    ``(* reset_polarity = "high" *)`` (any case / surrounding
+    whitespace) decodes to ``"high"`` — the branch the committed
+    ``"low"`` fixtures never reach (rules.py lines 419-420)."""
+    module = Module(
+        name="m",
+        ports={"rst": Port(name="rst", direction="input", bits=(2,))},
+        cells={},
+        netnames={
+            "rst": Netname(
+                name="rst",
+                bits=(2,),
+                attributes={"reset_polarity": "  HIGH  "},
+            ),
+        },
+    )
+    assert user_reset_polarity_overrides(module) == {"rst": "high"}
+
+
+def test_reset_polarity_override_unparseable_value_ignored() -> None:
+    """A value that decodes to neither ``high`` nor ``low`` (e.g. a typo)
+    is silently dropped — tolerant-input posture."""
+    module = Module(
+        name="m",
+        ports={"rst": Port(name="rst", direction="input", bits=(2,))},
+        cells={},
+        netnames={
+            "rst": Netname(name="rst", bits=(2,), attributes={"reset_polarity": "lo"}),
+        },
+    )
+    assert user_reset_polarity_overrides(module) == {}
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_reset_polarity_override_hints_overlay_wins() -> None:
+    """A reset-hints YAML port declaration overlays the SV-attribute map
+    for ports that exist on the module (rules.py lines 424-427). The
+    ``bad_hints_reset_polarity`` fixture ships an external ``low``
+    declaration for ``rst_n`` and an attribute-free SV file, so the
+    override map is produced *only* via the hints path."""
+    from rtl_buddy_cdc.reset_hints import load as load_hints
+
+    fix_dir = FIX_ROOT / "bad_hints_reset_polarity"
+    json_path = fix_dir / "bad_hints_reset_polarity.json"
+    hints_path = fix_dir / "bad_hints_reset_polarity.hints.yaml"
+    if not json_path.exists() or not hints_path.exists():
+        pytest.skip("fixture not built")
+    module = netlist.load(json_path)
+    hints = load_hints(hints_path)
+    # No SV attribute on the port — the map is empty without hints.
+    assert user_reset_polarity_overrides(module) == {}
+    # With hints, the external declaration overlays in.
+    overlaid = user_reset_polarity_overrides(module, hints=hints)
+    assert overlaid.get("rst_n") == "low"
+
+
+@pytest.mark.skipif(not PYYAML_INSTALLED, reason="[hints] extra not installed")
+def test_reset_polarity_hint_for_unknown_port_ignored() -> None:
+    """A hint naming a port that doesn't exist on the module is dropped
+    by the ``if name in port_names`` guard — no spurious entry."""
+    from rtl_buddy_cdc.reset_hints import PortHint, ResetHints
+
+    module = Module(
+        name="m",
+        ports={"rst_n": Port(name="rst_n", direction="input", bits=(2,))},
+        cells={},
+        netnames={},
+    )
+    hints = ResetHints(
+        schema_version="1.0",
+        ports=(PortHint(name="nonexistent", polarity="high", type="async"),),
+        synchronizers=(),
+    )
+    assert user_reset_polarity_overrides(module, hints=hints) == {}

--- a/tests/test_cov_rules_b.py
+++ b/tests/test_cov_rules_b.py
@@ -1,0 +1,487 @@
+"""Coverage-focused tests for the upper half of ``rules.py``.
+
+Targets the rule functions added after the original CDC-001..008 pack:
+CDC-011..CDC-021 and RDC-001..RDC-008, plus the ``run_all``
+post-processing layer (``_tag_handshake_related`` and the CDC-018
+``depth_threshold`` plumbing / guard).
+
+Every test drives the analyzer the way CI does — load a committed
+netlist-JSON fixture with :func:`rtl_buddy_cdc.netlist.load` (pure
+JSON read, no toolchain), parse the paired SDC, build crossings, run
+the full rule
+pack via :func:`rtl_buddy_cdc.rules.run_all` — then asserts on the
+concrete :class:`~rtl_buddy_cdc.rules.Violation` content (rule_id,
+severity, message anchors, cell_name). A handful of unit-level tests
+construct ``Violation`` objects directly to pin the handshake-tagging
+branches that need no netlist.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import netlist, sdc as sdc_mod
+from rtl_buddy_cdc.domain import Crossing, find_crossings
+from rtl_buddy_cdc.flops import Flop
+from rtl_buddy_cdc.netlist import Cell
+from rtl_buddy_cdc.rules import (
+    _tag_handshake_related,
+    check_cdc_018,
+    run_all,
+)
+
+FIX = Path(__file__).parent / "fixtures"
+
+
+def _analyze(name: str) -> tuple[netlist.Module, list[Crossing], sdc_mod.ClockSpec]:
+    """Load ``<name>`` fixture, synthesize unconstrained inputs, and
+    return ``(module, async_crossings, spec)`` ready for ``run_all``.
+
+    Mirrors the per-fixture ``context`` fixtures used across the
+    existing ``test_bad_*`` suite (e.g. ``test_bad_rdc_005...``): the
+    async filter drops same-domain and unreachable crossings so the
+    crossing list handed to ``run_all`` is the CDC-relevant subset.
+    """
+    fix_dir = FIX / name
+    json_path = fix_dir / f"{name}.json"
+    sdc_path = fix_dir / f"{name}.sdc"
+    if not json_path.exists():
+        pytest.skip(f"fixture not built: {json_path}")
+    module = netlist.load(json_path)
+    spec = sdc_mod.parse_file(sdc_path)
+    sdc_mod.synthesize_unconstrained_inputs(spec, module)
+    crossings = find_crossings(module, port_clock=spec.port_clock)
+    async_crossings: list[Crossing] = []
+    for c in crossings:
+        a = spec.clock_for_port(c.src_clock) or c.src_clock
+        b = spec.clock_for_port(c.dst_clock) or c.dst_clock
+        if spec.is_unreachable_crossing(a, b):
+            continue
+        if spec.are_async(a, b):
+            async_crossings.append(c)
+    return module, async_crossings, spec
+
+
+def _run(name: str):
+    module, async_crossings, spec = _analyze(name)
+    return run_all(module, async_crossings, spec)
+
+
+def _of(violations, rule_id: str):
+    return [v for v in violations if v.rule_id == rule_id]
+
+
+# --------------------------------------------------------------------------
+# RDC family
+# --------------------------------------------------------------------------
+
+
+def test_rdc_001_reset_crossing_groups_by_source() -> None:
+    """RDC-001 fires on an async ARST driven by a foreign-domain flop;
+    the message names the destination clock and the foreign source."""
+    violations = _run("bad_reset_crossing")
+    rdc_001 = _of(violations, "RDC-001")
+    assert len(rdc_001) >= 1
+    v = rdc_001[0]
+    assert v.severity == "error"
+    assert "async reset crossing" in v.message
+    assert "add a reset" in v.message
+    assert v.cell_name is not None
+
+
+def test_rdc_003_sync_reset_crossing() -> None:
+    """RDC-003 walks the SRST pin backward into a foreign async domain."""
+    violations = _run("bad_rdc_003_sync_reset_crossing")
+    rdc_003 = _of(violations, "RDC-003")
+    assert len(rdc_003) == 1
+    v = rdc_003[0]
+    assert v.severity == "error"
+    assert "sync reset crossing" in v.message
+    assert "SRST" in v.message
+    assert "2FF reset synchroniser" in v.message
+    # The source flop named in the message lives in src_clk.
+    assert "$procdff$12" in v.message
+
+
+def test_rdc_004_comb_driven_reset_lists_fanin_flops() -> None:
+    """RDC-004 fires when an async reset pin is a comb-gate output whose
+    fanin reaches flops; the message enumerates those flops."""
+    violations = _run("bad_rdc_004_comb_driven_reset")
+    rdc_004 = _of(violations, "RDC-004")
+    assert len(rdc_004) == 1
+    v = rdc_004[0]
+    assert v.severity == "error"
+    assert "reset driven by combinational logic" in v.message
+    assert v.cell_name == "$procdff$12"
+    # Both upstream flops are surfaced.
+    assert "$procdff$17" in v.message
+    assert "$procdff$22" in v.message
+
+
+def test_rdc_005_multi_source_reset_is_warning() -> None:
+    """RDC-005 warns on a comb-AND of two top-level reset ports with no
+    mux selection; lists both ports and suggests muxing."""
+    violations = _run("bad_rdc_005_multi_source_reset")
+    rdc_005 = _of(violations, "RDC-005")
+    assert len(rdc_005) == 1
+    v = rdc_005[0]
+    assert v.severity == "warning"
+    assert "multiple reset sources converging" in v.message
+    assert "global_rst_n" in v.message
+    assert "block_rst_n" in v.message
+    assert "$mux" in v.message
+
+
+def test_rdc_002_polarity_mismatch_inferred_variant() -> None:
+    """RDC-002 fires on a flop->flop reset where the producer's
+    ARST_VALUE disagrees with the consumer's ARST_POLARITY."""
+    violations = _run("bad_rdc_002_polarity_mismatch")
+    rdc_002 = _of(violations, "RDC-002")
+    assert len(rdc_002) == 1
+    v = rdc_002[0]
+    assert v.severity == "error"
+    assert "reset polarity mismatch" in v.message
+    assert "ARST_POLARITY" in v.message
+    assert "ARST_VALUE" in v.message
+
+
+def test_rdc_006_muxed_async_reset_is_warning() -> None:
+    """RDC-006 fills the gap RDC-005 leaves: a $mux directly driving an
+    async reset pin still has an unsynchronised deassertion edge."""
+    violations = _run("bad_derived_async_reset_unsync")
+    rdc_006 = _of(violations, "RDC-006")
+    assert len(rdc_006) == 1
+    v = rdc_006[0]
+    assert v.severity == "warning"
+    assert "muxed async reset without local synchroniser" in v.message
+    assert "$mux" in v.message
+    # The mux's data legs trace back to the two reset ports.
+    assert "block_rst_n" in v.message
+    assert "global_rst_n" in v.message
+    assert "2FF reset synchroniser" in v.message
+    assert v.cell_name == "$procdff$8"
+
+
+def test_rdc_007_deassert_polarity_backwards() -> None:
+    """RDC-007 fires on a reset-sync chain whose head D loads the
+    *asserted* value, so it never deasserts."""
+    violations = _run("bad_reset_sync_deassert_polarity")
+    rdc_007 = _of(violations, "RDC-007")
+    assert len(rdc_007) == 1
+    v = rdc_007[0]
+    assert v.severity == "error"
+    assert "reset-synchroniser chain" in v.message
+    assert "one-shot" in v.message
+    # Active-low chain whose head was tied to the asserted ('0') value.
+    assert "active-low" in v.message
+    assert "deasserts on '1'" in v.message
+
+
+def test_rdc_008_unsynced_primary_reset_port() -> None:
+    """RDC-008 fires on >=2 consumers driven directly by a raw reset
+    port in a domain that has a sync chain elsewhere (asymmetry gate)."""
+    violations = _run("bad_primary_reset_unsynced")
+    rdc_008 = _of(violations, "RDC-008")
+    assert len(rdc_008) == 1
+    v = rdc_008[0]
+    assert v.severity == "error"
+    assert "unsynced primary-reset port" in v.message
+    assert "raw_rst_n" in v.message
+    # Two consumer flops in the unsynced domain are named.
+    assert "$procdff$13" in v.message
+    assert "$procdff$18" in v.message
+    assert "clk_b" in v.message
+
+
+# --------------------------------------------------------------------------
+# CDC-011: unconstrained primary input on a data pin
+# --------------------------------------------------------------------------
+
+
+def test_cdc_011_multi_domain_is_error() -> None:
+    """A single unconstrained port captured in >=2 domains is an
+    intrinsic error — it cannot be synchronous to two clocks."""
+    violations = _run("bad_unconstrained_input_two_domains")
+    cdc_011 = _of(violations, "CDC-011")
+    assert len(cdc_011) == 1
+    v = cdc_011[0]
+    assert v.severity == "error"
+    assert "captured in multiple clock domains" in v.message
+    assert "'in'" in v.message
+    # Both destination clocks are listed.
+    assert "clk_a" in v.message
+    assert "clk_b" in v.message
+
+
+def test_cdc_011_single_domain_is_warning() -> None:
+    """A single unconstrained port landing in one domain is a
+    methodology warning suggesting set_input_delay -clock."""
+    violations = _run("bad_unconstrained_input_derived_clock")
+    cdc_011 = _of(violations, "CDC-011")
+    assert len(cdc_011) == 1
+    v = cdc_011[0]
+    assert v.severity == "warning"
+    assert "no set_input_delay -clock typing" in v.message
+    assert "set_input_delay -clock" in v.message
+
+
+# --------------------------------------------------------------------------
+# CDC-012 / CDC-013 (handshake / toggle families)
+# --------------------------------------------------------------------------
+
+
+def test_cdc_012_functional_datahold_warning() -> None:
+    """CDC-012 warns on a gated multi-bit crossing with no synced-back
+    handshake (the functional data-hold risk)."""
+    violations = _run("bad_functional_datahold_enable")
+    cdc_012 = _of(violations, "CDC-012")
+    assert len(cdc_012) >= 1
+    v = cdc_012[0]
+    assert v.severity == "warning"
+    assert "functional data-hold risk" in v.message
+    assert "gated bus crossing" in v.message
+    assert "req/ack handshake" in v.message
+    assert v.crossing is not None
+    assert v.crossing.width > 1
+
+
+def test_cdc_013_toggle_event_loss_warning() -> None:
+    """CDC-013 warns on a fast-to-slow toggle synchroniser with no XOR
+    edge-detector tail (event-loss risk)."""
+    violations = _run("bad_toggle_no_xor_tail")
+    cdc_013 = _of(violations, "CDC-013")
+    assert len(cdc_013) == 1
+    v = cdc_013[0]
+    assert v.severity == "warning"
+    assert "toggle-synchroniser event-loss risk" in v.message
+    assert "D = en ? ~Q : Q" in v.message
+    # Fast-to-slow: src period strictly less than dst period.
+    assert v.crossing is not None
+
+
+# --------------------------------------------------------------------------
+# CDC-014..017 (synchroniser structural hazards)
+# --------------------------------------------------------------------------
+
+
+def test_cdc_014_comb_between_sync_stages() -> None:
+    """CDC-014 fires on a gate sitting between two synchroniser
+    stages — the gate samples a still-metastable first-stage output."""
+    violations = _run("bad_comb_between_sync_stages")
+    cdc_014 = _of(violations, "CDC-014")
+    assert len(cdc_014) == 1
+    v = cdc_014[0]
+    assert v.severity == "error"
+    assert "combinational logic between synchroniser stages" in v.message
+    assert "feeds a comb cell" in v.message
+    assert v.cell_name == "$procdff$19"
+
+
+def test_cdc_016_opposite_edge_synchroniser() -> None:
+    """CDC-016 fires when two adjacent sync-chain stages clock on
+    opposite edges — halves MTBF."""
+    violations = _run("bad_opposite_edge_sync")
+    cdc_016 = _of(violations, "CDC-016")
+    assert len(cdc_016) == 1
+    v = cdc_016[0]
+    assert v.severity == "error"
+    assert "opposite-edge synchroniser" in v.message
+    assert "halves MTBF" in v.message
+    # The message names both edges; one posedge, one negedge.
+    assert "posedge" in v.message
+    assert "negedge" in v.message
+
+
+def test_cdc_017_transparent_latch_in_cdc_path() -> None:
+    """CDC-017 fires on a $dlatch between two flops in different
+    domains — the latch is transparent and provides no resolution."""
+    violations = _run("bad_latch_in_cdc_path")
+    cdc_017 = _of(violations, "CDC-017")
+    assert len(cdc_017) == 1
+    v = cdc_017[0]
+    assert v.severity == "error"
+    assert "transparent latch in CDC path" in v.message
+    # cell_name anchors on the offending latch cell.
+    assert v.cell_name is not None
+    assert "dlatch" in v.cell_name
+
+
+# --------------------------------------------------------------------------
+# CDC-018..021
+# --------------------------------------------------------------------------
+
+
+def test_cdc_018_cascaded_synchroniser_warning() -> None:
+    """CDC-018 warns on a chain at/over the depth threshold (default 4)."""
+    violations = _run("bad_cascaded_synchroniser")
+    cdc_018 = _of(violations, "CDC-018")
+    assert len(cdc_018) == 1
+    v = cdc_018[0]
+    assert v.severity == "warning"
+    assert "cascaded synchroniser chain" in v.message
+    assert "4-flop chain" in v.message
+    assert "textbook 2FF sync is sufficient" in v.message
+
+
+def test_cdc_018_threshold_raises_above_chain_silences() -> None:
+    """Raising ``cdc_018_depth_threshold`` above the chain depth
+    silences CDC-018 while leaving the rest of the pack untouched."""
+    module, async_crossings, spec = _analyze("bad_cascaded_synchroniser")
+    high = run_all(module, async_crossings, spec, cdc_018_depth_threshold=8)
+    assert _of(high, "CDC-018") == []
+    low = run_all(module, async_crossings, spec, cdc_018_depth_threshold=4)
+    assert len(_of(low, "CDC-018")) == 1
+
+
+def test_cdc_018_threshold_below_two_raises() -> None:
+    """The standalone checker guards against a sub-2FF threshold."""
+    module, async_crossings, spec = _analyze("bad_cascaded_synchroniser")
+    with pytest.raises(ValueError, match="depth_threshold must be >= 2"):
+        check_cdc_018(module, async_crossings, spec, 1)
+
+
+def test_cdc_019_independent_onehot_sync_warning() -> None:
+    """CDC-019 warns when a one-hot decode is split into independent
+    per-bit syncs that can resolve on different cycles."""
+    violations = _run("bad_onehot_decode_independent_sync")
+    cdc_019 = _of(violations, "CDC-019")
+    assert len(cdc_019) >= 1
+    v = cdc_019[0]
+    assert v.severity == "warning"
+    assert "independently-synced one-hot decode" in v.message
+
+
+def test_cdc_020_sliced_bus_reconvergence_warning() -> None:
+    """CDC-020 warns on a multi-bit source flop sliced into per-lane
+    crossings that reconverge in the destination domain."""
+    violations = _run("bad_sliced_bus_reconvergence")
+    cdc_020 = _of(violations, "CDC-020")
+    assert len(cdc_020) >= 1
+    v = cdc_020[0]
+    assert v.severity == "warning"
+    assert "sliced-bus reconvergence across CDC" in v.message
+    assert "WIDTH=4" in v.message
+
+
+def test_cdc_021_undeclared_clock_port_is_error() -> None:
+    """CDC-021 fires when a flop's CLK traces to a port with no
+    create_clock — every other rule silently skips that domain."""
+    violations = _run("bad_flop_clk_undeclared_port")
+    cdc_021 = _of(violations, "CDC-021")
+    assert len(cdc_021) == 1
+    v = cdc_021[0]
+    assert v.severity == "error"
+    assert "flop CLK driven by undeclared port" in v.message
+    assert "clk_aux" in v.message
+    assert "create_clock" in v.message
+    assert v.cell_name == "$procdff$3"
+
+
+# --------------------------------------------------------------------------
+# run_all post-processing: _tag_handshake_related
+# --------------------------------------------------------------------------
+
+
+def test_handshake_tag_appended_on_paired_finding() -> None:
+    """When a CDC-012 and a CDC-001/002 finding share an async domain
+    pair, run_all appends a ``[handshake-related]`` cross-reference to
+    the CDC-001/002 message naming the gated bus source flop."""
+    violations = _run("bad_handshake_ack_missing")
+    # Both families must fire for the tag to be meaningful.
+    assert _of(violations, "CDC-012")
+    cdc_001 = _of(violations, "CDC-001")
+    assert cdc_001
+    tagged = [v for v in cdc_001 if "[handshake-related]" in v.message]
+    assert tagged, "expected the CDC-001 finding to carry the handshake tag"
+    msg = tagged[0].message
+    assert "same async domain pair" in msg
+    assert "CDC-012-firing gated bus" in msg
+    assert "req/ack" in msg
+
+
+def _flop(name: str) -> Flop:
+    """Minimal Flop standing in for a crossing endpoint in unit tests."""
+    cell = Cell(name=name, type="$dff", connections={})
+    return Flop(cell=cell, clk=1, d=(2,), q=(3,))
+
+
+def _crossing(src: str, dst: str, src_flop: Flop, dst_flop: Flop) -> Crossing:
+    return Crossing(
+        src_clock=src,
+        dst_flop=dst_flop,
+        dst_clock=dst,
+        min_hops=0,
+        width=1,
+        src_flop=src_flop,
+    )
+
+
+def test_tag_handshake_noop_without_cdc_012(monkeypatch) -> None:
+    """``_tag_handshake_related`` is a pure pass-through when the list
+    has no CDC-012 finding — the common case."""
+    from rtl_buddy_cdc.rules import Violation
+
+    only = [
+        Violation(
+            rule_id="CDC-001",
+            severity="error",
+            message="lone control crossing",
+            crossing=_crossing("a", "b", _flop("src"), _flop("dst")),
+        )
+    ]
+    out = _tag_handshake_related(only)
+    assert out is only  # identity: early return, untouched
+
+
+def test_tag_handshake_unpaired_domain_left_untouched() -> None:
+    """A CDC-012 on one domain pair must not tag a CDC-001 on a
+    *different* pair — the partner lookup misses, so the message is
+    passed through verbatim."""
+    from rtl_buddy_cdc.rules import Violation
+
+    cdc_012 = Violation(
+        rule_id="CDC-012",
+        severity="warning",
+        message="gated bus on a/b",
+        crossing=_crossing("a", "b", _flop("gsrc"), _flop("gdst")),
+    )
+    # CDC-001 on an unrelated (c, d) pair.
+    cdc_001 = Violation(
+        rule_id="CDC-001",
+        severity="error",
+        message="unrelated control crossing",
+        crossing=_crossing("c", "d", _flop("csrc"), _flop("cdst")),
+    )
+    out = _tag_handshake_related([cdc_012, cdc_001])
+    tagged = [v for v in out if v.rule_id == "CDC-001"][0]
+    assert "[handshake-related]" not in tagged.message
+    assert tagged.message == "unrelated control crossing"
+
+
+def test_tag_handshake_matches_either_direction() -> None:
+    """The pairing is by *unordered* domain pair: a CDC-012 on (a,b)
+    tags a CDC-001 whose crossing runs b->a."""
+    from rtl_buddy_cdc.rules import Violation
+
+    gated_src = _flop("gated_src_flop")
+    gated_dst = _flop("gated_dst_flop")
+    cdc_012 = Violation(
+        rule_id="CDC-012",
+        severity="warning",
+        message="gated bus on a/b",
+        crossing=_crossing("a", "b", gated_src, gated_dst),
+    )
+    cdc_001 = Violation(
+        rule_id="CDC-001",
+        severity="error",
+        message="reverse-direction control crossing",
+        crossing=_crossing("b", "a", _flop("csrc"), _flop("cdst")),
+    )
+    out = _tag_handshake_related([cdc_012, cdc_001])
+    tagged = [v for v in out if v.rule_id == "CDC-001"][0]
+    assert "[handshake-related]" in tagged.message
+    # The tag names the gated bus endpoints, not the CDC-001 crossing.
+    assert "gated_src_flop" in tagged.message
+    assert "gated_dst_flop" in tagged.message

--- a/tests/test_cov_sdc.py
+++ b/tests/test_cov_sdc.py
@@ -1,0 +1,441 @@
+"""Coverage-raising tests for :mod:`rtl_buddy_cdc.sdc` parser corners.
+
+These exercise the less-trodden branches of the SDC parser through the
+public ``parse`` / ``parse_file`` entry points (plus a few targeted
+direct calls into the documented Layer-2 helpers ``_slice`` / ``Arity``
+/ ``ArgSpec`` / ``_extract_names`` / ``_safe_int``):
+
+  * ``ClockSpec`` resolve/are_async edge cases — master cycles, the
+    ``-master_clock`` chain dead-end, the unconstrained sentinel, and
+    the unresolved-name false-path branch.
+  * The ``_slice`` arg-spec slicer's malformed-input corners — a
+    one-operand flag that runs off the end of the command, and the
+    unknown-flag skip heuristic (flag-then-flag vs flag-then-operand).
+  * Per-command handler bail-outs that append ``partial_warnings``:
+    missing/non-numeric ``-period``, missing ``-name``, the
+    ``create_generated_clock`` filter clause, duplicate generated-clock
+    names, fewer-than-two ``-group`` clauses, and an incomplete
+    ``set_false_path`` ``-from``/``-to``.
+  * The collection-peeling helpers — ``-filter`` cut, the
+    ``-include_generated_clocks`` drop, and bare vendor-flag skipping.
+
+No Yosys binary, no frontend: pure text-in / ``ClockSpec``-out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rtl_buddy_cdc.sdc import (
+    UNCONSTRAINED_SENTINEL,
+    ArgSpec,
+    Arity,
+    Clock,
+    ClockSpec,
+    _extract_names,
+    _safe_int,
+    _slice,
+    parse,
+    parse_file,
+)
+
+# ---- ClockSpec.resolve corners ---------------------------------------------
+
+
+def test_resolve_master_cycle_guard_terminates() -> None:
+    """A self-referential master chain must not infinite-loop.
+
+    ``resolve`` keeps a ``seen`` set; the first clock revisited
+    terminates the walk and that name is returned (sdc.py:144). Build
+    a two-clock A<->B cycle directly and confirm ``resolve`` returns
+    within the cycle rather than hanging.
+    """
+    spec = ClockSpec()
+    spec.clocks["A"] = Clock(
+        name="A", period=0.0, ports=(), master="B", is_generated=True
+    )
+    spec.clocks["B"] = Clock(
+        name="B", period=0.0, ports=(), master="A", is_generated=True
+    )
+    # First revisited node terminates; result is one of the cycle members.
+    assert spec.resolve("A") in {"A", "B"}
+    assert spec.resolve("B") in {"A", "B"}
+
+
+def test_resolve_unknown_master_returns_name_unchanged() -> None:
+    """A ``-master_clock`` naming a clock that was never declared:
+    the chain dead-ends and ``resolve`` returns the unknown name."""
+    spec = parse(
+        """
+        create_generated_clock -name g -master_clock ck_missing \\
+            -divide_by 2 [get_pins u/clk_out]
+        """
+    )
+    # ck_missing is not in spec.clocks, so resolve stops at it.
+    assert spec.resolve("g") == "ck_missing"
+
+
+# ---- ClockSpec.are_async corners -------------------------------------------
+
+
+def test_are_async_unconstrained_sentinel_is_async_to_everything() -> None:
+    """The synthesised ``<unconstrained>`` sentinel is async to every
+    real clock (sdc.py:177-178)."""
+    spec = parse("create_clock -name clk -period 10 [get_ports clk]")
+    assert spec.are_async(UNCONSTRAINED_SENTINEL, "clk")
+    assert spec.are_async("clk", UNCONSTRAINED_SENTINEL)
+    # Identity short-circuits before the sentinel check.
+    assert not spec.are_async(UNCONSTRAINED_SENTINEL, UNCONSTRAINED_SENTINEL)
+
+
+def test_are_async_unresolved_name_false_path_branch() -> None:
+    """A false-path declared on *generated* clock names whose resolved
+    roots differ is honoured via the raw-name ``frozenset({a, b})``
+    branch (sdc.py:192-193).
+
+    ``g0``/``g1`` resolve to distinct masters ``m0``/``m1``, so the
+    resolved-root false-path check (``frozenset({m0, m1})``, sdc.py:190)
+    misses — that pair was never declared. The raw-name set still
+    carries ``{g0, g1}``, so are_async returns True only via line 193.
+    """
+    spec = parse(
+        """
+        create_clock -name m0 -period 10 [get_ports m0]
+        create_clock -name m1 -period 7  [get_ports m1]
+        create_generated_clock -name g0 -master_clock m0 \\
+            -divide_by 2 [get_pins u0/clk_out]
+        create_generated_clock -name g1 -master_clock m1 \\
+            -divide_by 2 [get_pins u1/clk_out]
+        set_false_path -from [get_clocks g0] -to [get_clocks g1]
+        """
+    )
+    # Roots differ (m0 vs m1) so the ra==rb short-circuit is skipped;
+    # {m0, m1} was never declared a false-path, but {g0, g1} was.
+    assert spec.resolve("g0") == "m0"
+    assert spec.resolve("g1") == "m1"
+    assert frozenset({"g0", "g1"}) in spec.false_path_pairs
+    assert frozenset({"m0", "m1"}) not in spec.false_path_pairs
+    assert spec.are_async("g0", "g1")
+
+
+def test_are_async_resolved_root_async_group_branch() -> None:
+    """Two generated clocks on distinct masters, with an async group
+    declared on the *masters*: are_async must collapse the generated
+    clocks to their roots and find the cross-group relation
+    (sdc.py:194-198)."""
+    spec = parse(
+        """
+        create_clock -name m0 -period 10 [get_ports m0]
+        create_clock -name m1 -period 7  [get_ports m1]
+        create_generated_clock -name g0 -master_clock m0 \\
+            -divide_by 2 [get_pins u0/clk_out]
+        create_generated_clock -name g1 -master_clock m1 \\
+            -divide_by 2 [get_pins u1/clk_out]
+        set_clock_groups -asynchronous -group {m0} -group {m1}
+        """
+    )
+    # Neither g0 nor g1 is named in any group; resolution to m0 / m1
+    # is what makes them async.
+    assert spec.resolve("g0") == "m0"
+    assert spec.resolve("g1") == "m1"
+    assert spec.are_async("g0", "g1")
+    assert spec.are_async("g1", "g0")
+
+
+# ---- parse() top-level: blank command skip ---------------------------------
+
+
+def test_parse_skips_blank_lines_between_commands() -> None:
+    """``parse`` continues past empty word-lists (sdc.py:231); a file
+    that is mostly blank still yields the one real clock."""
+    spec = parse("\n\n   \n\ncreate_clock -name clk -period 10 [get_ports clk]\n\n")
+    assert set(spec.clocks) == {"clk"}
+    assert spec.clocks["clk"].period == 10.0
+
+
+def test_parse_file_reads_from_disk(tmp_path: Path) -> None:
+    """``parse_file`` reads the path then delegates to ``parse``."""
+    p = tmp_path / "design.sdc"
+    p.write_text("create_clock -name clk -period 12.5 [get_ports clk]\n")
+    spec = parse_file(p)
+    assert spec.clocks["clk"].period == 12.5
+    # And the str-path overload.
+    spec2 = parse_file(str(p))
+    assert spec2.clocks["clk"].period == 12.5
+
+
+# ---- _slice arg-spec slicer corners ----------------------------------------
+
+
+def test_slice_arity_one_flag_at_end_of_command() -> None:
+    """An ``Arity.ONE`` flag with no following operand (it is the last
+    word) is consumed without recording a value (sdc.py:609-610)."""
+    spec = ArgSpec(flags={"-name": Arity.ONE})
+    parsed = _slice(["-name"], spec)
+    assert parsed.flags["-name"] == []
+    assert not parsed.present("-name")
+    assert parsed.first("-name") is None
+    assert parsed.tail == []
+
+
+def test_slice_unknown_flag_then_operand_skips_both() -> None:
+    """Unknown flag followed by a non-flag operand: the heuristic skips
+    both, assuming one-operand arity (sdc.py:621-622). The real flag
+    after them must still parse."""
+    spec = ArgSpec(flags={"-name": Arity.ONE})
+    parsed = _slice(["-weird", "value", "-name", "clk"], spec)
+    assert parsed.first("-name") == "clk"
+    # The unknown flag and its operand left no tail and no spurious flag.
+    assert parsed.tail == []
+
+
+def test_slice_unknown_flag_then_flag_skips_only_flag() -> None:
+    """Unknown flag immediately followed by another flag: only the
+    unknown flag is skipped (sdc.py:623-624); the following known flag
+    parses normally."""
+    spec = ArgSpec(flags={"-name": Arity.ONE})
+    parsed = _slice(["-weird", "-name", "clk"], spec)
+    assert parsed.first("-name") == "clk"
+    assert parsed.tail == []
+
+
+def test_slice_unknown_flag_at_end_skips_only_flag() -> None:
+    """Unknown flag as the final word: nothing follows, so just the
+    flag is skipped (sdc.py:623-624 else-branch via i+1 == n)."""
+    spec = ArgSpec(flags={"-name": Arity.ONE})
+    parsed = _slice(["-name", "clk", "-weird"], spec)
+    assert parsed.first("-name") == "clk"
+    assert parsed.tail == []
+
+
+# ---- _handle_create_clock bail-outs ----------------------------------------
+
+
+def test_create_clock_missing_period_is_dropped() -> None:
+    """No ``-period`` operand → handler returns early, no clock recorded
+    (sdc.py:715-716)."""
+    spec = parse("create_clock -name clk [get_ports clk]")
+    assert "clk" not in spec.clocks
+    assert spec.clocks == {}
+
+
+def test_create_clock_non_numeric_period_is_dropped() -> None:
+    """A ``-period`` that doesn't ``float()`` → ValueError → early
+    return, no clock (sdc.py:719-720)."""
+    spec = parse("create_clock -name clk -period not_a_number [get_ports clk]")
+    assert "clk" not in spec.clocks
+
+
+def test_create_clock_name_falls_back_to_first_port() -> None:
+    """With no ``-name`` but a port target, the first port becomes the
+    clock name (sdc.py:729-730)."""
+    spec = parse("create_clock -period 10 [get_ports my_clk]")
+    assert "my_clk" in spec.clocks
+    assert spec.clocks["my_clk"].period == 10.0
+    assert spec.clocks["my_clk"].ports == ("my_clk",)
+
+
+def test_create_clock_no_name_no_ports_is_dropped() -> None:
+    """Neither ``-name`` nor any port target → no name to key on → the
+    handler returns without recording a clock (sdc.py:731-732)."""
+    spec = parse("create_clock -period 10")
+    assert spec.clocks == {}
+    assert spec.partial_warnings == []
+
+
+# ---- _handle_create_generated_clock bail-outs ------------------------------
+
+
+def test_generated_clock_name_falls_back_to_first_target() -> None:
+    """No ``-name`` on create_generated_clock, but a (non-pin) target —
+    the first target supplies the name (sdc.py:776-777)."""
+    spec = parse(
+        """
+        create_clock -name ck_a -period 10 [get_ports ck_a]
+        create_generated_clock -master_clock ck_a -divide_by 2 [get_ports ck_b]
+        """
+    )
+    assert "ck_b" in spec.clocks
+    assert spec.clocks["ck_b"].is_generated
+    assert spec.clocks["ck_b"].master == "ck_a"
+
+
+def test_generated_clock_missing_name_and_target_warns() -> None:
+    """No ``-name`` and no fallback target → a partial warning, no clock
+    (sdc.py:778-782)."""
+    spec = parse("create_generated_clock -master_clock ck_a -divide_by 2")
+    assert spec.clocks == {}
+    assert any(
+        "create_generated_clock: missing -name" in w for w in spec.partial_warnings
+    ), spec.partial_warnings
+
+
+def test_generated_clock_filter_clause_warns() -> None:
+    """A ``-filter`` clause inside the target collection surfaces a
+    partial warning (sdc.py:792-793) but the clock is still recorded."""
+    spec = parse(
+        """
+        create_clock -name ck_a -period 10 [get_ports ck_a]
+        create_generated_clock -name g -master_clock ck_a -divide_by 2 \\
+            [get_pins -filter {NAME =~ \\"u/*\\"} u/clk_out]
+        """
+    )
+    assert "g" in spec.clocks
+    assert any(
+        "create_generated_clock g" in w and "filter" in w for w in spec.partial_warnings
+    ), spec.partial_warnings
+
+
+def test_generated_clock_duplicate_name_warns() -> None:
+    """Two ``create_generated_clock -name g`` → the second silently
+    overrides and a duplicate-name partial warning fires (sdc.py:809-811)."""
+    spec = parse(
+        """
+        create_clock -name ck_a -period 10 [get_ports ck_a]
+        create_generated_clock -name g -master_clock ck_a -divide_by 2 \\
+            [get_pins u0/clk_out]
+        create_generated_clock -name g -master_clock ck_a -divide_by 4 \\
+            [get_pins u1/clk_out]
+        """
+    )
+    assert any(
+        "duplicate clock name 'g'" in w and "create_generated_clock" in w
+        for w in spec.partial_warnings
+    ), spec.partial_warnings
+    # The second declaration's pin target is the one retained.
+    assert spec.pin_clocks == {"u0/clk_out": "g", "u1/clk_out": "g"}
+
+
+# ---- _handle_set_clock_groups: fewer than 2 groups -------------------------
+
+
+def test_set_clock_groups_single_group_warns() -> None:
+    """A ``set_clock_groups`` kind with only one ``-group`` clause is
+    meaningless (you need at least two groups to declare a relation):
+    a partial warning fires and nothing is recorded (sdc.py:848-852)."""
+    spec = parse(
+        """
+        create_clock -name ck0 -period 10 [get_ports ck0]
+        set_clock_groups -asynchronous -group {ck0}
+        """
+    )
+    assert spec.async_groups == []
+    assert spec.exclusive_groups == []
+    assert any("fewer than 2 -group" in w for w in spec.partial_warnings), (
+        spec.partial_warnings
+    )
+
+
+# ---- _handle_set_false_path: incomplete from/to ----------------------------
+
+
+def test_set_false_path_missing_to_warns() -> None:
+    """``set_false_path -from <clk>`` with no ``-to`` clock list is an
+    incomplete pair: a partial warning fires and no false-path pair is
+    recorded (sdc.py:908-912)."""
+    spec = parse(
+        """
+        create_clock -name a -period 10 [get_ports a]
+        create_clock -name b -period 7  [get_ports b]
+        set_false_path -from [get_clocks a]
+        """
+    )
+    assert spec.false_path_pairs == set()
+    assert not spec.are_async("a", "b")
+    assert any("incomplete -from/-to clock list" in w for w in spec.partial_warnings), (
+        spec.partial_warnings
+    )
+
+
+# ---- _handle_set_delay: filter clause --------------------------------------
+
+
+def test_set_input_delay_filter_clause_warns() -> None:
+    """A ``-filter`` inside the ``[get_ports ...]`` target of a
+    ``set_input_delay`` surfaces the generic delay filter warning
+    (sdc.py:939-940)."""
+    spec = parse(
+        """
+        create_clock -name clk -period 10 [get_ports clk]
+        set_input_delay -clock clk 1.5 [get_ports -filter {DIRECTION == in} d_in]
+        """
+    )
+    assert any(
+        "set_*_delay: ignored unsupported -filter" in w for w in spec.partial_warnings
+    ), spec.partial_warnings
+
+
+# ---- _extract_names collection-peeling corners -----------------------------
+
+
+def test_extract_names_filter_cut_drops_trailing_tokens() -> None:
+    """``-filter`` cuts the name list at its position; tokens after
+    ``-filter`` are dropped and ``saw_filter`` is True (sdc.py:996-1005).
+    Here a name precedes the filter, so it survives the cut."""
+    names, saw_filter = _extract_names("[get_ports keep -filter {NAME =~ x} drop]")
+    assert saw_filter is True
+    assert names == ["keep"]
+
+
+def test_extract_names_filter_substring_without_standalone_token() -> None:
+    """``saw_filter`` is True whenever ``-filter`` is a substring, but
+    the cut only happens if ``-filter`` is a standalone token. When it
+    is glued to other text (``-filterish``) the ``.index`` lookup raises
+    ValueError and is swallowed (sdc.py:1004-1005) — names are kept and
+    the glued ``-``-prefixed token is dropped by the vendor-flag skip."""
+    names, saw_filter = _extract_names("[get_ports -filterish clk]")
+    assert saw_filter is True
+    # No standalone "-filter" token → no cut → clk survives; the
+    # "-filterish" pseudo-flag is skipped as an unknown vendor flag.
+    assert names == ["clk"]
+
+
+def test_extract_names_include_generated_clocks_dropped() -> None:
+    """The ``-include_generated_clocks`` vendor flag is silently dropped
+    from the name list (sdc.py:1008-1009) while real names survive."""
+    names, saw_filter = _extract_names(
+        "[get_clocks -include_generated_clocks ck_a ck_b]"
+    )
+    assert saw_filter is False
+    assert names == ["ck_a", "ck_b"]
+
+
+def test_extract_names_unknown_vendor_flag_skipped() -> None:
+    """Any other ``-``-prefixed token inside a ``get_*`` expression is
+    conservatively skipped (sdc.py:1010-1012)."""
+    names, _ = _extract_names("[get_ports -hierarchical clk]")
+    assert names == ["clk"]
+
+
+# ---- _safe_int fallback ----------------------------------------------------
+
+
+def test_safe_int_none_returns_default() -> None:
+    """``_safe_int(None, ...)`` short-circuits to the default
+    (sdc.py:1031-1032)."""
+    assert _safe_int(None, default=1) == 1
+    assert _safe_int(None, default=7) == 7
+
+
+def test_safe_int_non_numeric_returns_default() -> None:
+    """A word that doesn't ``int()`` falls back to the default via the
+    ValueError branch (sdc.py:1035-1036)."""
+    assert _safe_int("not_int", default=3) == 3
+    # And a parseable value passes straight through.
+    assert _safe_int("12", default=3) == 12
+
+
+def test_generated_clock_non_numeric_divide_by_uses_default_period() -> None:
+    """End-to-end exercise of the ``_safe_int`` ValueError fallback:
+    a non-numeric ``-divide_by`` defaults to 1, so the generated clock
+    inherits the master's period unscaled."""
+    spec = parse(
+        """
+        create_clock -name ck_a -period 10 [get_ports ck_a]
+        create_generated_clock -name g -master_clock ck_a \\
+            -divide_by bogus [get_pins u/clk_out]
+        """
+    )
+    # default divide_by == 1, multiply_by == 1 → period == master period.
+    assert spec.clocks["g"].period == 10.0
+    assert spec.resolve("g") == "ck_a"

--- a/tests/test_cov_slang_a.py
+++ b/tests/test_cov_slang_a.py
@@ -1,0 +1,377 @@
+"""Coverage tests for the slang frontend's *early* lowering paths
+(``frontends/slang.py`` lines 171-905): the elaborate() entry point's
+error surfaces, generate-block expansion, port / netname collection,
+async-reset-arm value capture, and the procedural-block dispatch
+guards.
+
+These complement ``test_slang_lowering.py`` (operator zoo) and
+``test_slang_const_cond_fold.py`` (mux folding) by pinning the
+*structural-edge* behaviours those files skip: what happens on a
+parse error, an unknown top, an unconnected child port, a blocking /
+non-constant reset assignment, a plain ``always @(*)`` block, and the
+generate-array / generate-if naming convention.
+
+Each test drives the public ``elaborate(paths, top,
+frontend=Frontend.slang)`` factory exactly as the CLI does — the same
+``_elaborate_inline`` / ``_elaborate_full`` helper shape used by
+``test_slang_lowering.py`` — and asserts on the produced ``Module``'s
+cells / netnames / parameters or on the raised
+``SlangElaborationError`` text. No Yosys binary is involved; pyslang
+reads the SV directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.frontends.slang import SlangElaborationError
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang early-lowering tests are gated on it",
+        allow_module_level=True,
+    )
+
+
+def _elaborate_full(tmp_path: Path, src: str, top: str = "m"):
+    """Write ``src`` to a temp .sv file and elaborate via the slang
+    frontend, returning the full :class:`Module`."""
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _elaborate_inline(tmp_path: Path, src: str, top: str = "m") -> dict[str, str]:
+    """Flat ``{cell_name: cell_type}`` map for membership assertions."""
+    module = _elaborate_full(tmp_path, src, top)
+    return {name: cell.type for name, cell in module.cells.items()}
+
+
+# --- elaborate() error surfaces (lines 190-209) ---------------------------
+
+
+def test_fatal_diagnostic_raises_elaboration_error(tmp_path: Path) -> None:
+    """A genuine SV syntax error must be surfaced as a
+    :class:`SlangElaborationError` whose message carries the rendered
+    ``TextDiagnosticClient`` summary — not swallowed, not a bare
+    pyslang crash. Exercises the fatal-diagnostic branch
+    (``DiagnosticEngine`` + ``TextDiagnosticClient`` rendering)."""
+    sv = tmp_path / "broken.sv"
+    # ``assign a = ;`` is a parse error (missing RHS expression).
+    sv.write_text("module m (output logic a);\n    assign a = ;\nendmodule\n")
+    with pytest.raises(SlangElaborationError) as exc:
+        elaborate([sv], "m", frontend=Frontend.slang)
+    assert "pyslang elaboration produced errors" in str(exc.value)
+
+
+def test_unknown_top_lists_available_instances(tmp_path: Path) -> None:
+    """Asking for a top that doesn't exist must raise with a message
+    that names the requested top *and* enumerates the instances that
+    were actually elaborated — the diagnostic the CLI surfaces when a
+    user fat-fingers ``--top``."""
+    sv = tmp_path / "real.sv"
+    sv.write_text(
+        "module real_top (input logic a, output logic b);\n"
+        "    assign b = a;\nendmodule\n"
+    )
+    with pytest.raises(SlangElaborationError) as exc:
+        elaborate([sv], "does_not_exist", frontend=Frontend.slang)
+    msg = str(exc.value)
+    assert "does_not_exist" in msg
+    assert "real_top" in msg, msg
+
+
+# --- generate-block expansion (lines 394-410) ------------------------------
+
+
+def test_generate_for_array_uses_indexed_dotted_prefix(tmp_path: Path) -> None:
+    """A ``for (genvar ...)`` generate array
+    (:class:`GenerateBlockArraySymbol`) must expand into one body per
+    iteration, each emitting cells under the Yosys-flatten
+    ``g_label[i].`` dotted prefix. Confirms the array-entry naming path
+    (``arrayIndex`` → ``g_stage[0].`` … ``g_stage[3].``)."""
+    src = """module m (
+    input  logic clk,
+    input  logic [3:0] d,
+    output logic [3:0] q
+);
+    genvar i;
+    generate
+        for (i = 0; i < 4; i = i + 1) begin : g_stage
+            always_ff @(posedge clk) q[i] <= d[i];
+        end
+    endgenerate
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    flop_names = sorted(
+        c.name for c in module.cells.values() if c.type in {"$dff", "$adff"}
+    )
+    assert len(flop_names) == 4, flop_names
+    assert flop_names[0].startswith("g_stage[0]."), flop_names
+    assert flop_names[3].startswith("g_stage[3]."), flop_names
+
+
+def test_generate_if_emits_only_the_taken_branch(tmp_path: Path) -> None:
+    """A ``generate if`` keeps only the elaborated
+    (:attr:`isUninstantiated` ``False``) branch. With ``EN = 1`` the
+    ``g_on`` body's flop is emitted under the ``g_on.`` prefix and the
+    pruned ``g_off`` branch contributes nothing — proving the
+    uninstantiated-branch skip and the single-named-block prefix path
+    both fire."""
+    src = """module m #(parameter bit EN = 1) (
+    input  logic clk, d,
+    output logic q
+);
+    generate
+        if (EN) begin : g_on
+            always_ff @(posedge clk) q <= d;
+        end else begin : g_off
+            always_ff @(posedge clk) q <= 1'b0;
+        end
+    endgenerate
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    flop_names = sorted(
+        c.name for c in module.cells.values() if c.type in {"$dff", "$adff"}
+    )
+    assert len(flop_names) == 1, flop_names
+    assert flop_names[0].startswith("g_on."), flop_names
+    assert not any("g_off" in n for n in flop_names), flop_names
+
+
+# --- async-reset-arm value capture (lines 857-892) -------------------------
+#
+# The reset arm is walked by ``_collect_reset_assignments`` to fill the
+# ``$adff`` ``ARST_VALUE`` parameter. A recognised constant literal is
+# captured (control below shows 4'd5 → "0101"); the blocking,
+# non-constant, and non-assignment shapes each early-return and fall
+# back to the conservative ARST_VALUE = "0". Asserting "0" against the
+# captured-value control proves the fallback, not coincidence.
+
+
+def test_reset_arm_constant_literal_is_captured(tmp_path: Path) -> None:
+    """Control: a recognised ``q <= 4'd5;`` reset arm populates
+    ``ARST_VALUE`` with the literal's bits (length tracks WIDTH). This
+    is the value the early-return cases below deliberately do *not*
+    capture."""
+    src = """module m (
+    input  logic clk, rst_n,
+    input  logic [3:0] d,
+    output logic [3:0] q
+);
+    always_ff @(posedge clk or negedge rst_n)
+        if (!rst_n) q <= 4'd5;
+        else        q <= d;
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    adff = next(c for c in module.cells.values() if c.type == "$adff")
+    assert adff.parameters["ARST_VALUE"] == "0101", adff.parameters
+
+
+def test_reset_arm_blocking_assign_falls_back_to_zero(tmp_path: Path) -> None:
+    """A *blocking* assign in the reset arm (``q = 1'b0;`` — an SV
+    style slip) is not a nonblocking write, so the reset-value walker
+    skips it and ``ARST_VALUE`` defaults to ``"0"``. The flop still
+    emits as an ``$adff`` (the event list still carries the async
+    reset)."""
+    src = """module m (
+    input  logic clk, rst_n, d,
+    output logic q
+);
+    always_ff @(posedge clk or negedge rst_n)
+        if (!rst_n) q = 1'b0;
+        else        q <= d;
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    adff = next(c for c in module.cells.values() if c.type == "$adff")
+    assert adff.parameters["ARST_VALUE"] == "0", adff.parameters
+
+
+def test_reset_arm_non_constant_rhs_falls_back_to_zero(tmp_path: Path) -> None:
+    """A reset arm whose RHS isn't a compile-time constant
+    (``q <= e;`` where ``e`` is a runtime input) can't be folded, so
+    ``_const_int`` returns None and ``ARST_VALUE`` defaults to
+    ``"0"``."""
+    src = """module m (
+    input  logic clk, rst_n, d, e,
+    output logic q
+);
+    always_ff @(posedge clk or negedge rst_n)
+        if (!rst_n) q <= e;
+        else        q <= d;
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    adff = next(c for c in module.cells.values() if c.type == "$adff")
+    assert adff.parameters["ARST_VALUE"] == "0", adff.parameters
+
+
+def test_reset_arm_non_assignment_statement_is_skipped(tmp_path: Path) -> None:
+    """A non-assignment statement in the reset arm (a ``$display``
+    system task) is not an :class:`AssignmentExpression`, so the
+    reset-value walker bails and ``ARST_VALUE`` defaults to ``"0"`` —
+    while the flop itself still emits with the data-arm semantics
+    intact."""
+    src = """module m (
+    input  logic clk, rst_n, d,
+    output logic q
+);
+    always_ff @(posedge clk or negedge rst_n)
+        if (!rst_n) $display("in reset");
+        else        q <= d;
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    adff = next(c for c in module.cells.values() if c.type == "$adff")
+    assert adff.parameters["ARST_VALUE"] == "0", adff.parameters
+    # The data arm still wires d → D.
+    d_bits = module.netnames["d"].bits
+    assert adff.connections["D"] == tuple(d_bits), adff.connections
+
+
+# --- procedural-block dispatch guards (lines 743-759) ----------------------
+
+
+def test_plain_always_star_block_is_not_modelled(tmp_path: Path) -> None:
+    """A bare ``always @(*)`` (``procedureKind == Always``, neither
+    ``AlwaysFF`` nor ``AlwaysComb`` nor ``AlwaysLatch``) falls through
+    the dispatch and emits no cell — the continuous-assign aliasing on
+    ``b`` is what carries the signal. Pins that the unmodelled-kind
+    guard doesn't crash and doesn't fabricate a flop."""
+    src = """module m (
+    input  logic a,
+    output logic b
+);
+    logic y;
+    always @(*) y = a;
+    assign b = y;
+endmodule
+"""
+    cells = _elaborate_inline(tmp_path, src)
+    assert "$dff" not in cells.values()
+    assert "$adff" not in cells.values()
+    assert "$dlatch" not in cells.values()
+
+
+def test_always_latch_emits_dlatch(tmp_path: Path) -> None:
+    """An ``always_latch`` with the canonical single-arm
+    ``if (en) q = d;`` shape lowers to a ``$dlatch`` (active-high EN,
+    1-bit WIDTH). Exercises the ``AlwaysLatch`` dispatch leg of
+    ``_emit_procedural_block``."""
+    src = """module m (
+    input  logic en, d,
+    output logic q
+);
+    always_latch
+        if (en) q = d;
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    latch = next(c for c in module.cells.values() if c.type == "$dlatch")
+    assert latch.parameters["EN_POLARITY"] == "1", latch.parameters
+    assert latch.parameters["WIDTH"] == "0" * 31 + "1", latch.parameters
+    assert set(latch.connections) == {"EN", "D", "Q"}
+
+
+def test_always_ff_without_else_emits_no_flop(tmp_path: Path) -> None:
+    """A reset-style ``if (!rst_n) q <= 0;`` with *no* ``else`` data
+    arm has no data assignment to model, so the block drains to
+    nothing — no flop is emitted. Pins the ``data_branch is None``
+    early-return."""
+    src = """module m (
+    input  logic clk, rst_n,
+    output logic q
+);
+    always_ff @(posedge clk or negedge rst_n)
+        if (!rst_n) q <= 1'b0;
+endmodule
+"""
+    cells = _elaborate_inline(tmp_path, src)
+    assert "$adff" not in cells.values(), cells
+    assert "$dff" not in cells.values(), cells
+
+
+# --- child-instance port collection (lines 662-707) ------------------------
+
+
+def test_unconnected_child_output_port_allocates_own_net(tmp_path: Path) -> None:
+    """A child instance with its output port left ``.q()`` (unconnected)
+    must still flatten: the child's flop allocates its own bits rather
+    than aliasing to a parent net, and the child port's netname appears
+    under the ``u_c.`` dotted prefix. Exercises the
+    ``EmptyArgumentExpression`` / ``None``-expression port-connection
+    branches."""
+    src = """module child (
+    input  logic clk,
+    input  logic d,
+    output logic q
+);
+    always_ff @(posedge clk) q <= d;
+endmodule
+
+module m (
+    input  logic clk,
+    input  logic d,
+    output logic top_q
+);
+    child u_c (.clk(clk), .d(d), .q());
+    always_ff @(posedge clk) top_q <= d;
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    # Both flops still flatten in.
+    flop_types = sorted(
+        c.type for c in module.cells.values() if c.type in {"$dff", "$adff"}
+    )
+    assert flop_types == ["$dff", "$dff"], flop_types
+    # The unconnected child port still gets a dotted netname entry.
+    assert "u_c.q" in module.netnames, sorted(module.netnames)
+
+
+# --- inline net initializer (lines 633-660) --------------------------------
+
+
+def test_inline_wire_initializer_emits_comb_cell(tmp_path: Path) -> None:
+    """``wire s1n = ~s1;`` between two flops lowers via the
+    :class:`NetSymbol` initializer path to a real ``$not`` cell whose
+    Y bits alias the wire — same shape the explicit ``assign s1n =
+    ~s1;`` form produces. Pins the net-initializer dispatch leg."""
+    src = """module m (
+    input  logic clk, a,
+    output logic q
+);
+    logic s1;
+    always_ff @(posedge clk) s1 <= a;
+    wire s1n = ~s1;
+    always_ff @(posedge clk) q <= s1n;
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    not_cells = [c for c in module.cells.values() if c.type == "$not"]
+    assert len(not_cells) == 1, [c.type for c in module.cells.values()]
+    not_cell = not_cells[0]
+    flops = [c for c in module.cells.values() if c.type == "$dff"]
+    assert len(flops) == 2, [c.type for c in module.cells.values()]
+    by_q = {f.connections["Q"]: f for f in flops}
+    # The $not bridges the two flops: its A reads the first flop's Q
+    # (s1), its Y drives the second flop's D. Without the net-initializer
+    # lowering the second flop's D would be driven by nothing.
+    src_q = module.netnames["s1"].bits
+    assert not_cell.connections["A"] == tuple(src_q), (
+        not_cell.connections,
+        src_q,
+    )
+    dst_flop = next(f for q, f in by_q.items() if q != tuple(src_q))
+    assert dst_flop.connections["D"] == not_cell.connections["Y"], (
+        dst_flop.connections,
+        not_cell.connections,
+    )

--- a/tests/test_cov_slang_b.py
+++ b/tests/test_cov_slang_b.py
@@ -1,0 +1,783 @@
+"""Coverage tests for the slang frontend's statement walker and
+procedural-block lowering (``frontends/slang.py``, lines ~905-1610).
+
+The existing ``test_slang_*`` suite pins the *happy paths* of the
+walker — canonical for-loops, both-arms if/else, dynamic case items,
+always_latch, enable inference. This module deliberately drives the
+*bail / fall-through / fold* arms that the happy-path tests skip:
+
+- statement shapes the walker can't model (struct-member LHS,
+  function-call RHS / case-expr / case-match) must degrade gracefully
+  rather than crash, producing either no flop or a ``$_UNKNOWN_``
+  driver as documented in the source;
+- the synchronous-reset heuristic
+  (``_classify_reset_check`` → ``_is_constant_only_assignment_tree``)
+  must recognise an all-constant ``if (rst)`` arm and emit ``$sdff``,
+  recursing through for-loop / case reset arms;
+- an async-reset event-list whose body's outer ``if`` gates on a
+  *different* symbol than the reset must NOT be classified as a reset
+  check — the body walks as a normal mux tree;
+- every ``for``-loop header shape the unroller supports
+  (``<=`` / ``>`` / ``!=`` stop ops, ``-=`` compound step) must
+  unroll to the right trip count, and every shape it deliberately
+  refuses (multi-var header, multi-step header, ``*=`` step,
+  non-binary stop) must bail with zero flops rather than throw.
+
+Each test asserts on concrete netlist content — flop count, cell
+type set, ``$sdff`` vs ``$adff`` reset shape, ``$_UNKNOWN_`` presence,
+mux-tree structure — so a regression in any branch is diagnostic, not
+a silent coverage drop.
+
+Gated on pyslang (same module-level skip as ``test_slang_lowering``);
+the coverage job has pyslang installed so these run there.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang walker bail-path tests are gated on it",
+        allow_module_level=True,
+    )
+
+FLOP_TYPES = frozenset({"$dff", "$adff", "$dffe", "$adffe", "$sdff", "$sdffe"})
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    """Write ``src`` to a temp .sv file and elaborate via the slang
+    frontend — the same entry point the CLI's ``lint`` command uses."""
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _flops(module) -> list:
+    return [c for c in module.cells.values() if c.type in FLOP_TYPES]
+
+
+def _flop_count(module) -> int:
+    return sum(1 for c in module.cells.values() if c.type in FLOP_TYPES)
+
+
+def _cell_types(module) -> set[str]:
+    return {c.type for c in module.cells.values()}
+
+
+def _build_drivers(mod) -> dict:
+    """Bit → (cell_name, port_name) for every cell output bit."""
+    drv = {}
+    for name, cell in mod.cells.items():
+        for port, bits in cell.connections.items():
+            if port in ("Q", "Y"):
+                for b in bits:
+                    if isinstance(b, int):
+                        drv[b] = (name, port)
+    return drv
+
+
+# --- timing-control edge classification -----------------------------------
+
+
+def test_negedge_clock_single_event_sets_clk_polarity_zero(tmp_path: Path) -> None:
+    """``always_ff @(negedge clk)`` (no reset) must lower to a plain
+    ``$dff`` with ``CLK_POLARITY`` = 0 — the negedge edge threads
+    through ``_classify_timing`` into the flop's parameter, closing
+    the CDC-016 parity gap. The single-event no-reset shape exercises
+    the ``clk_edge == "NegEdge"`` branch of the classifier."""
+    src = """
+    module m (input logic clk, input logic [3:0] d, output logic [3:0] q);
+        always_ff @(negedge clk) q <= d;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 1, f"expected one $dff for q; got {len(flops)}"
+    flop = flops[0]
+    assert flop.type == "$dff", (
+        f"no-reset always_ff should be a plain $dff; got {flop.type}"
+    )
+    clk_pol = flop.parameters.get("CLK_POLARITY")
+    assert clk_pol is not None, "CLK_POLARITY parameter missing on $dff"
+    assert int(clk_pol, 2) == 0, (
+        f"negedge clock should set CLK_POLARITY=0; got {clk_pol!r}"
+    )
+
+
+# --- non-lowerable condition: both arms walk unconditionally --------------
+
+
+def test_multibit_if_condition_walks_both_arms(tmp_path: Path) -> None:
+    """When the ``else if`` condition is multi-bit (``if (sel)`` with a
+    2-bit ``sel``), ``_lower_condition_to_bit`` can't reduce it to a
+    single mux-select bit and returns ``None``. The walker then falls
+    back to walking *both* arms unconditionally (the conservative
+    pre-enable-inference policy). With each arm writing a distinct LHS
+    that yields two independent flops — proving the fall-through path
+    still surfaces every assignment site rather than dropping the
+    block."""
+    src = """
+    module m (
+        input  logic       clk, rst_n,
+        input  logic [1:0] sel,
+        input  logic       da, db,
+        output logic       qa, qb
+    );
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) begin qa <= 1'b0; qb <= 1'b0; end
+            else if (sel) qa <= da;
+            else          qb <= db;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 2, (
+        f"expected two flops (qa, qb) from the unconditional both-arms walk "
+        f"of a non-lowerable multi-bit condition; got {len(flops)}"
+    )
+    # Both LHS ports must each be driven by a flop's Q — confirming the
+    # fall-through reached both arms.
+    q_outputs = set()
+    for f in flops:
+        q_outputs.update(f.connections.get("Q", ()))
+    qa_bit = mod.ports["qa"].bits[0]
+    qb_bit = mod.ports["qb"].bits[0]
+    assert qa_bit in q_outputs and qb_bit in q_outputs, (
+        "both qa and qb must be flop Q outputs; the non-lowerable condition "
+        "must not silently drop an arm"
+    )
+
+
+# --- non-lowerable RHS: $_UNKNOWN_ driver ---------------------------------
+
+
+def test_function_call_rhs_emits_unknown_driver(tmp_path: Path) -> None:
+    """A nonblocking assign whose RHS is a function call
+    (``q <= inc(d)``) can't be lowered by ``_bits_of_expression``
+    (function calls aren't modelled), so the drain substitutes a
+    ``$_UNKNOWN_`` stub driver for D. The flop must still be emitted —
+    the netlist stays well-formed and the rule pack treats the D input
+    as opaque rather than crashing."""
+    src = """
+    module m (input logic clk, rst_n, input logic [3:0] d, output logic [3:0] q);
+        function automatic logic [3:0] inc(input logic [3:0] x);
+            inc = x + 4'd1;
+        endfunction
+        always_ff @(posedge clk or negedge rst_n)
+            if (!rst_n) q <= 4'd0;
+            else        q <= inc(d);
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$adff" in types, f"expected an $adff for q; got {sorted(types)}"
+    assert "$_UNKNOWN_" in types, (
+        f"function-call RHS should fall back to a $_UNKNOWN_ driver; "
+        f"got cell types {sorted(types)}"
+    )
+    # The flop's D must trace to the $_UNKNOWN_ output (opaque upstream).
+    flop = _flops(mod)[0]
+    d_bit = flop.connections["D"][0]
+    drv = _build_drivers(mod).get(d_bit)
+    assert drv is not None, "flop D has no driver"
+    assert mod.cells[drv[0]].type == "$_UNKNOWN_", (
+        f"flop D should be driven by the $_UNKNOWN_ stub; got {mod.cells[drv[0]].type}"
+    )
+
+
+# --- non-lowerable LHS: assignment site skipped ---------------------------
+
+
+def test_struct_member_lhs_is_skipped(tmp_path: Path) -> None:
+    """``q.a <= d`` writes a struct member — ``_lvalue_bits`` only
+    resolves NamedValue / ElementSelect / RangeSelect lvalues, so a
+    struct-member LHS returns ``None`` and the write is skipped. The
+    block contributes no flop (rather than emitting a malformed cell)
+    — the documented "other LHS shapes are skipped" contract."""
+    src = """
+    typedef struct packed { logic [3:0] a; } s_t;
+    module m (input logic clk, rst_n, input logic [3:0] d, output s_t q);
+        always_ff @(posedge clk or negedge rst_n)
+            if (!rst_n) q.a <= 4'd0;
+            else        q.a <= d;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 0, (
+        f"struct-member LHS should be skipped (no flop emitted); "
+        f"got {_flop_count(mod)} flops, cells {sorted(_cell_types(mod))}"
+    )
+
+
+# --- non-lowerable case-expr: conservative bail ---------------------------
+
+
+def test_case_on_function_call_bails_to_unconditional_walk(tmp_path: Path) -> None:
+    """``case (f(sel))`` — the case expression is a function call that
+    ``_bits_of_expression`` can't lower, so the walker takes the
+    conservative bail: it walks every item (and the default) with no
+    per-arm enable. The single ``q <= d`` arm still surfaces as a flop;
+    no ``$eq`` gating cell is emitted because the case-expr never
+    lowered to bits."""
+    src = """
+    module m (
+        input  logic       clk, rst_n,
+        input  logic [1:0] sel,
+        input  logic [3:0] d,
+        output logic [3:0] q
+    );
+        function automatic logic [1:0] f(input logic [1:0] x);
+            f = x ^ 2'b01;
+        endfunction
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 4'd0;
+            else case (f(sel))
+                2'd0:    q <= d;
+                default: q <= 4'd0;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$adff" in types, f"expected an $adff for q; got {sorted(types)}"
+    assert "$eq" not in types, (
+        f"non-lowerable case-expr must NOT emit per-arm $eq gating cells "
+        f"(bail path walks unconditionally); got {sorted(types)}"
+    )
+    assert _flop_count(mod) == 1, (
+        f"distinct lvalue ``q`` collapses to one flop; got {_flop_count(mod)}"
+    )
+
+
+# --- non-lowerable case-match: item walks without enable ------------------
+
+
+def test_case_match_function_call_walks_item_without_enable(tmp_path: Path) -> None:
+    """The case-expr *is* lowerable (a 2-bit signal) but the item's
+    match expression is a function call. ``_bits_of_expression`` returns
+    ``None`` for that match, so the per-match ``$eq`` is skipped, the
+    item's combined enable is ``None``, and the arm walks with no
+    enable pushed. The arm's ``q <= d`` write still emits a flop."""
+    src = """
+    module m (
+        input  logic       clk, rst_n,
+        input  logic [1:0] sel,
+        input  logic [3:0] d,
+        output logic [3:0] q
+    );
+        function automatic logic [1:0] thresh();
+            thresh = 2'd1;
+        endfunction
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 4'd0;
+            else case (sel)
+                thresh(): q <= d;
+                default:  ;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 1, (
+        f"the unmatched-shape item should still emit its q-flop "
+        f"(walk-without-enable path); got {_flop_count(mod)}"
+    )
+    types = _cell_types(mod)
+    assert "$eq" not in types, (
+        f"a function-call match expr should not produce an $eq gating cell; "
+        f"got {sorted(types)}"
+    )
+
+
+# --- synchronous-reset heuristic: $sdff -----------------------------------
+
+
+def test_sync_reset_emits_sdff(tmp_path: Path) -> None:
+    """A no-async-event ``always_ff @(posedge clk)`` whose body is
+    ``if (rst) q <= 0; else q <= d;`` must be classified as a
+    synchronous reset: the ``ifTrue`` arm assigns only constants
+    (``_is_constant_only_assignment_tree`` → True) so the flop
+    materialises as ``$sdff``, not a plain ``$dff`` with a mux."""
+    src = """
+    module m (input logic clk, rst, input logic [3:0] d, output logic [3:0] q);
+        always_ff @(posedge clk) begin
+            if (rst) q <= 4'd0;
+            else     q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$sdff" in types, (
+        f"all-constant if (rst) arm should fold to $sdff; got {sorted(types)}"
+    )
+    assert "$adff" not in types, (
+        "no async event in the sensitivity list — must not be $adff"
+    )
+
+
+def test_sync_reset_with_forloop_reset_arm(tmp_path: Path) -> None:
+    """The synchronous-reset detector recurses through a ``for``-loop
+    in the reset arm: ``if (rst) for (i) q[i] <= 0; else ...`` — the
+    loop body assigns only constants, so
+    ``_is_constant_only_assignment_tree`` returns True through its
+    ForLoopStatement branch and every unrolled bit becomes an
+    ``$sdff``."""
+    src = """
+    module m #(parameter int N = 3) (
+        input  logic clk, rst,
+        input  logic [N-1:0] d,
+        output logic [N-1:0] q
+    );
+        always_ff @(posedge clk) begin
+            if (rst) begin
+                for (int i = 0; i < N; i++) q[i] <= 1'b0;
+            end else begin
+                for (int i = 0; i < N; i++) q[i] <= d[i];
+            end
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 3, f"expected 3 unrolled flops (N=3); got {len(flops)}"
+    assert all(f.type == "$sdff" for f in flops), (
+        f"for-loop reset arm of constants must classify as sync reset ($sdff); "
+        f"got {[f.type for f in flops]}"
+    )
+
+
+def test_sync_reset_with_case_reset_arm(tmp_path: Path) -> None:
+    """The detector also recurses through a ``case`` whose every arm
+    (items + default) assigns only constants in the reset branch:
+    ``if (rst) case (mode) ... endcase`` folds to ``$sdff`` via the
+    CaseStatement branch of ``_is_constant_only_assignment_tree``."""
+    src = """
+    module m (
+        input  logic       clk, rst,
+        input  logic [1:0] mode,
+        input  logic [3:0] d,
+        output logic [3:0] q
+    );
+        always_ff @(posedge clk) begin
+            if (rst) begin
+                case (mode)
+                    2'd0:    q <= 4'd0;
+                    default: q <= 4'd0;
+                endcase
+            end else q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$sdff" in types, (
+        f"case-of-constants reset arm should fold to $sdff; got {sorted(types)}"
+    )
+
+
+def test_reset_arm_with_task_call_is_not_sync(tmp_path: Path) -> None:
+    """The sync-reset detector walks the ``ifTrue`` arm via
+    ``_is_constant_only_assignment_tree``. When that arm contains a
+    non-assignment statement (a void task call), the helper bails to
+    ``False`` (the call isn't a constant assign), so the block is NOT
+    classified as a synchronous reset — it lowers as a plain ``$dff``
+    with a mux tree instead of ``$sdff``."""
+    src = """
+    module m (input logic clk, rst, input logic [3:0] d, output logic [3:0] q);
+        task automatic noop(); endtask
+        always_ff @(posedge clk) begin
+            if (rst) begin noop(); q <= 4'd0; end
+            else     q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$sdff" not in types, (
+        f"a reset arm containing a task call must not classify as sync; "
+        f"got {sorted(types)}"
+    )
+    assert "$dff" in types and "$mux" in types, (
+        f"non-classified block lowers as $dff + mux tree; got {sorted(types)}"
+    )
+
+
+def test_reset_arm_with_blocking_assign_is_not_sync(tmp_path: Path) -> None:
+    """A *blocking* assign in the candidate reset arm (``if (rst) q =
+    0;``) likewise fails the constant-only check — the helper requires
+    nonblocking assigns (``isNonBlocking``), so it returns ``False``
+    and the block is not folded to ``$sdff``."""
+    src = """
+    module m (input logic clk, rst, input logic [3:0] d, output logic [3:0] q);
+        always_ff @(posedge clk) begin
+            if (rst) q = 4'd0;
+            else     q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$sdff" not in types, (
+        f"a blocking-assign reset arm must not classify as sync; got {sorted(types)}"
+    )
+    assert "$dff" in types, f"expected a plain $dff; got {sorted(types)}"
+
+
+# --- async event list but mismatched reset symbol -------------------------
+
+
+def test_async_event_with_mismatched_if_symbol_is_not_a_reset(tmp_path: Path) -> None:
+    """``always_ff @(posedge clk or negedge rst_n)`` whose body's outer
+    ``if`` gates on a *different* signal (``en``, not ``rst_n``) must
+    NOT be classified as a reset check: ``_classify_reset_check``
+    returns ``None`` because ``cond_sym is not reset_sym_from_event_list``.
+    The body then walks as an ordinary if/else, building a mux tree
+    (with a ``$not`` for the else arm) — not a clean reset fold."""
+    src = """
+    module m (
+        input  logic       clk, rst_n, en,
+        input  logic [3:0] d,
+        output logic [3:0] q
+    );
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (en) q <= d;
+            else    q <= 4'd0;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    # The async event still gives an $adff binding, but the body's
+    # if/else is walked as a mux tree rather than folded into the
+    # reset value — so a $mux and a $not appear.
+    assert "$mux" in types, (
+        f"mismatched-symbol if/else must build a mux tree (not a reset fold); "
+        f"got {sorted(types)}"
+    )
+    assert "$not" in types, (
+        f"the else arm pushes $not(en) onto the enable stack; got {sorted(types)}"
+    )
+    en_bit = mod.ports["en"].bits[0]
+    # The select of the mux must trace back to ``en`` (the gating
+    # condition), confirming en — not rst_n — drives the conditional.
+    seen: set = set()
+    frontier = [
+        b
+        for c in mod.cells.values()
+        if c.type == "$mux"
+        for b in c.connections.get("S", ())
+    ]
+    drivers = _build_drivers(mod)
+    walk = {"$mux", "$not", "$and", "$or"}
+    while frontier:
+        b = frontier.pop()
+        if b in seen or not isinstance(b, int):
+            continue
+        seen.add(b)
+        drv = drivers.get(b)
+        if drv is None or mod.cells[drv[0]].type not in walk:
+            continue
+        for port, bits in mod.cells[drv[0]].connections.items():
+            if port in ("Q", "Y"):
+                continue
+            frontier.extend(bits)
+    assert en_bit in seen, (
+        "the mux select must trace back to the ``en`` port — confirming the "
+        "body gated on en, distinct from the rst_n reset event"
+    )
+
+
+# --- for-loop header shapes the unroller supports -------------------------
+
+
+def test_for_loop_less_than_equal_stop(tmp_path: Path) -> None:
+    """``for (int i = 0; i <= 3; i++)`` — the ``LessThanEqual`` stop op
+    includes the bound, so the trip count is 4 (i = 0,1,2,3)."""
+    src = """
+    module m (input logic clk, input logic [4:0] d, output logic [4:0] q);
+        always_ff @(posedge clk)
+            for (int i = 0; i <= 3; i++) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 4, (
+        f"i <= 3 should unroll 4 times (0..3); got {_flop_count(mod)}"
+    )
+
+
+def test_for_loop_greater_than_stop(tmp_path: Path) -> None:
+    """``for (int i = 3; i > 0; i--)`` — the ``GreaterThan`` stop op
+    with a decrement: trip count 3 (i = 3,2,1; i=0 excluded)."""
+    src = """
+    module m (input logic clk, input logic [4:0] d, output logic [4:0] q);
+        always_ff @(posedge clk)
+            for (int i = 3; i > 0; i--) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 3, (
+        f"i > 0 from 3 should unroll 3 times (3,2,1); got {_flop_count(mod)}"
+    )
+
+
+def test_for_loop_inequality_stop(tmp_path: Path) -> None:
+    """``for (int i = 0; i != 3; i++)`` — the ``Inequality`` stop op
+    runs while i differs from 3: trip count 3 (i = 0,1,2)."""
+    src = """
+    module m (input logic clk, input logic [4:0] d, output logic [4:0] q);
+        always_ff @(posedge clk)
+            for (int i = 0; i != 3; i++) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 3, (
+        f"i != 3 from 0 should unroll 3 times (0,1,2); got {_flop_count(mod)}"
+    )
+
+
+def test_for_loop_compound_subtract_step(tmp_path: Path) -> None:
+    """``for (int i = 5; i > 0; i -= 2)`` — the compound ``-=`` step
+    desugars to ``i = i - 2`` (lvalue on the left of the Subtract), so
+    the step amount is -2: trip count 3 (i = 5,3,1)."""
+    src = """
+    module m (input logic clk, input logic [5:0] d, output logic [5:0] q);
+        always_ff @(posedge clk)
+            for (int i = 5; i > 0; i -= 2) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 3, (
+        f"i -= 2 from 5 (i>0) should unroll 3 times (5,3,1); got {_flop_count(mod)}"
+    )
+
+
+def test_nested_for_loops_unroll_product(tmp_path: Path) -> None:
+    """Two procedural for-loops nested with distinct loop variables
+    must unroll to the product of their trip counts (2 x 3 = 6),
+    confirming the inner loop's binding is re-pushed and restored on
+    each outer iteration without leaking state."""
+    src = """
+    module m (input logic clk, input logic [5:0] d, output logic [5:0] q);
+        always_ff @(posedge clk) begin
+            for (int i = 0; i < 2; i++)
+                for (int j = 0; j < 3; j++)
+                    q[i*3 + j] <= d[i*3 + j];
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 6, (
+        f"nested 2x3 for-loops should unroll to 6 flops; got {_flop_count(mod)}"
+    )
+
+
+# --- for-loop header shapes the unroller deliberately refuses -------------
+
+
+def test_for_loop_multiple_loop_vars_bails(tmp_path: Path) -> None:
+    """``for (int i = 0, j = 0; ...; ...)`` declares two loop vars. The
+    unroller only handles a single loop variable, so it bails with no
+    flop emitted (rather than guessing). Must not raise."""
+    src = """
+    module m (input logic clk, input logic [3:0] d, output logic [3:0] q);
+        always_ff @(posedge clk)
+            for (int i = 0, j = 0; i < 4; i++) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 0, (
+        f"multi-loop-var header must bail with 0 flops; got {_flop_count(mod)}"
+    )
+
+
+def test_for_loop_multiple_steps_bails(tmp_path: Path) -> None:
+    """``for (...; ...; i++, j++)`` has two step expressions. The
+    unroller only supports a single step, so it bails cleanly."""
+    src = """
+    module m (input logic clk, input logic [3:0] d, output logic [3:0] q);
+        int j;
+        always_ff @(posedge clk)
+            for (int i = 0; i < 4; i++, j++) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 0, (
+        f"multi-step header must bail with 0 flops; got {_flop_count(mod)}"
+    )
+
+
+def test_for_loop_multiplicative_step_bails(tmp_path: Path) -> None:
+    """``for (int i = 1; i < 8; i *= 2)`` — the ``*=`` compound step is
+    not one of the supported (``+=`` / ``-=`` / ``++`` / ``--``) shapes,
+    so ``step_amount`` stays ``None`` and the loop bails. (A real
+    geometric loop would otherwise need a non-constant trip model.)"""
+    src = """
+    module m (input logic clk, input logic [7:0] d, output logic [7:0] q);
+        always_ff @(posedge clk)
+            for (int i = 1; i < 8; i *= 2) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 0, (
+        f"multiplicative step must bail with 0 flops; got {_flop_count(mod)}"
+    )
+
+
+def test_for_loop_runtime_stop_expr_bails(tmp_path: Path) -> None:
+    """A stop expression that isn't a ``BinaryExpression`` against the
+    loop var (here a bare runtime signal ``go``) can't yield a
+    compile-time trip count, so the unroller bails. Must not crash."""
+    src = """
+    module m (input logic clk, go, input logic [3:0] d, output logic [3:0] q);
+        always_ff @(posedge clk)
+            for (int i = 0; go; i++) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 0, (
+        f"non-BinaryExpression stop must bail with 0 flops; got {_flop_count(mod)}"
+    )
+    # Elaboration still produced a well-formed module.
+    assert mod.name == "m"
+
+
+def test_for_loop_runtime_start_bails(tmp_path: Path) -> None:
+    """A loop whose *initial* value is a runtime signal (``i = base``)
+    has no compile-time start, so ``_const_int(init_expr)`` returns
+    ``None`` and the unroller bails before computing a trip count."""
+    src = """
+    module m (
+        input  logic       clk,
+        input  logic [3:0] base,
+        input  logic [3:0] d,
+        output logic [3:0] q
+    );
+        always_ff @(posedge clk)
+            for (int i = base; i < 4; i++) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 0, (
+        f"runtime loop start must bail with 0 flops; got {_flop_count(mod)}"
+    )
+
+
+def test_for_loop_runtime_stop_bound_bails(tmp_path: Path) -> None:
+    """A stop bound that's a runtime signal (``i < n`` with ``n`` an
+    ``int`` so no width-conversion is inserted around the loop-var
+    reference) is a ``BinaryExpression`` whose left operand resolves
+    to the loop var — but ``_const_int`` of the right bound returns
+    ``None``. The unroller bails at the ``stop_val is None`` guard
+    (the documented fall-through-on-unknown policy) rather than
+    spinning an unbounded unroll."""
+    src = """
+    module m (
+        input  logic        clk,
+        input  int          n,
+        input  logic [15:0] d,
+        output logic [15:0] q
+    );
+        always_ff @(posedge clk)
+            for (int i = 0; i < n; i++) q[i] <= d[i];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 0, (
+        f"runtime stop bound must bail with 0 flops; got {_flop_count(mod)}"
+    )
+
+
+# --- non-assignment statements inside always_ff ---------------------------
+
+
+def test_task_call_statement_in_always_ff_is_skipped(tmp_path: Path) -> None:
+    """A non-assignment ``ExpressionStatement`` (a void task call) in
+    the data branch must be tolerated: ``_emit_assignment_expression``
+    sees a non-``AssignmentExpression`` and returns without emitting,
+    while the sibling ``q <= d`` still produces its flop. Confirms the
+    walker doesn't choke on procedural statements it can't model."""
+    src = """
+    module m (input logic clk, rst_n, input logic [3:0] d, output logic [3:0] q);
+        task automatic noop(); endtask
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 4'd0;
+            else begin
+                noop();
+                q <= d;
+            end
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 1, (
+        f"the task-call statement must be skipped while q<=d still emits "
+        f"its flop; got {_flop_count(mod)} flops"
+    )
+    assert "$adff" in _cell_types(mod)
+
+
+def test_nonconstant_reset_arm_is_not_a_sync_reset(tmp_path: Path) -> None:
+    """A no-async-event block whose outer ``if`` arm assigns a *signal*
+    (``if (rst) q <= dd;``) — not a constant — must NOT be treated as a
+    synchronous reset. ``_is_constant_only_assignment_tree`` returns
+    ``False`` (the RHS is a runtime value), so the classifier declines
+    the sync fold and the block lowers as a plain ``$dff`` driven by a
+    mux tree (the runtime-``if`` shape), distinguishing it from the
+    genuine ``if (rst) q <= 0`` reset that yields ``$sdff``."""
+    src = """
+    module m (
+        input  logic       clk, rst,
+        input  logic [3:0] d, dd,
+        output logic [3:0] q
+    );
+        always_ff @(posedge clk) begin
+            if (rst) q <= dd;
+            else     q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$sdff" not in types, (
+        f"a non-constant reset arm must NOT fold to $sdff; got {sorted(types)}"
+    )
+    assert "$dff" in types, (
+        f"the block should lower as a plain $dff with a mux tree; got {sorted(types)}"
+    )
+    assert "$mux" in types, (
+        f"the runtime-if shape must build a mux tree; got {sorted(types)}"
+    )
+
+
+# --- blocking assignment inside always_ff ---------------------------------
+
+
+def test_blocking_assign_in_always_ff_is_skipped(tmp_path: Path) -> None:
+    """A *blocking* assignment (``q = d``) inside an ``always_ff`` body
+    is an SV style violation; ``_emit_assignment_expression`` checks
+    ``isNonBlocking`` and skips it rather than modelling it. The data
+    arm here is blocking, so no flop is accumulated for it — the block
+    emits nothing once the reset fold has nothing to attach to."""
+    src = """
+    module m (input logic clk, rst_n, input logic [3:0] d, output logic [3:0] q);
+        always_ff @(posedge clk or negedge rst_n) begin
+            if (!rst_n) q <= 4'd0;
+            else        q = d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _flop_count(mod) == 0, (
+        f"blocking assign in always_ff must be skipped (not emitted); "
+        f"got {_flop_count(mod)} flops"
+    )

--- a/tests/test_cov_slang_c.py
+++ b/tests/test_cov_slang_c.py
@@ -1,0 +1,788 @@
+"""Coverage tests for the slang-frontend expression / statement lowering
+helpers in the ``1740-2860`` line band of ``frontends/slang.py``.
+
+The existing slang test files (``test_slang_lowering`` and friends)
+cover the headline shapes — binary/unary operators, ternary mux,
+unpacked arrays, sync-reset, shift fold, ``always_latch``,
+``always_ff`` case completeness. This file fills the remaining gaps
+in the same band that those tests happen not to touch:
+
+- ``always_comb`` ``if`` / ``else`` lowering (the procedural-mux merge
+  in :meth:`_walk_conditional_statement`): both-arms,
+  same-value-both-arms (no mux), only-true, only-false.
+- ``always_comb`` ``case`` lowering (:meth:`_walk_case_statement`) —
+  distinct from the ``always_ff`` case walker exercised elsewhere.
+- The indexed-assign CDC-019 one-hot decoder shape
+  (:meth:`_alias_indexed_assign`).
+- RHS range-selects (``d[hi:lo]``), arithmetic / arithmetic-shift /
+  division / reduction operators not in the lowering table tested
+  elsewhere.
+- ``_const_int`` folding over a procedural ``i*N`` index and a
+  parameter-driven replication count.
+- The conservative fall-throughs: an unmodelled RHS becomes a
+  ``$_UNKNOWN_`` driver, a multi-bit ``always_latch`` enable / a
+  non-blocking latch body / a multi-statement latch arm all drop the
+  latch, and a non-blocking write in ``always_comb`` is ignored.
+
+Each test elaborates a tiny SV snippet through the public
+``elaborate`` entry point (same path the CLI uses) and asserts on the
+concrete netlist shape the lowering must produce — cell types, the
+bit identity wired into ``D`` / ``Q`` / mux operands — not merely that
+a call returned.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang lowering tests are gated on it",
+        allow_module_level=True,
+    )
+
+FLOP_TYPES = frozenset({"$dff", "$adff", "$dffe", "$adffe", "$sdff", "$sdffe"})
+
+
+def _elaborate(tmp_path: Path, src: str, top: str = "m"):
+    """Write ``src`` to a temp .sv file and elaborate via the slang
+    frontend, returning the full :class:`Module`."""
+    sv = tmp_path / f"{top}.sv"
+    sv.write_text(src)
+    return elaborate([sv], top, frontend=Frontend.slang)
+
+
+def _cell_types(module) -> list[str]:
+    return sorted(c.type for c in module.cells.values())
+
+
+def _flops(module) -> list:
+    return [c for c in module.cells.values() if c.type in FLOP_TYPES]
+
+
+def _one_dff(module):
+    dffs = [c for c in module.cells.values() if c.type == "$dff"]
+    assert len(dffs) == 1, (
+        f"expected one $dff; got {[c.type for c in module.cells.values()]}"
+    )
+    return dffs[0]
+
+
+def _build_drivers(module) -> dict:
+    """Map each int bit-id to the (cell_name, port) that drives it via
+    a ``Q`` / ``Y`` output pin."""
+    drv: dict = {}
+    for name, cell in module.cells.items():
+        for port, bits in cell.connections.items():
+            if port in ("Q", "Y"):
+                for b in bits:
+                    if isinstance(b, int):
+                        drv[b] = (name, port)
+    return drv
+
+
+# --- always_comb if/else procedural-mux merge -----------------------------
+
+
+def test_comb_if_else_both_arms_emit_mux(tmp_path: Path) -> None:
+    """``always_comb if (sel) y = a; else y = b;`` — both arms write
+    ``y`` with *different* values, so the merge in
+    :meth:`_walk_conditional_statement` must emit a ``$mux`` whose A is
+    the false arm (b), B is the true arm (a), and S is the selector."""
+    src = """
+    module m (input logic sel, a, b, output logic y);
+        always_comb begin
+            if (sel) y = a;
+            else     y = b;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    muxes = [c for c in mod.cells.values() if c.type == "$mux"]
+    assert len(muxes) == 1, (
+        f"expected one $mux for the merged branches; got {_cell_types(mod)}"
+    )
+    mux = muxes[0]
+    a_bit = mod.ports["a"].bits[0]
+    b_bit = mod.ports["b"].bits[0]
+    sel_bit = mod.ports["sel"].bits[0]
+    # Yosys $mux: A selected when S=0 (false arm), B when S=1 (true arm).
+    assert mux.connections["A"] == (b_bit,), (
+        f"$mux A (sel=0) should be the else-arm value b; got {mux.connections['A']}"
+    )
+    assert mux.connections["B"] == (a_bit,), (
+        f"$mux B (sel=1) should be the if-arm value a; got {mux.connections['B']}"
+    )
+    assert mux.connections["S"] == (sel_bit,)
+
+
+def test_comb_if_else_same_value_both_arms_no_mux(tmp_path: Path) -> None:
+    """When both arms assign the *same* bits (``if (sel) y = a; else y =
+    a;``) the merge takes the ``t == f`` short-circuit: no ``$mux`` is
+    emitted and the destination flop reads ``a`` directly."""
+    src = """
+    module m (input logic clk, sel, a, output logic q);
+        logic y;
+        always_comb begin
+            if (sel) y = a;
+            else     y = a;
+        end
+        always_ff @(posedge clk) q <= y;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$mux" not in _cell_types(mod), (
+        f"identical both-arm values must not emit a $mux; got {_cell_types(mod)}"
+    )
+    a_bit = mod.ports["a"].bits[0]
+    assert _one_dff(mod).connections["D"] == (a_bit,), (
+        "destination flop should read a directly (no mux) when both arms agree"
+    )
+
+
+def test_comb_if_only_true_branch_keeps_single_branch_alias(tmp_path: Path) -> None:
+    """``y = b; if (sel) y = a;`` — only the true branch rewrites ``y``
+    relative to its prior value, so :meth:`_walk_conditional_statement`
+    keeps the single-branch aliasing (issue #36): no mux, the flop reads
+    the true-arm value ``a``."""
+    src = """
+    module m (input logic clk, sel, a, b, output logic q);
+        logic y;
+        always_comb begin
+            y = b;
+            if (sel) y = a;
+        end
+        always_ff @(posedge clk) q <= y;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$mux" not in _cell_types(mod), (
+        f"single written branch must not emit a $mux; got {_cell_types(mod)}"
+    )
+    a_bit = mod.ports["a"].bits[0]
+    assert _one_dff(mod).connections["D"] == (a_bit,), (
+        "with only the true arm rewriting y, the flop should read a"
+    )
+
+
+def test_comb_if_only_false_branch_keeps_single_branch_alias(tmp_path: Path) -> None:
+    """Mirror of the above for the ``f_changed`` leg: ``y = b; if (sel)
+    ; else y = a;`` rewrites ``y`` only on the else side, so the flop
+    reads ``a`` with no mux emitted."""
+    src = """
+    module m (input logic clk, sel, a, b, output logic q);
+        logic y;
+        always_comb begin
+            y = b;
+            if (sel) ;
+            else     y = a;
+        end
+        always_ff @(posedge clk) q <= y;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$mux" not in _cell_types(mod), (
+        f"single written (else) branch must not emit a $mux; got {_cell_types(mod)}"
+    )
+    a_bit = mod.ports["a"].bits[0]
+    assert _one_dff(mod).connections["D"] == (a_bit,)
+
+
+# --- always_comb case -> chained $mux -------------------------------------
+
+
+def test_comb_case_builds_chained_mux_with_eq_selectors(tmp_path: Path) -> None:
+    """``always_comb case (sel) 0: y=a; 1: y=b; default: y=c;`` —
+    :meth:`_walk_case_statement` must build a chained ``$mux`` per LHS
+    with ``$eq`` selectors comparing ``sel`` against each arm constant.
+    Two non-default arms → two ``$mux`` cells, two ``$eq`` cells."""
+    src = """
+    module m (input logic [1:0] sel, input logic a, b, c, output logic y);
+        always_comb begin
+            case (sel)
+                2'd0:    y = a;
+                2'd1:    y = b;
+                default: y = c;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert types.count("$mux") == 2, (
+        f"two non-default arms should yield two chained $mux cells; got {types}"
+    )
+    assert types.count("$eq") == 2, (
+        f"each arm constant should drive an $eq against sel; got {types}"
+    )
+    # The selector of each $eq must read the case expression (sel).
+    sel_bits = set(mod.ports["sel"].bits)
+    eqs = [c for c in mod.cells.values() if c.type == "$eq"]
+    for eq in eqs:
+        a_in = set(b for b in eq.connections.get("A", ()) if isinstance(b, int))
+        assert a_in & sel_bits, (
+            f"$eq A operand should be the case expression sel; got {eq.connections['A']}"
+        )
+    # The outermost mux's data inputs must all reach a / b / c so no arm
+    # value got dropped.
+    drivers = _build_drivers(mod)
+    muxes = [c for c in mod.cells.values() if c.type == "$mux"]
+
+    def reaches(start: int) -> set:
+        seen: set = set()
+        frontier = [start]
+        while frontier:
+            x = frontier.pop()
+            if x in seen or not isinstance(x, int):
+                continue
+            seen.add(x)
+            d = drivers.get(x)
+            if d is None:
+                continue
+            for port, bits in mod.cells[d[0]].connections.items():
+                if port in ("Q", "Y"):
+                    continue
+                frontier.extend(bits)
+        return seen
+
+    # Find the outermost mux (the one not feeding another mux's A/B data).
+    inner_mux_outputs = set()
+    for mux in muxes:
+        for port in ("A", "B"):
+            inner_mux_outputs |= set(mux.connections[port])
+    outer = next(m_ for m_ in muxes if not set(m_.connections["Y"]) & inner_mux_outputs)
+    reachable = reaches(outer.connections["Y"][0])
+    for label, port in (("a", "a"), ("b", "b"), ("c", "c")):
+        bit = mod.ports[port].bits[0]
+        assert bit in reachable, (
+            f"arm value {label} should remain reachable from the mux chain; "
+            f"reachable={sorted(b for b in reachable if isinstance(b, int))}"
+        )
+
+
+def test_comb_case_single_writer_per_lhs_keeps_single_arm_alias(tmp_path: Path) -> None:
+    """When each LHS is written in exactly one arm (no pre-case default,
+    empty ``default``), :meth:`_walk_case_statement` takes the
+    ``total_writers == 1`` single-arm-aliasing leg: no ``$mux`` and no
+    ``$eq`` selector is emitted — the var simply aliases to that arm's
+    value."""
+    src = """
+    module m (
+        input  logic       clk,
+        input  logic [1:0] sel,
+        input  logic       a, b,
+        output logic       q1, q2
+    );
+        logic y1, y2;
+        always_comb begin
+            case (sel)
+                2'd0:    y1 = a;
+                2'd1:    y2 = b;
+                default: ;
+            endcase
+        end
+        always_ff @(posedge clk) begin q1 <= y1; q2 <= y2; end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$mux" not in types and "$eq" not in types, (
+        f"single-writer-per-LHS arms must not synthesise mux/eq gating; got {types}"
+    )
+    by_name = sorted(_flops(mod), key=lambda c: c.name)
+    assert len(by_name) == 2
+    assert by_name[0].connections["D"] == (mod.ports["a"].bits[0],), (
+        "y1 (written only in arm 0) should alias to a"
+    )
+    assert by_name[1].connections["D"] == (mod.ports["b"].bits[0],), (
+        "y2 (written only in arm 1) should alias to b"
+    )
+
+
+def test_comb_case_multilabel_item_ors_equalities(tmp_path: Path) -> None:
+    """``2'd0, 2'd1: y = a;`` — a multi-label item's selector is the OR
+    of per-label ``$eq`` cells (:meth:`_lower_case_arm_selector`). The
+    mux's S must be driven by a ``$or`` whose two inputs are ``$eq``
+    cells."""
+    src = """
+    module m (input logic [1:0] sel, input logic a, c, output logic y);
+        always_comb begin
+            case (sel)
+                2'd0, 2'd1: y = a;
+                default:    y = c;
+            endcase
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$or" in types, (
+        f"multi-label item selector should OR the per-label equalities; got {types}"
+    )
+    assert types.count("$eq") == 2, f"two labels → two $eq cells; got {types}"
+    drivers = _build_drivers(mod)
+    or_cell = next(c for c in mod.cells.values() if c.type == "$or")
+    for port in ("A", "B"):
+        src_drv = drivers.get(or_cell.connections[port][0])
+        assert src_drv is not None and mod.cells[src_drv[0]].type == "$eq", (
+            f"$or input {port} should be driven by an $eq (per-label match)"
+        )
+
+
+# --- indexed-assign one-hot decoder (CDC-019 shape) -----------------------
+
+
+def test_indexed_assign_onehot_emits_shift(tmp_path: Path) -> None:
+    """``oh = '0; oh[idx] = 1'b1;`` — :meth:`_alias_indexed_assign`
+    models ``oh = oh | (1 << idx)``, emitting a ``$shl`` whose B is the
+    index and (because the prior alias is not the literal zero constant)
+    an ``$or`` folding the shift onto the previous bits."""
+    src = """
+    module m (input logic [1:0] idx, output logic [3:0] oh);
+        always_comb begin
+            oh = '0;
+            oh[idx] = 1'b1;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    types = _cell_types(mod)
+    assert "$shl" in types, (
+        f"one-hot ``oh[idx] = 1`` should emit a $shl (1 << idx); got {types}"
+    )
+    shl = next(c for c in mod.cells.values() if c.type == "$shl")
+    idx_bits = mod.ports["idx"].bits
+    assert tuple(shl.connections["B"]) == tuple(idx_bits), (
+        f"$shl B should be the index bits {idx_bits}; got {shl.connections['B']}"
+    )
+    # The $shl Y must be 4 bits wide (matches oh width) so each of the 4
+    # one-hot positions has its own output bit.
+    assert len(shl.connections["Y"]) == 4, (
+        f"$shl Y width must match oh width (4); got {len(shl.connections['Y'])}"
+    )
+    assert "$or" in types, (
+        f"non-constant prior alias takes the ``base | shl`` OR path; got {types}"
+    )
+    or_cell = next(c for c in mod.cells.values() if c.type == "$or")
+    assert set(shl.connections["Y"]).issubset(set(or_cell.connections["B"])), (
+        "the $or B operand should be the $shl result"
+    )
+
+
+# --- RHS range-select -----------------------------------------------------
+
+
+def test_range_select_rhs_picks_contiguous_lsb_first_slice(tmp_path: Path) -> None:
+    """``q <= d[5:2]`` — :meth:`_range_select_bits` must return the
+    contiguous LSB-first slice ``d_bits[2:6]`` of the underlying
+    variable, wired straight onto the flop's D (no extra cell)."""
+    src = """
+    module m (input logic clk, input logic [7:0] d, output logic [3:0] q);
+        always_ff @(posedge clk) q <= d[5:2];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    ff = _flops(mod)
+    assert len(ff) == 1
+    d_bits = mod.netnames["d"].bits
+    assert ff[0].connections["D"] == tuple(d_bits[2:6]), (
+        f"d[5:2] should slice d_bits[2:6] LSB-first; got {ff[0].connections['D']} "
+        f"vs expected {tuple(d_bits[2:6])}"
+    )
+
+
+# --- arithmetic / shift / division / reduction operator lowering ----------
+
+
+@pytest.mark.parametrize(
+    "op,expected_cell",
+    [
+        ("+", "$add"),
+        ("-", "$sub"),
+        ("*", "$mul"),
+        ("/", "$div"),
+        ("%", "$mod"),
+    ],
+)
+def test_arithmetic_binary_ops_lower_to_expected_cell(
+    tmp_path: Path, op: str, expected_cell: str
+) -> None:
+    """Each arithmetic ``BinaryOperator`` must lower to its Yosys cell
+    so the rule pack treats the operator as a transit node rather than
+    an opaque ``$_UNKNOWN_`` driver."""
+    src = f"""
+    module m (input logic [3:0] a, b, output logic [3:0] y);
+        assign y = a {op} b;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert expected_cell in _cell_types(mod), (
+        f"op {op!r} should lower to {expected_cell}; got {_cell_types(mod)}"
+    )
+
+
+def test_unary_plus_is_identity_no_cell(tmp_path: Path) -> None:
+    """``+a`` is the SV identity unary; :meth:`_lower_unary` peeks
+    through it (no ``$pos`` cell). The destination flop must read ``a``'s
+    bits directly."""
+    src = """
+    module m (input logic clk, input logic [3:0] a, output logic [3:0] q);
+        always_ff @(posedge clk) q <= +a;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    ff = _flops(mod)
+    assert len(ff) == 1
+    a_bits = mod.netnames["a"].bits
+    assert ff[0].connections["D"] == tuple(a_bits), (
+        f"unary plus should pass a through unchanged; got D={ff[0].connections['D']} "
+        f"a={a_bits}"
+    )
+    assert "$pos" not in _cell_types(mod), "unary plus must not emit a cell"
+
+
+def test_continuous_assign_unmodelled_rhs_emits_no_cell(tmp_path: Path) -> None:
+    """``assign y = f(a);`` where the RHS isn't modelled —
+    :meth:`_emit_continuous_assign` bails when ``_bits_of_expression``
+    returns ``None`` (the comb-driven-port leg), so no aliasing happens
+    and no cell is emitted for the assign."""
+    src = """
+    module m (input logic [3:0] a, output logic [3:0] y);
+        function automatic logic [3:0] f(input logic [3:0] x);
+            return x + 1;
+        endfunction
+        assign y = f(a);
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert _cell_types(mod) == [], (
+        f"an unmodelled continuous-assign RHS should emit no cell; got {_cell_types(mod)}"
+    )
+
+
+def test_arithmetic_shift_left_emits_sshl(tmp_path: Path) -> None:
+    """``a <<< 1`` on a signed operand must emit ``$sshl`` — the
+    arithmetic-shift family is *not* constant-folded (only the logical
+    ``$shl`` / ``$shr`` fold to wire-routing), so the cell survives."""
+    src = """
+    module m (input logic clk, input logic signed [3:0] a, output logic signed [3:0] q);
+        always_ff @(posedge clk) q <= a <<< 1;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$sshl" in _cell_types(mod), (
+        f"arithmetic shift-left should emit $sshl (not folded); got {_cell_types(mod)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "op,expected_cell",
+    [
+        ("&", "$reduce_and"),
+        ("~&", "$reduce_and"),
+        ("|", "$reduce_or"),
+        ("~|", "$reduce_or"),
+        ("^", "$reduce_xor"),
+        ("~^", "$reduce_xor"),
+    ],
+)
+def test_reduction_unary_ops_lower_and_collapse_to_one_bit(
+    tmp_path: Path, op: str, expected_cell: str
+) -> None:
+    """Each reduction ``UnaryOperator`` collapses its multi-bit operand
+    to a single-bit ``$reduce_*`` cell. ``~&`` / ``~|`` / ``~^`` share a
+    cell with their non-inverting form (the rule pack only reads
+    category membership), and the Y width is exactly 1."""
+    src = f"""
+    module m (input logic [3:0] a, output logic y);
+        assign y = {op}a;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    reduces = [c for c in mod.cells.values() if c.type == expected_cell]
+    assert reduces, (
+        f"reduction {op!r} should lower to {expected_cell}; got {_cell_types(mod)}"
+    )
+    assert len(reduces[0].connections["Y"]) == 1, (
+        f"reduction output must be a single bit; got {reduces[0].connections['Y']}"
+    )
+    assert len(reduces[0].connections["A"]) == 4, (
+        f"reduction A should be the full 4-bit operand; got {reduces[0].connections['A']}"
+    )
+
+
+# --- _const_int folding ---------------------------------------------------
+
+
+def test_procedural_multiply_index_folds_to_distinct_stripes(tmp_path: Path) -> None:
+    """``mem[i*2]`` inside an unrolled for-loop exercises the ``Multiply``
+    arm of :meth:`_const_int` (pyslang leaves ``i*2`` unfolded because
+    ``i`` is a loop variable). Two iterations must land on the
+    non-overlapping ``mem[0]`` and ``mem[2]`` stripes."""
+    src = """
+    module m #(parameter int STAGES = 2) (
+        input  logic clk,
+        input  logic [3:0] d0, d1,
+        output logic [3:0] q
+    );
+        logic [3:0] mem [4];
+        always_ff @(posedge clk) begin
+            mem[0*2] <= d0;
+            for (int i = 1; i < STAGES; i++)
+                mem[i*2] <= d1;
+        end
+        assign q = mem[0];
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    flops = _flops(mod)
+    assert len(flops) == 2, f"expected two flops (mem[0] and mem[2]); got {len(flops)}"
+    q_sets = [set(f.connections["Q"]) for f in flops]
+    assert q_sets[0].isdisjoint(q_sets[1]), (
+        f"mem[0] and mem[i*2]=mem[2] must occupy disjoint stripes; "
+        f"got {q_sets} (collapse implies the *2 stride folded wrong)"
+    )
+
+
+def test_parameter_replication_count_folds(tmp_path: Path) -> None:
+    """``{N{x}}`` with ``N`` a parameter exercises the ``ParameterSymbol``
+    arm of :meth:`_const_int` (used as the replication count). With
+    ``N=3`` the result must be ``x`` repeated three times."""
+    src = """
+    module m #(parameter int N = 3) (input logic x, output logic [2:0] y);
+        assign y = {N{x}};
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    x_bit = mod.netnames["x"].bits[0]
+    assert mod.ports["y"].bits == (x_bit, x_bit, x_bit), (
+        f"{{N{{x}}}} with N=3 should repeat x three times; got {mod.ports['y'].bits}"
+    )
+
+
+# --- conservative fall-throughs -------------------------------------------
+
+
+def test_unmodelled_rhs_becomes_unknown_driver(tmp_path: Path) -> None:
+    """A function-call RHS isn't modelled by ``_bits_of_expression``, so
+    the flop's D must be driven by a fresh ``$_UNKNOWN_`` cell — the
+    driver exists (so the rule pack's lookup finds *something*) but its
+    type stops the data-cone walk, and the real source ``d`` does not
+    reach D."""
+    src = """
+    module m (input logic clk, input logic [3:0] d, output logic [3:0] q);
+        function automatic logic [3:0] f(input logic [3:0] x);
+            return x + 1;
+        endfunction
+        always_ff @(posedge clk) q <= f(d);
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    unknowns = [c for c in mod.cells.values() if c.type == "$_UNKNOWN_"]
+    assert len(unknowns) == 1, (
+        f"unmodelled RHS should emit one $_UNKNOWN_ driver; got {_cell_types(mod)}"
+    )
+    ff = _flops(mod)
+    assert len(ff) == 1
+    assert tuple(ff[0].connections["D"]) == tuple(unknowns[0].connections["Y"]), (
+        "the flop's D must be wired to the $_UNKNOWN_ driver's Y"
+    )
+    d_bits = set(mod.netnames["d"].bits)
+    assert d_bits.isdisjoint(set(ff[0].connections["D"])), (
+        "the real source d must NOT reach D through the opaque $_UNKNOWN_ stub"
+    )
+
+
+def test_multibit_latch_enable_drops_latch(tmp_path: Path) -> None:
+    """A multi-bit ``always_latch`` enable can't lower to a single mux
+    select (``_lower_condition_to_bit`` bails on width != 1), so the
+    latch is conservatively dropped — no ``$dlatch`` emitted."""
+    src = """
+    module m (input logic [1:0] en, input logic d, output logic q);
+        always_latch begin
+            if (en) q = d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$dlatch" not in _cell_types(mod), (
+        f"a multi-bit latch enable can't be lowered; latch should drop. got {_cell_types(mod)}"
+    )
+
+
+def test_nonblocking_latch_body_drops_latch(tmp_path: Path) -> None:
+    """A non-blocking write inside ``always_latch`` is a style violation;
+    :meth:`_walk_latch_statement` bails rather than model it, so no
+    ``$dlatch`` is emitted."""
+    src = """
+    module m (input logic en, d, output logic q);
+        always_latch begin
+            if (en) q <= d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$dlatch" not in _cell_types(mod), (
+        f"non-blocking latch body must drop the latch; got {_cell_types(mod)}"
+    )
+
+
+def test_no_conditional_latch_body_drops_latch(tmp_path: Path) -> None:
+    """An ``always_latch`` body with no ``if`` (a bare ``q = d;``) isn't
+    the single-arm-implicit-hold shape, so the walker returns without
+    emitting a ``$dlatch``."""
+    src = """
+    module m (input logic d, output logic q);
+        always_latch begin
+            q = d;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$dlatch" not in _cell_types(mod), (
+        f"latch body with no if-guard isn't a clean $dlatch shape; got {_cell_types(mod)}"
+    )
+
+
+def test_multistatement_latch_arm_drops_latch(tmp_path: Path) -> None:
+    """``if (en) begin q = a; r = b; end`` — the ifTrue arm is a multi-
+    statement block, not a single ``ExpressionStatement``, so
+    :meth:`_walk_latch_statement` bails and emits no ``$dlatch``."""
+    src = """
+    module m (input logic en, a, b, output logic q, r);
+        always_latch begin
+            if (en) begin q = a; r = b; end
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$dlatch" not in _cell_types(mod), (
+        f"multi-statement latch arm isn't the single-arm shape; got {_cell_types(mod)}"
+    )
+
+
+def test_latch_with_else_still_emits_single_dlatch(tmp_path: Path) -> None:
+    """``if (en) q = a; else q = b;`` — the explicit ``else`` is ignored
+    (it would break single-arm implicit-hold semantics), but the ifTrue
+    arm still produces exactly one ``$dlatch`` whose D reads ``a``."""
+    src = """
+    module m (input logic en, a, b, output logic q);
+        always_latch begin
+            if (en) q = a;
+            else    q = b;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    latches = [c for c in mod.cells.values() if c.type == "$dlatch"]
+    assert len(latches) == 1, (
+        f"latch-with-else should still emit one $dlatch from the ifTrue arm; "
+        f"got {_cell_types(mod)}"
+    )
+    a_bit = mod.ports["a"].bits[0]
+    assert latches[0].connections["D"] == (a_bit,), (
+        f"the $dlatch D should read the ifTrue value a (else ignored); "
+        f"got {latches[0].connections['D']}"
+    )
+
+
+def test_nonblocking_assign_in_always_comb_is_ignored(tmp_path: Path) -> None:
+    """A non-blocking ``y <= a`` inside ``always_comb`` is a style
+    violation; :meth:`_alias_assign` bails on it, so ``y`` keeps its own
+    fresh bits and the downstream flop does NOT alias through to ``a``."""
+    src = """
+    module m (input logic clk, a, output logic q);
+        logic y;
+        always_comb begin
+            y <= a;
+        end
+        always_ff @(posedge clk) q <= y;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    a_bit = mod.ports["a"].bits[0]
+    ff = _one_dff(mod)
+    assert ff.connections["D"] != (a_bit,), (
+        "a non-blocking write in always_comb must NOT alias y onto a; "
+        f"got D={ff.connections['D']} a={a_bit}"
+    )
+
+
+def test_comb_if_with_unlowerable_selector_descends_without_mux(tmp_path: Path) -> None:
+    """When the ``if`` condition can't be lowered to bits (a function
+    call here), :meth:`_walk_conditional_statement` takes the
+    conservative-descend leg: it walks both arms unconditionally and
+    emits **no** ``$mux``. Contrast :func:`test_comb_if_else_both_arms_emit_mux`,
+    where a lowerable selector *does* produce a mux — the only
+    difference is whether the selector lowered."""
+    src = """
+    module m (input logic clk, input logic [3:0] a, b, output logic [3:0] q);
+        logic [3:0] y;
+        function automatic logic g(input logic [3:0] x); return ^x; endfunction
+        always_comb begin
+            if (g(a)) y = a;
+            else      y = b;
+        end
+        always_ff @(posedge clk) q <= y;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    assert "$mux" not in _cell_types(mod), (
+        "an unlowerable if-selector must skip the mux merge and descend "
+        f"conservatively; got {_cell_types(mod)}"
+    )
+
+
+def test_latch_body_with_two_if_arms_emits_two_dlatches(tmp_path: Path) -> None:
+    """An ``always_latch`` body holding two sibling ``if`` statements is
+    a ``StatementList``; :meth:`_walk_latch_statement` recurses over the
+    list and emits one ``$dlatch`` per single-arm guarded write."""
+    src = """
+    module m (input logic en1, en2, a, b, output logic q, r);
+        always_latch begin
+            if (en1) q = a;
+            if (en2) r = b;
+        end
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    latches = [c for c in mod.cells.values() if c.type == "$dlatch"]
+    assert len(latches) == 2, (
+        f"two guarded writes in a latch body should emit two $dlatch cells; "
+        f"got {_cell_types(mod)}"
+    )
+    # Each latch's D should read its own source (a / b respectively).
+    d_sources = {latches[0].connections["D"], latches[1].connections["D"]}
+    assert {(mod.ports["a"].bits[0],), (mod.ports["b"].bits[0],)} == d_sources, (
+        f"the two latches should read a and b on their D pins; got {d_sources}"
+    )
+
+
+def test_rangeselect_lhs_in_always_comb_is_not_aliased(tmp_path: Path) -> None:
+    """An ``always_comb`` blocking assign whose LHS is a range-select
+    (``y[3:0] = d``) isn't a bare ``NamedValueExpression`` nor an
+    element-select, so :meth:`_alias_assign` ignores it — ``y`` is not
+    rewritten to ``d`` and the downstream flop reads ``y``'s own bits."""
+    src = """
+    module m (input logic clk, input logic [3:0] d, output logic [3:0] q);
+        logic [3:0] y;
+        always_comb begin
+            y[3:0] = d;
+        end
+        always_ff @(posedge clk) q <= y;
+    endmodule
+    """
+    mod = _elaborate(tmp_path, src)
+    d_bits = set(mod.netnames["d"].bits)
+    ff = _flops(mod)
+    assert len(ff) == 1
+    assert d_bits.isdisjoint(set(ff[0].connections["D"])), (
+        "a range-select LHS in always_comb is not modelled, so d must NOT "
+        f"reach the flop D; got D={ff[0].connections['D']} d={sorted(d_bits)}"
+    )


### PR DESCRIPTION
## Summary

A per-module test sweep (`tests/test_cov_*.py`, 11 files, 375 tests) that lifts the CI coverage job from **84% → 93%** line+branch, then raises `--cov-fail-under` from 78 to **90** to lock the gain. **No `src/` changes** — analyzer, CLI surface, and JSON/SARIF contract are untouched.

## CI-valid by construction

The `pytest (with slang)` coverage job runs **without yosys / iverilog / xeno** (only the `[slang]` extra), so the `fuzz` / `sim` / `fuzz_grammar` selections skip there and contribute nothing. Every new test is therefore **yosys-free** and exercises `src/` via one of three paths that run in that job:

- committed Yosys-JSON fixtures → `netlist.load` + `find_crossings` + `run_all` (analyzer pack: `rules`, `domain`, `clock_network`, `pulse`, `reset_*`);
- pyslang elaboration via `elaborate(frontend=Frontend.slang)` (slang frontend lowering);
- `CliRunner` analyze/lint flows + monkeypatched `subprocess`/`shutil.which` for the yosys-frontend guard branches.

This was verified statically (no `yosys_available` / `run_case(` / real-binary calls in the new files) and by measuring coverage with the yosys-dependent selections deselected — the number reflects exactly what CI's job exercises.

## Per-module line+branch coverage (before → after)

| module | before → after | module | before → after |
| --- | --- | --- | --- |
| `__init__` | 67 → 100 | `pulse` | 73 → 100 |
| `cli` | 82 → 97 | `render` | 90 → 100 |
| `clock_network` | 73 → 98 | `reporter` | 86 → 96 |
| `domain` | 90 → 98 | `reset_domain` | 93 → 99 |
| `domain_map` | 86 → 100 | `reset_domain_map` | 86 → 94 |
| `flops` | 93 → 100 | `reset_hints` | 76 → 100 |
| `frontend` | 94 → 100 | `rules` | 86 → 90 |
| `frontends/slang` | 76 → 86 | `sdc` | 90 → 99 |
| `frontends/yosys` | 63 → 100 | `waivers` | 96 → 96 |
| `netlist` | 81 → 100 | **TOTAL** | **84 → 93** |

The remaining `slang.py` (86%) and `rules.py` (90%) misses are defensive guards / fall-through arms not reachable from valid SystemVerilog or well-formed netlists (documented per-file by the authoring pass); chasing them would require malformed-AST injection rather than meaningful behavioral assertions.

## Coverage-job gains the `[hints]` extra

So `reset_hints.py`'s YAML loader is exercised under coverage instead of skipping. The no-slang companion job keeps PyYAML absent and those tests skip there — verified: **1058 passed, 407 skipped, 0 failed**.

## Reviewability

Test-only and additive — each of the 11 files is self-contained and named by the module it covers, so review is per-file. Happy to split into themed PRs if you'd prefer.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` / `uv run mypy` clean
- [x] CI-equivalent (slang+hints, no yosys): **93%**, 937 passed — on both Python 3.13 and 3.11
- [x] Complete suite incl. fuzz/sim (yosys present): 1809 passed, 0 failed
- [x] No-slang companion job replicated: 1058 passed, 407 skipped, 0 failed
- [x] New files statically confirmed yosys-binary-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)