### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-06-16
+
 ### Fixed
 
 - **Blackbox / auto-abstract soundness** (#259 audit). Four silent
@@ -1108,6 +1110,7 @@ shlex-based SDC subset (`create_clock`, `create_generated_clock`,
 through CDC-008 rule pack, Spyglass-`.swl`-style waiver matcher,
 and text / JSON / SARIF reporters.
 
-[Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/rtl-buddy/rtl-buddy-cdc/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rtl-buddy-cdc"
-version = "0.2.0"
+version = "0.3.0"
 description = "CDC (clock domain crossing) linting tool for RTL designs, with pluggable Yosys or slang (pyslang) frontend; integrates with rtl-buddy."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -27,7 +27,7 @@ from rtl_buddy_cdc.sdc import ClockSpec
 from rtl_buddy_cdc.waivers import SuppressedViolation
 
 TOOL_NAME = "rtl-buddy-cdc"
-TOOL_VERSION = "0.2.0"
+TOOL_VERSION = "0.3.0"
 TOOL_INFO_URI = "https://github.com/rtl-buddy/rtl-buddy-cdc"
 
 # JSON output schema contract — these dotted keys are PUBLIC API.

--- a/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.reset-domain-map.json
+++ b/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.reset-domain-map.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "generator": {
     "name": "rtl-buddy-cdc",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "design": {
     "top": "bad_marked_reset_polarity",

--- a/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
+++ b/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
@@ -2,7 +2,7 @@
   "schema_version": "1.1",
   "generator": {
     "name": "rtl-buddy-cdc",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "design": {
     "top": "ip_cdc_handshake",

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "rtl-buddy-cdc"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
## Release 0.3.0

Cuts the **0.3.0** release for the CDC hierarchical-scaling epic (#253, shipped in #259).

- **Version** bumped `0.2.0 → 0.3.0` in lockstep: `pyproject.toml [project].version` + `reporter.TOOL_VERSION` (SARIF / domain-map consumers key off the latter; `test_tool_version_matches_pyproject` enforces the lockstep).
- **CHANGELOG**: `[Unreleased]` → `[0.3.0] — 2026-06-16`, fresh empty `[Unreleased]` on top, link refs updated.
- **Golden fixtures**: regenerated the two domain-map / reset-domain-map goldens whose `generator.version` embeds `TOOL_VERSION` (content otherwise unchanged).

### What 0.3.0 contains (since 0.2.0)
The CDC-scaling epic — first-class blackbox boundaries, auto-abstraction of single-clock subtrees, the compositional boundary walk, literal flat↔abstracted parity, per-instance keying, lint-path abstraction — plus the audit-driven **soundness** fixes (multi-clock detection, declined-boundary visibility, the reconvergence gate, CDC-008 narrowing) escalated to a **waivable `CDC-BBX`** error; and the `find_crossings` lane-aware perf rewrite (#260).

### Gate
ruff / format / mypy clean · pytest **1815 passed** (with slang+hints) · coverage **95.25%** (≥93).

After merge: tag `v0.3.0`, then bump the `rtl-buddy-cdc` pin in `rtl_buddy` to unblock rtl_buddy#318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
