### PR TITLE
ci(test): build yosys-slang plugin and exercise the read_slang path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -181,9 +181,13 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
+          # libfl-dev provides FlexLexer.h (the `flex` package alone does
+          # not, on ubuntu-latest) and gperf is required by the Yosys
+          # build — both are in yosys-slang's own CI dep list. Omitting
+          # libfl-dev fails the Yosys compile at verilog_parser.tab.o.
           sudo apt-get install -y --no-install-recommends \
-            build-essential cmake ccache pkg-config git \
-            bison flex libreadline-dev gawk tcl-dev libffi-dev zlib1g-dev
+            build-essential cmake ccache pkg-config git gperf \
+            bison flex libfl-dev libreadline-dev gawk tcl-dev libffi-dev zlib1g-dev
 
       - name: Cache Yosys ${{ env.YOSYS_VERSION }}
         id: cache-yosys

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,13 +208,20 @@ jobs:
           make -C yosys_build -j"$(nproc)"
           make -C yosys_build install DESTDIR="$HOME/yosys-install"
 
-      - name: Put Yosys on PATH
-        run: echo "$HOME/yosys-install/usr/local/bin" >> "$GITHUB_PATH"
+      # Populate the real install prefix from the DESTDIR staging tree.
+      # yosys-config bakes in its build-time prefix (/usr/local), so the
+      # plugin build's `yosys-config --cxxflags` points at
+      # /usr/local/share/yosys/include — that path must actually hold the
+      # Yosys headers (kernel/rtlil.h, ...), not just the cached staging
+      # dir. Copying the tree into / is how yosys-slang's own CI does it,
+      # and it runs on cache hits too (the build step is skipped then).
+      - name: Install Yosys into the system prefix
+        run: sudo cp -r "$HOME/yosys-install"/* /
 
       - name: Verify Yosys
         run: |
           yosys -V
-          yosys-config --datdir >/dev/null
+          test -f "$(yosys-config --datdir)/include/kernel/rtlil.h"
 
       - name: Cache plugin ccache
         uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
       - 'src/**/*.py'
       - 'tests/**/*.py'
       - 'tests/**/*.sv'
+      - 'tests/**/*.sdc'
   pull_request:
     branches: [main]
     paths:
@@ -21,6 +22,7 @@ on:
       - 'src/**/*.py'
       - 'tests/**/*.py'
       - 'tests/**/*.sv'
+      - 'tests/**/*.sdc'
 
 jobs:
   # Primary job: install with the [slang] extra so the pyslang-backed
@@ -143,3 +145,95 @@ jobs:
 
       - name: Coverage report (fuzz rule firings)
         run: uv run python -m tests.fuzz.coverage
+
+  # End-to-end exercise of the yosys-slang plugin (`read_slang`) path —
+  # the `--yosys-plugin` / RTL_BUDDY_SLANG_PLUGIN flow in cli.py /
+  # frontends/yosys.py. Every other job leaves the plugin tests skipped
+  # (RTL_BUDDY_SLANG_PLUGIN unset), so without this job the read_slang
+  # branch is untested in CI.
+  #
+  # yosys-slang needs a Yosys in its supported range (0.52–0.65); the
+  # distro `apt` Yosys is far older, so we build a pinned Yosys from
+  # source (cached by version) the way yosys-slang's own CI does, then
+  # build the fork's `build/slang.so` against that Yosys's `yosys-config`
+  # (ccache-accelerated, cached by source hash). The test itself
+  # (tests/test_yosys_slang_plugin.py) only needs the default install —
+  # the read_slang path is a Yosys subprocess, not pyslang — so no
+  # `[slang]` extra here.
+  yosys-slang-plugin:
+    name: yosys-slang plugin (read_slang) oracle
+    runs-on: ubuntu-latest
+    env:
+      # Pinned Yosys release to build the plugin against. Bump only to a
+      # version yosys-slang's README lists as supported.
+      YOSYS_VERSION: v0.64
+      # rtl-buddy fork + branch carrying this project's slang frontend.
+      YOSYS_SLANG_REPO: https://github.com/rtl-buddy/yosys-slang.git
+      YOSYS_SLANG_REF: rtl-buddy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake ccache pkg-config git \
+            bison flex libreadline-dev gawk tcl-dev libffi-dev zlib1g-dev
+
+      - name: Cache Yosys ${{ env.YOSYS_VERSION }}
+        id: cache-yosys
+        uses: actions/cache@v4
+        with:
+          path: ~/yosys-install
+          key: yosys-${{ runner.os }}-${{ env.YOSYS_VERSION }}
+
+      - name: Build Yosys ${{ env.YOSYS_VERSION }}
+        if: steps.cache-yosys.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --recursive --branch "${YOSYS_VERSION}" \
+            https://github.com/YosysHQ/yosys.git yosys_build
+          make -C yosys_build config-gcc
+          # ABC is irrelevant to the read_slang -> write_json path and is
+          # the slowest part of the build; drop it to keep the job lean.
+          echo "ENABLE_ABC := 0" >> yosys_build/Makefile.conf
+          make -C yosys_build -j"$(nproc)"
+          make -C yosys_build install DESTDIR="$HOME/yosys-install"
+
+      - name: Put Yosys on PATH
+        run: echo "$HOME/yosys-install/usr/local/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Yosys
+        run: |
+          yosys -V
+          yosys-config --datdir >/dev/null
+
+      - name: Cache plugin ccache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: yosys-slang-${{ env.YOSYS_SLANG_REF }}-${{ env.YOSYS_VERSION }}-${{ github.sha }}
+          restore-keys: |
+            yosys-slang-${{ env.YOSYS_SLANG_REF }}-${{ env.YOSYS_VERSION }}-
+
+      - name: Build yosys-slang plugin (rtl-buddy fork @ ${{ env.YOSYS_SLANG_REF }})
+        run: |
+          git clone --recursive --branch "${YOSYS_SLANG_REF}" \
+            "${YOSYS_SLANG_REPO}" yosys-slang-src
+          ccache --max-size=2G -z
+          make -C yosys-slang-src -j"$(nproc)" \
+            CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          test -f yosys-slang-src/build/slang.so
+          # Export the built plugin so the gated test (and any rtl_buddy
+          # .env-style consumer) resolves it the same way as on a dev box.
+          echo "RTL_BUDDY_SLANG_PLUGIN=$PWD/yosys-slang-src/build/slang.so" >> "$GITHUB_ENV"
+
+      - name: Install test dependencies (default install)
+        run: uv sync --group test --python 3.13
+
+      - name: Run yosys-slang plugin oracle
+        run: uv run --python 3.13 pytest -m yosys_slang -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CI: end-to-end yosys-slang plugin (`read_slang`) oracle** (#251). A
+  new `yosys-slang plugin` job in `test.yml` builds a pinned Yosys (v0.64,
+  cached) from source and the rtl-buddy fork of `yosys-slang`
+  (branch `rtl-buddy`, ccache-accelerated) into `build/slang.so`, then
+  runs a gated test (`tests/test_yosys_slang_plugin.py`, marker
+  `yosys_slang`) that elaborates a package-typed design through the
+  `--yosys-plugin` / `RTL_BUDDY_SLANG_PLUGIN` path and asserts the
+  expected CDC finding. The fixture
+  (`tests/fixtures/slang_pkg_unsync_crossing`) imports a SystemVerilog
+  package — a construct Yosys's built-in `read_verilog -sv` rejects — so
+  a green result proves the plugin path is exercised, not bypassed.
+  Every other job leaves the test skipped (`RTL_BUDDY_SLANG_PLUGIN`
+  unset), so this is the first CI coverage of the `read_slang` branch.
+
 - **`(* cdc_handshake *)` attribute — sanctioned four-phase req/ack
   handshake** (#247). A correct req/ack vector-CDC primitive (the
   `ip_cdc_handshake` shape) trips four rules on its protected paths —

--- a/scripts/gen_fixture_docs.py
+++ b/scripts/gen_fixture_docs.py
@@ -224,12 +224,18 @@ def _render(netlist: Path | None, sdc: Path, sv: Path, top: str) -> tuple[dict, 
                 "--no-findings",
                 str(sv),
             ]
-        subprocess.run(
+        elab = subprocess.run(
             cmd,
-            check=True,
             cwd=REPO_ROOT,
             capture_output=True,
         )
+        if elab.returncode != 0:
+            # Plugin-only fixtures (e.g. those importing a SystemVerilog
+            # package, which `read_verilog -sv` rejects and only the
+            # yosys-slang `read_slang` plugin elaborates) can't be doc'd
+            # by the plain Yosys frontend. Skip rather than abort the
+            # whole run — the plugin path is covered by a gated test.
+            raise _SkipFixture("plain yosys frontend could not elaborate it")
         map_data = json.loads(map_path.read_text())
         result = subprocess.run(
             [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,3 +22,9 @@ def pytest_configure(config) -> None:
         "markers",
         "sim: behavioural simulation oracle (opt-in; needs iverilog)",
     )
+    config.addinivalue_line(
+        "markers",
+        "yosys_slang: end-to-end yosys-slang plugin (read_slang) oracle "
+        "(gated; needs yosys on PATH + RTL_BUDDY_SLANG_PLUGIN pointing at "
+        "a built slang.so; run via `pytest -m yosys_slang`)",
+    )

--- a/tests/fixtures/slang_pkg_unsync_crossing/cdc_pkg.sv
+++ b/tests/fixtures/slang_pkg_unsync_crossing/cdc_pkg.sv
@@ -1,0 +1,12 @@
+// Package consumed by slang_pkg_unsync_crossing.sv via `import cdc_pkg::*`.
+//
+// The package import is the SV-2017 construct that makes this fixture a
+// yosys-slang (`read_slang`) exercise: Yosys's built-in `read_verilog -sv`
+// frontend does not elaborate a separately-compiled package referenced by
+// a module header, so this design only loads through the slang plugin.
+package cdc_pkg;
+    // Bus width carried across the asynchronous clock-domain boundary.
+    parameter int BUS_W = 8;
+
+    typedef logic [BUS_W-1:0] word_t;
+endpackage

--- a/tests/fixtures/slang_pkg_unsync_crossing/slang_pkg_unsync_crossing.sdc
+++ b/tests/fixtures/slang_pkg_unsync_crossing/slang_pkg_unsync_crossing.sdc
@@ -1,0 +1,7 @@
+create_clock -name src_clk -period 10.0 [get_ports src_clk]
+create_clock -name dst_clk -period 7.5  [get_ports dst_clk]
+set_clock_groups -asynchronous -group {src_clk} -group {dst_clk}
+# `d_in` originates in src_clk's domain — declare it so the unconstrained
+# -input rule (CDC-011) stays silent and this fixture targets only the
+# missing-synchronizer shape (CDC-001).
+set_input_delay -clock src_clk 1.0 [get_ports d_in]

--- a/tests/fixtures/slang_pkg_unsync_crossing/slang_pkg_unsync_crossing.sv
+++ b/tests/fixtures/slang_pkg_unsync_crossing/slang_pkg_unsync_crossing.sv
@@ -1,0 +1,44 @@
+// Negative-case fixture exercised through the yosys-slang plugin.
+//
+// A `word_t` bus (typedef'd in the imported `cdc_pkg`) crosses from
+// src_clk to dst_clk with no gating or gray-coding, so the crossing
+// must trip CDC-004 (unprotected bus crossing).
+//
+// The CDC bug itself is ordinary; what is special is the front door:
+// the design pulls its bus type from a separately-compiled package via
+// `import cdc_pkg::*`. Yosys's built-in `read_verilog -sv` does not
+// elaborate that (it rejects the `word_t` port type), so this fixture
+// only loads through `read_slang` (the yosys-slang plugin). It is the
+// end-to-end proof that the `--yosys-plugin` / RTL_BUDDY_SLANG_PLUGIN
+// path produces a netlist the rule pack can analyse.
+//
+//        src_clk             dst_clk
+//   ┌──[ src_q (word_t) ]──[ dst_q ]──── 8-bit, ungated → CDC-004
+
+import cdc_pkg::*;
+
+module slang_pkg_unsync_crossing (
+    input  logic        src_clk,
+    input  logic        dst_clk,
+    input  logic        rst_n,
+    input  word_t       d_in,
+    output word_t       q_out
+);
+
+    word_t src_q;
+    word_t dst_q;
+
+    always_ff @(posedge src_clk or negedge rst_n) begin
+        if (!rst_n) src_q <= '0;
+        else        src_q <= d_in;
+    end
+
+    // BAD: single flop on the destination side instead of a 2FF sync.
+    always_ff @(posedge dst_clk or negedge rst_n) begin
+        if (!rst_n) dst_q <= '0;
+        else        dst_q <= src_q;
+    end
+
+    assign q_out = dst_q;
+
+endmodule

--- a/tests/test_yosys_slang_plugin.py
+++ b/tests/test_yosys_slang_plugin.py
@@ -1,0 +1,130 @@
+"""End-to-end yosys-slang plugin (`read_slang`) oracle.
+
+Unlike ``test_yosys_plugin_envvar.py`` — which monkeypatches ``elaborate``
+to check only the typer-envvar → kwarg wiring — this test drives the real
+plugin: it shells out to ``yosys``, loads the freshly-built
+``slang.so``, elaborates a design through ``read_slang``, and runs the
+rule pack on the resulting netlist.
+
+The design (``fixtures/slang_pkg_unsync_crossing``) pulls its bus type
+from a separately-compiled package via ``import cdc_pkg::*`` — a
+SystemVerilog-2017 construct Yosys's built-in ``read_verilog -sv``
+rejects. So a green result here is proof the ``--yosys-plugin`` /
+RTL_BUDDY_SLANG_PLUGIN path produces a netlist the analyzer can read.
+
+Gated three ways (skips unless all hold), so it is a no-op in every job
+except the dedicated ``yosys-slang plugin`` CI job that builds the
+plugin and exports the env var:
+
+* ``RTL_BUDDY_SLANG_PLUGIN`` points at an existing ``slang.so``;
+* ``yosys`` is on PATH.
+
+Select it explicitly with ``pytest -m yosys_slang``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from rtl_buddy_cdc.cli import app
+
+runner = CliRunner()
+
+FIX = Path(__file__).parent / "fixtures" / "slang_pkg_unsync_crossing"
+TOP = "slang_pkg_unsync_crossing"
+
+_PLUGIN = os.environ.get("RTL_BUDDY_SLANG_PLUGIN")
+
+pytestmark = [
+    pytest.mark.yosys_slang,
+    pytest.mark.skipif(
+        not _PLUGIN or not Path(_PLUGIN).exists(),
+        reason="RTL_BUDDY_SLANG_PLUGIN not set to an existing slang.so",
+    ),
+    pytest.mark.skipif(
+        shutil.which("yosys") is None,
+        reason="yosys not on PATH",
+    ),
+]
+
+
+def _lint_json(tmp_path: Path) -> dict:
+    """Run ``lint`` through the yosys-slang plugin, return parsed JSON.
+
+    Writes to ``--output`` rather than stdout so the yosys subprocess
+    chatter can never contaminate the parsed report.
+    """
+    out = tmp_path / "report.json"
+    result = runner.invoke(
+        app,
+        [
+            "lint",
+            "--top",
+            TOP,
+            "--sdc",
+            str(FIX / f"{TOP}.sdc"),
+            "--yosys-plugin",
+            _PLUGIN,
+            "--format",
+            "json",
+            "--output",
+            str(out),
+            str(FIX / "cdc_pkg.sv"),
+            str(FIX / f"{TOP}.sv"),
+        ],
+    )
+    # Exit 1 == "ran successfully, found unsuppressed violations" per the
+    # CLI contract; the bus crossing is meant to fire, so 1 is expected.
+    assert result.exit_code == 1, result.output
+    return json.loads(out.read_text())
+
+
+def test_read_verilog_rejects_the_package_typed_port() -> None:
+    """Guard rail: confirm the design genuinely needs the plugin.
+
+    If a future Yosys gains package-typed-port support in
+    ``read_verilog -sv``, this fixture stops proving the plugin is
+    exercised — fail loudly here rather than let the plugin test pass
+    for the wrong reason.
+    """
+    import subprocess
+
+    yosys = shutil.which("yosys")
+    assert yosys is not None  # guarded by pytestmark skipif
+    proc = subprocess.run(
+        [
+            yosys,
+            "-q",
+            "-p",
+            f"read_verilog -sv {FIX / 'cdc_pkg.sv'} {FIX / f'{TOP}.sv'}; "
+            f"hierarchy -top {TOP}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0, (
+        "read_verilog -sv unexpectedly accepted the package-typed port; "
+        "the fixture no longer proves read_slang is required"
+    )
+
+
+def test_slang_plugin_bus_crossing_fires_cdc_004(tmp_path: Path) -> None:
+    report = _lint_json(tmp_path)
+
+    # The plugin actually elaborated something: an 8-bit async crossing.
+    assert report["summary"]["crossings"] >= 1
+
+    cdc_004 = [v for v in report["violations"] if v["rule_id"] == "CDC-004"]
+    assert len(cdc_004) == 1, report["violations"]
+    assert cdc_004[0]["severity"] == "error"
+    assert cdc_004[0]["crossing"]["width"] == 8
+
+    # CDC-011 (unconstrained input) must stay silent: the SDC declares
+    # d_in's domain, so the only finding is the bus crossing itself.
+    assert [v for v in report["violations"] if v["rule_id"] == "CDC-011"] == []


### PR DESCRIPTION
## What

Adds a `yosys-slang plugin (read_slang) oracle` job to `test.yml` that builds the **rtl-buddy fork of yosys-slang** (branch `rtl-buddy`) into `build/slang.so` and runs a design through the `read_slang` plugin path end-to-end.

## Why

The repo already has the plugin frontend (`--yosys-plugin` / `RTL_BUDDY_SLANG_PLUGIN` → `read_slang`, in `cli.py` / `frontends/yosys.py`), but **CI never built the plugin or ran a design through it** — only the typer-envvar wiring was unit-tested with `elaborate` mocked out. The `read_slang` branch was untested end-to-end. This is the first CI coverage of it.

## How

- **New CI job.** The distro `apt` Yosys is far older than yosys-slang's supported range (0.52–0.65), so the job builds a pinned **Yosys v0.64** from source (cached by version) and the fork's `slang.so` against its `yosys-config` (ccache-accelerated, cached by source hash) — the same pattern yosys-slang's own CI uses. It exports `RTL_BUDDY_SLANG_PLUGIN` and runs `pytest -m yosys_slang`.
- **New gated test** (`tests/test_yosys_slang_plugin.py`, marker `yosys_slang`). Drives the real `lint --yosys-plugin` CLI through yosys + `slang.so` and asserts the expected **CDC-004** finding.
- **New fixture** (`tests/fixtures/slang_pkg_unsync_crossing`). Pulls a bus type from a SystemVerilog package via `import cdc_pkg::*` — a construct built-in `read_verilog -sv` rejects — so a green result proves the plugin actually elaborated the design rather than being bypassed. A guard test asserts `read_verilog` still rejects it, so the fixture can't silently stop differentiating.
- The test **skips everywhere `RTL_BUDDY_SLANG_PLUGIN` is unset**, so it's a no-op in every other job.
- `gen_fixture_docs.py` now **skips** (instead of aborting on) fixtures the plain Yosys frontend can't elaborate, so a full doc regen doesn't crash on this plugin-only fixture.

## Notes

- The single-line CHANGELOG marker removal here overlaps with #250 (the standalone fix for that artifact). Whichever merges first, the other should rebase cleanly (identical deletion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)