### PR TITLE
docs(fuzz): drop stale "xeno is py3.13-only" comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,10 +121,12 @@ jobs:
 
       - name: Install test + fuzz + slang dependencies
         # The fuzz group pulls in rtl-buddy-xeno (Stage-3 Layer B,
-        # rtl-buddy-cdc#221); it's py3.13-only by its own
-        # ``requires-python``, matched to this job's --python 3.13.
-        # The [slang] extra is needed for the cross-frontend
-        # differential oracle (Stage-3 Layer C).
+        # rtl-buddy-cdc#221). xeno is >=3.11 since rtl-buddy-xeno PR #17,
+        # so it resolves on any Python this project supports; this job
+        # runs the fuzz/sim suites on a single interpreter (3.13) by
+        # choice — the mutation operators are pure Python, not
+        # version-sensitive. The [slang] extra is needed for the
+        # cross-frontend differential oracle (Stage-3 Layer C).
         run: uv sync --extra slang --group test --group fuzz --python 3.13
 
       - name: Run fuzz suite

--- a/tests/fuzz/_mutator.py
+++ b/tests/fuzz/_mutator.py
@@ -69,10 +69,10 @@ _CDC_KINDS: tuple[str, ...] = (
 def xeno_available() -> bool:
     """``True`` when :mod:`rtl_buddy_xeno` is importable.
 
-    The fuzz dependency group pins xeno via a GitHub git source under
-    a ``python_version >= '3.13'`` marker; on the py3.11 / py3.12 CI
-    matrix entries xeno simply isn't installed and the mutant tests
-    skip — same pattern :mod:`tests.fuzz.slang_cache` uses.
+    The fuzz dependency group pins xeno via a GitHub git source. Jobs
+    that don't install that group (the matrix ``pytest (with slang)``
+    entries) leave xeno absent and the mutant tests skip — same pattern
+    :mod:`tests.fuzz.slang_cache` uses.
     """
     try:
         importlib.import_module("rtl_buddy_xeno")

--- a/tests/fuzz/test_mutants.py
+++ b/tests/fuzz/test_mutants.py
@@ -91,7 +91,7 @@ pytestmark = [
     pytest.mark.skipif(not yosys_available(), reason="yosys not on PATH"),
     pytest.mark.skipif(
         not xeno_available(),
-        reason="rtl-buddy-xeno not importable (needs python>=3.13 + the fuzz dep group)",
+        reason="rtl-buddy-xeno not importable (install the fuzz dep group)",
     ),
 ]
 


### PR DESCRIPTION
Comment/string-only cleanup. After `rtl-buddy-xeno` relaxed its floor to `>=3.11` ([rtl-buddy-xeno#17](https://github.com/rtl-buddy/rtl-buddy-xeno/pull/17)) and #241 dropped the fuzz group's `python_full_version >= '3.13'` marker + bumped the pin to xeno main, three places still asserted xeno is "py3.13-only":

- **`.github/workflows/test.yml`** (fuzz-and-sim install step) — *"py3.13-only by its own `requires-python`, matched to this job's --python 3.13"*. Refreshed to: xeno resolves on any supported Python; this job runs the fuzz/sim suites on a single interpreter (3.13) **by choice** (the operators are pure Python, not version-sensitive).
- **`tests/fuzz/test_mutants.py`** skip reason — *"needs python>=3.13 + the fuzz dep group"* → *"install the fuzz dep group"*.
- **`tests/fuzz/_mutator.py`** `xeno_available()` docstring — dropped the *">=3.13 marker / py3.11-py3.12 skip"* rationale (the marker no longer exists).

No behavior change. The fuzz/mut tests still execute in the dedicated py3.13 `fuzz + sim oracle` job (verified running: 93 mutant cases, 0 skipped, on the latest main) — this just describes that accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)