### PR TITLE
fix(changelog): remove stray `<<<<<<< HEAD` conflict marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-<<<<<<< HEAD
 - **`(* cdc_handshake *)` attribute — sanctioned four-phase req/ack
   handshake** (#247). A correct req/ack vector-CDC primitive (the
   `ip_cdc_handshake` shape) trips four rules on its protected paths —


### PR DESCRIPTION
## What

Removes a lone, unbalanced `<<<<<<< HEAD` line from the `[Unreleased] / Added` section of `CHANGELOG.md`.

## Why

PR #249 (commit `f25c216`) committed the opening marker of a merge conflict without its `=======`/`>>>>>>>` halves — a botched conflict resolution. It merged into `main`, so the default branch currently carries a literal Git conflict marker inside its changelog.

The entries beneath it are intact and valid; this just deletes the orphan line.

## Verification

```
$ grep -cE '<<<<<<<|>>>>>>>|^=======' CHANGELOG.md
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)