### PR TITLE
chore(deps): re-lock fuzz xeno so rtl-buddy-view resolves from PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,8 @@ exclude_also = [
 # CDC-006 → CDC-016; ATTRIBUTE_TOGGLE CDC-008 → CDC-010 for
 # glitchless_clock_mux) and the reset-edge skip that previously produced
 # Yosys-rejected invalid SV — so the prediction-accuracy metric in
-# test_mutants.py stays high. Content-addressed pin until xeno reaches
-# PyPI.
-rtl-buddy-xeno = { git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git", rev = "67f251f6d719f79f49f67aecab93093c85541ee7" }
+# test_mutants.py stays high. xeno is on PyPI now (0.1.0) but we stay on
+# git main for these post-0.1.0 corrections; bumping to this rev (post
+# xeno #24) also resolves the transitive rtl-buddy-view from PyPI 0.2.1
+# instead of the stale v0.2.0 git tag.
+rtl-buddy-xeno = { git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git", rev = "6549e36519686fbc27723495c5abb7a20369b5fe" }

--- a/uv.lock
+++ b/uv.lock
@@ -710,7 +710,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.11.0" },
 ]
-fuzz = [{ name = "rtl-buddy-xeno", extras = ["verible", "slang"], git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git?rev=67f251f6d719f79f49f67aecab93093c85541ee7" }]
+fuzz = [{ name = "rtl-buddy-xeno", extras = ["verible", "slang"], git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git?rev=6549e36519686fbc27723495c5abb7a20369b5fe" }]
 lint = [
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "ruff", specifier = ">=0.11.0" },
@@ -723,17 +723,20 @@ test = [
 
 [[package]]
 name = "rtl-buddy-view"
-version = "0.2.0"
-source = { git = "https://github.com/rtl-buddy/rtl-buddy-view.git?tag=v0.2.0#1bef422ae73d49ab48201fa0cd80420c6c27016e" }
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
     { name = "typer" },
 ]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/6a/28d289eb41185e835eae30f9d9c91d92cc89070eba5a126835229f6703fc/rtl_buddy_view-0.2.1-py3-none-any.whl", hash = "sha256:4db09ec7fbb2a0ae42e19c715ac36f62e9e99f8d7fd062007192c6fc506543bb", size = 727285, upload-time = "2026-06-05T06:26:50.418Z" },
+]
 
 [[package]]
 name = "rtl-buddy-xeno"
-version = "0.0.2"
-source = { git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git?rev=67f251f6d719f79f49f67aecab93093c85541ee7#67f251f6d719f79f49f67aecab93093c85541ee7" }
+version = "0.1.1.dev1+g6549e3651"
+source = { git = "https://github.com/rtl-buddy/rtl-buddy-xeno.git?rev=6549e36519686fbc27723495c5abb7a20369b5fe#6549e36519686fbc27723495c5abb7a20369b5fe" }
 
 [package.optional-dependencies]
 slang = [


### PR DESCRIPTION
## What

Part of the ecosystem-wide move off the stale `rtl-buddy-view` git build. rtl-buddy-cdc has no direct view dependency — view enters only transitively through the `fuzz` group's git-pinned `rtl-buddy-xeno[verible,slang]`. The committed `uv.lock` captured **view 0.2.0 from the `v0.2.0` git tag** (no SPA bundle, the v0.2.0 filelist `IsADirectoryError` bug).

Bump the content-addressed xeno rev `67f251f` → `6549e36` (post xeno #24, which dropped view's own `v0.2.0`-tag source). After re-locking, **`rtl-buddy-view` now resolves from PyPI `0.2.1`**:

```
Updated rtl-buddy-view v0.2.0 (1bef422a) -> v0.2.1   (git tag -> PyPI registry)
Updated rtl-buddy-xeno  v0.0.2 (67f251f6) -> v0.1.1.dev1+g6549e3651
```

`pyproject.toml` (the single `[tool.uv.sources]` rev line + its comment) and `uv.lock` only — no API/cap/guard work applies here (cdc declares no view cap of its own). Staying on xeno **git main** (rather than PyPI 0.1.0) is deliberate: the fuzz prediction-accuracy metric needs the post-0.1.0 CDC rule-id corrections.

`uv lock --check` passes. The `fuzz` group's mutant tests run in CI (need slang + verible + yosys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
