### PR TITLE
feat(cli): --yosys-plugin falls back to RTL_BUDDY_SLANG_PLUGIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+<<<<<<< HEAD
 - **`(* cdc_handshake *)` attribute — sanctioned four-phase req/ack
   handshake** (#247). A correct req/ack vector-CDC primitive (the
   `ip_cdc_handshake` shape) trips four rules on its protected paths —
@@ -37,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checkout no longer raises `FileNotFoundError`), and a
   `--yosys-plugin` not-found error now reports the resolved absolute
   path so it's actionable.
+
+- **`--yosys-plugin` reads `RTL_BUDDY_SLANG_PLUGIN`**. The
+  `lint --yosys-plugin` flag now falls back to the
+  `RTL_BUDDY_SLANG_PLUGIN` environment variable when omitted (an
+  explicit flag still wins). This lets the yosys-slang plugin
+  location be a machine-local value instead of a hard-coded path:
+  `rtl_buddy` already loads `.rtl-buddy/.env` into the environment
+  before invoking `rtl-buddy-cdc`, so a config can simply drop the
+  `--yosys-plugin` extra-arg and let the `.env` flow supply it.
+  Mirrors `rtl_buddy`'s own slang `plugin-path` resolution.
 
 - **CDC-021: flop CLK driven by undeclared port** (#206). Closes
   G-10 from the #188 coverage survey. Companion to CDC-011 on the

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Standalone wrapper (`lint`):
 | Top module name (`--top`) | yes | Elaboration root |
 | `--frontend {yosys,slang,auto}` | optional | Elaboration frontend. `yosys` (default) shells out to `yosys` and runs `hierarchy; proc; flatten; opt_clean`. `slang` elaborates via the [pyslang](https://pypi.org/project/pyslang/) binding directly — no synth step, no Yosys runtime dependency. `auto` picks `slang` when pyslang is importable and falls back to `yosys` otherwise; useful in CI matrices where some jobs install the `[slang]` extra and others don't. Reaches parity with the Yosys frontend on every paired *bad/good* fixture in the regression suite. |
 | `--yosys PATH` | optional | Yosys frontend only: override the default yosys binary lookup |
+| `--yosys-plugin PATH` | optional | Yosys frontend only: load a Yosys plugin (e.g. yosys-slang's `slang.so`) and elaborate via `read_slang` for full SystemVerilog-2017 support. Falls back to the `RTL_BUDDY_SLANG_PLUGIN` environment variable when the flag is omitted; the explicit flag wins. This is the machine-local `.env` flow `rtl_buddy` populates from `.rtl-buddy/.env`. |
 | `--keep-json PATH` | optional | Yosys frontend only: save the intermediate netlist for debugging or re-runs |
 
 The slang frontend is an opt-in extra. Install it alongside the package with `pip install 'rtl-buddy-cdc[slang]'` (or `uv add 'rtl-buddy-cdc[slang]'`); the default install stays Yosys-only.

--- a/src/rtl_buddy_cdc/cli.py
+++ b/src/rtl_buddy_cdc/cli.py
@@ -334,10 +334,14 @@ def lint(
     yosys_plugin: str | None = typer.Option(
         None,
         "--yosys-plugin",
+        envvar="RTL_BUDDY_SLANG_PLUGIN",
         help="Yosys frontend only: path to a Yosys plugin to load before "
         "elaboration (e.g. yosys-slang's slang.so). When set, sources are "
         "read with `read_slang --std 1800-2017 --top <top>` instead of "
-        "`read_verilog -sv`, giving full SystemVerilog-2017 support.",
+        "`read_verilog -sv`, giving full SystemVerilog-2017 support. "
+        "Falls back to the RTL_BUDDY_SLANG_PLUGIN environment variable "
+        "when the flag is omitted (the explicit flag wins); this is the "
+        "machine-local .env flow rtl_buddy populates from .rtl-buddy/.env.",
     ),
     waivers_path: Path | None = typer.Option(
         None,

--- a/tests/test_yosys_plugin_envvar.py
+++ b/tests/test_yosys_plugin_envvar.py
@@ -1,0 +1,89 @@
+"""`lint --yosys-plugin` reads the RTL_BUDDY_SLANG_PLUGIN env var.
+
+The plugin path is the machine-local yosys-slang `slang.so`; baking it
+into a committed config forces the same on-disk location everywhere.
+The flag therefore falls back to ``RTL_BUDDY_SLANG_PLUGIN`` (the .env
+flow ``rtl_buddy`` populates), with the explicit flag winning.
+
+These tests don't need yosys: ``elaborate`` is monkeypatched to capture
+the resolved ``yosys_plugin`` kwarg, so they exercise the CLI wiring
+(typer envvar -> parameter) in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import rtl_buddy_cdc.cli as cli
+from rtl_buddy_cdc.cli import app
+
+runner = CliRunner()
+
+FIX = Path(__file__).parent / "fixtures" / "ip_cdc_handshake"
+
+
+class _Captured(Exception):
+    """Bail out of the command once the kwarg is captured."""
+
+
+def _patch_elaborate(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Replace cli.elaborate with a capturing stub; return the box that
+    receives the call kwargs."""
+    box: dict[str, object] = {}
+
+    def fake_elaborate(*_args: object, **kwargs: object):
+        box.update(kwargs)
+        raise _Captured
+
+    monkeypatch.setattr(cli, "elaborate", fake_elaborate)
+    return box
+
+
+def _invoke(env: dict[str, str | None], extra_args: list[str]):
+    return runner.invoke(
+        app,
+        [
+            "lint",
+            "--top",
+            "ip_cdc_handshake",
+            "--sdc",
+            str(FIX / "ip_cdc_handshake.sdc"),
+            *extra_args,
+            str(FIX / "ip_cdc_sync.sv"),
+            str(FIX / "ip_cdc_handshake.sv"),
+        ],
+        env=env,
+    )
+
+
+def test_env_var_supplies_plugin_when_flag_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    box = _patch_elaborate(monkeypatch)
+    result = _invoke({"RTL_BUDDY_SLANG_PLUGIN": "/from/env/slang.so"}, [])
+    # _Captured propagates as a non-zero exit; that's expected.
+    assert isinstance(result.exception, _Captured), result.output
+    assert box["yosys_plugin"] == "/from/env/slang.so"
+
+
+def test_explicit_flag_wins_over_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    box = _patch_elaborate(monkeypatch)
+    result = _invoke(
+        {"RTL_BUDDY_SLANG_PLUGIN": "/from/env/slang.so"},
+        ["--yosys-plugin", "/from/flag/slang.so"],
+    )
+    assert isinstance(result.exception, _Captured), result.output
+    assert box["yosys_plugin"] == "/from/flag/slang.so"
+
+
+def test_no_plugin_when_neither_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    box = _patch_elaborate(monkeypatch)
+    # None clears any RTL_BUDDY_SLANG_PLUGIN already in the real env.
+    result = _invoke({"RTL_BUDDY_SLANG_PLUGIN": None}, [])
+    assert isinstance(result.exception, _Captured), result.output
+    assert box["yosys_plugin"] is None


### PR DESCRIPTION
## What

`lint --yosys-plugin` now falls back to the `RTL_BUDDY_SLANG_PLUGIN`
environment variable when the flag is omitted. An explicit `--yosys-plugin`
still wins (typer precedence: arg > envvar > default).

## Why

The yosys-slang plugin is a machine-local build artifact. Baking its
on-disk path into a committed config (a downstream `cdc.yaml`'s
`--yosys-plugin` extra-arg) forces every machine to put `slang.so` in the
same place. `rtl_buddy` already loads `.rtl-buddy/.env` into the environment
before shelling out to `rtl-buddy-cdc`, so reading `RTL_BUDDY_SLANG_PLUGIN`
here lets a config simply omit the flag and inherit the plugin from that
machine-local env — the same variable `rtl_buddy`'s own synth/fpv slang
frontends already resolve.

## Changes

- `cli.py`: add `envvar="RTL_BUDDY_SLANG_PLUGIN"` to the `--yosys-plugin`
  option + document the fallback in its help.
- `README.md`: add the `--yosys-plugin` row to the `lint` flag table.
- `CHANGELOG.md`: `[Unreleased]` entry.
- `tests/test_yosys_plugin_envvar.py`: 3 yosys-free CLI tests — env var
  supplies the plugin when the flag is omitted, the explicit flag wins
  over the env var, and neither set leaves it `None`.

## Contract impact

Additive CLI change only — no change to the consumed JSON keys, CLI flag
names, or exit codes.

## Validation

- `ruff check` / `ruff format --check` / `mypy` clean; full suite
  `1634 passed, 3 skipped`.
- End-to-end via `rb cdc` in a downstream project with the
  `--yosys-plugin` extra-arg dropped from `cdc.yaml`: the yosys-frontend
  entries PASS with the plugin sourced from `.rtl-buddy/.env`, and a bogus
  `RTL_BUDDY_SLANG_PLUGIN` makes them FAIL (confirming the env var is the
  real source and process-env wins over the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)