### PR TITLE
chore(fuzz): bump xeno pin to >=3.11 main, drop the py3.13 marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,12 @@ dev = [
 ]
 # Fuzz-corpus mutator dep (Stage-3 Layer B of rtl-buddy-cdc#221).
 # Only consumed under @pytest.mark.fuzz inside tests/fuzz/test_mutants.py;
-# the analyzer's runtime closure stays unchanged. xeno's
-# `requires-python = ">=3.13"` is mirrored here via the marker so the
-# py3.11 / py3.12 pytest-with-slang matrix entries don't try to resolve
-# it. Source pinned via [tool.uv.sources] to a content-addressed commit
-# until xeno reaches PyPI.
+# the analyzer's runtime closure stays unchanged. xeno relaxed its
+# floor to >=3.11 (rtl-buddy-xeno PR #17) to match this project, so the
+# fuzz dep no longer needs a Python marker — it now resolves on every
+# pytest-with-slang matrix entry (py3.11 / py3.12 / py3.13). Source
+# pinned via [tool.uv.sources] to a content-addressed commit until xeno
+# reaches PyPI.
 fuzz = [
     # ``[verible,slang]`` extras pull in xeno's verible-CST helpers and
     # pyslang elaborator — required for the three structural CDC
@@ -75,7 +76,7 @@ fuzz = [
     # and the ≥10-mutants-per-template target in
     # rtl-buddy-cdc#221 done-when criterion 4 misses on every gap
     # family whose source has few ``posedge``/``negedge`` sites.
-    "rtl-buddy-xeno[verible,slang] ; python_full_version >= '3.13'",
+    "rtl-buddy-xeno[verible,slang]",
 ]
 
 [tool.ruff]
@@ -126,11 +127,13 @@ exclude_also = [
 ]
 
 [tool.uv.sources]
-# Pinned to the v0.0.2 fix commit on rtl-buddy-xeno (xeno PR #12). That
-# commit corrects two CDC rule-id mis-mappings (CLOCK_POLARITY_SWAP
+# Pinned to rtl-buddy-xeno main. This commit relaxes requires-python to
+# >=3.11 (rtl-buddy-xeno PR #17) so this project's py3.11 / py3.12
+# entries can resolve it and the fuzz dep above drops its >=3.13 marker.
+# It still carries the CDC rule-id corrections (CLOCK_POLARITY_SWAP
 # CDC-006 → CDC-016; ATTRIBUTE_TOGGLE CDC-008 → CDC-010 for
-# glitchless_clock_mux) and skips reset-edge polarity tokens that
-# previously produced Yosys-rejected invalid SV. The downstream
-# prediction-accuracy metric in test_mutants.py climbs substantially
-# with this pin in place.
-rtl-buddy-xeno = { git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git", rev = "ecc1bdbb7a11abf33b0e6bea2bb7d844a241d0bb" }
+# glitchless_clock_mux) and the reset-edge skip that previously produced
+# Yosys-rejected invalid SV — so the prediction-accuracy metric in
+# test_mutants.py stays high. Content-addressed pin until xeno reaches
+# PyPI.
+rtl-buddy-xeno = { git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git", rev = "67f251f6d719f79f49f67aecab93093c85541ee7" }

--- a/uv.lock
+++ b/uv.lock
@@ -682,7 +682,7 @@ dev = [
     { name = "ruff" },
 ]
 fuzz = [
-    { name = "rtl-buddy-xeno", extra = ["slang", "verible"], marker = "python_full_version >= '3.13'" },
+    { name = "rtl-buddy-xeno", extra = ["slang", "verible"] },
 ]
 lint = [
     { name = "mypy" },
@@ -710,7 +710,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.11.0" },
 ]
-fuzz = [{ name = "rtl-buddy-xeno", extras = ["verible", "slang"], marker = "python_full_version >= '3.13'", git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git?rev=ecc1bdbb7a11abf33b0e6bea2bb7d844a241d0bb" }]
+fuzz = [{ name = "rtl-buddy-xeno", extras = ["verible", "slang"], git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git?rev=67f251f6d719f79f49f67aecab93093c85541ee7" }]
 lint = [
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "ruff", specifier = ">=0.11.0" },
@@ -726,21 +726,21 @@ name = "rtl-buddy-view"
 version = "0.2.0"
 source = { git = "https://github.com/rtl-buddy/rtl-buddy-view.git?tag=v0.2.0#1bef422ae73d49ab48201fa0cd80420c6c27016e" }
 dependencies = [
-    { name = "jsonschema", marker = "python_full_version >= '3.13'" },
-    { name = "typer", marker = "python_full_version >= '3.13'" },
+    { name = "jsonschema" },
+    { name = "typer" },
 ]
 
 [[package]]
 name = "rtl-buddy-xeno"
 version = "0.0.2"
-source = { git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git?rev=ecc1bdbb7a11abf33b0e6bea2bb7d844a241d0bb#ecc1bdbb7a11abf33b0e6bea2bb7d844a241d0bb" }
+source = { git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git?rev=67f251f6d719f79f49f67aecab93093c85541ee7#67f251f6d719f79f49f67aecab93093c85541ee7" }
 
 [package.optional-dependencies]
 slang = [
-    { name = "pyslang", marker = "python_full_version >= '3.13'" },
+    { name = "pyslang" },
 ]
 verible = [
-    { name = "rtl-buddy-view", marker = "python_full_version >= '3.13'" },
+    { name = "rtl-buddy-view" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The `fuzz` dependency group gated `rtl-buddy-xeno[verible,slang]` behind `python_full_version >= '3.13'`, mirroring xeno's old self-imposed floor. The consequence: the **py3.11 / py3.12** `pytest (with slang)` matrix entries skipped resolving xeno entirely, so on those interpreters only the two parser-free CDC operators (`CLOCK_POLARITY_SWAP`, `ATTRIBUTE_TOGGLE`) fired — the three Verible-backed structural operators emitted nothing, and the ≥10-mutants target ([rtl-buddy-cdc#221](https://github.com/rtl-buddy/rtl-buddy-cdc/issues/221) done-when 4) was only really exercised on py3.13.

xeno relaxed its floor to `>=3.11` in [rtl-buddy-xeno#17](https://github.com/rtl-buddy/rtl-buddy-xeno/pull/17) (CI matrix green on 3.11/3.12/3.13), so the marker is obsolete.

## What

- **Bump the xeno pin** `ecc1bdb` → `67f251f` (xeno `main`). This is required, not cosmetic: the old pin is the *pre-#17* commit and still declares `requires-python = ">=3.13"`, so dropping the marker against it would make py3.11/py3.12 unresolvable. `main` carries the `>=3.11` relax **and** the same CDC rule-id corrections the old pin had (CLOCK_POLARITY_SWAP CDC-006→CDC-016, ATTRIBUTE_TOGGLE CDC-008→CDC-010) plus the reset-edge skip, so the prediction-accuracy metric in `test_mutants.py` is unaffected.
- **Drop the `; python_full_version >= '3.13'` marker** on the fuzz dep.
- **Refresh the two now-stale comments** (the fuzz-group rationale and the `[tool.uv.sources]` pin note).
- **Regenerate `uv.lock`** — the `>=3.13` markers on `rtl-buddy-xeno` and its transitive `rtl-buddy-view` are gone; both now resolve unconditionally.

## Scope / verification

Test-only dependency group — no runtime closure, CLI, or JSON-schema change, so no version bump (per AGENTS.md release rules). `uv lock` resolves cleanly across the full `>=3.11` range, which confirms py3.11/py3.12 now pull xeno. The fuzz tests themselves (`@pytest.mark.fuzz`, need Verible + slang) are validated by this repo's CI matrix — that's the point of the change: they now run xeno-backed on all three Pythons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
