### PR TITLE
feat(frontend): lint interface-port block tops via pyslang + use-before-decl leniency (0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] — 2026-06-16
+
 ### Changed
 
 - **Frontend leniency for standalone-block lint.** Both slang-based
@@ -1256,7 +1258,8 @@ shlex-based SDC subset (`create_clock`, `create_generated_clock`,
 through CDC-008 rule pack, Spyglass-`.swl`-style waiver matcher,
 and text / JSON / SARIF reporters.
 
-[Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Frontend leniency for standalone-block lint.** Both slang-based
+  frontends now tolerate two constructs the built-in `read_verilog`
+  frontend already accepts, so switching a design onto a slang frontend
+  doesn't newly reject structurally-valid sources:
+  - The **pyslang frontend** (`--frontend slang`) sets
+    `AllowTopLevelIfacePorts` (explicit; already a pyslang default) and
+    `AllowUseBeforeDeclare`. This lets a block with an **unconnected
+    top-level SystemVerilog interface port** (e.g. `apb_intf.subordinate
+    apb`) be CDC-linted on its own — the yosys `read_slang` path can't
+    do this at all, since a yosys netlist has no interface ports, so
+    interface-bearing block tops must use `--frontend slang`.
+  - The **yosys `read_slang` frontend** passes `--allow-use-before-declare`
+    so a module-item reference to a net declared later in the same
+    module no longer fails elaboration. (`--allow-toplevel-iface-ports`
+    is *unsupported* by yosys-slang and is intentionally not passed.)
 - **Clock-combining nodes decline instead of silently picking one leg**
   (#263 soundness). When a clock-network gate (`$and`/`$or`…) or a
   clock-path transparent latch (`$dlatch`/`$_DLATCH_*`) combines two

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rtl-buddy-cdc"
-version = "0.3.1"
+version = "0.3.2"
 description = "CDC (clock domain crossing) linting tool for RTL designs, with pluggable Yosys or slang (pyslang) frontend; integrates with rtl-buddy."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -177,7 +177,24 @@ def elaborate(sources: list[Path], top: str) -> Module:
     """Elaborate ``sources`` via pyslang and produce a :class:`Module`."""
     pyslang = _import_pyslang()
 
-    comp = pyslang.Compilation()
+    # Relax two defaults that are too strict for a *standalone block*
+    # CDC lint, keeping this frontend's leniency aligned with the
+    # yosys / read_slang path (see frontends/yosys.py): a block linted
+    # on its own legitimately has unconnected top-level SystemVerilog
+    # interface ports, and module-item references to nets declared
+    # later in the same module are valid RTL. ``AllowTopLevelIfacePorts``
+    # is already on by default in pyslang; set it explicitly so the
+    # intent survives a future default change.
+    options = pyslang.CompilationOptions()
+    options.flags = (
+        options.flags
+        | pyslang.CompilationFlags.AllowTopLevelIfacePorts
+        | pyslang.CompilationFlags.AllowUseBeforeDeclare
+    )
+    bag = pyslang.Bag()
+    bag.compilationOptions = options
+
+    comp = pyslang.Compilation(bag)
     for src in sources:
         tree = pyslang.SyntaxTree.fromFile(str(src))
         comp.addSyntaxTree(tree)

--- a/src/rtl_buddy_cdc/frontends/yosys.py
+++ b/src/rtl_buddy_cdc/frontends/yosys.py
@@ -111,9 +111,20 @@ def elaborate_with_blackboxes(
             bb = "".join(
                 f"--blackboxed-module {shlex.quote(m)} " for m in (blackbox or ())
             )
+            # ``--allow-use-before-declare`` relaxes a yosys-slang default
+            # that is too strict for ordinary RTL: a module-item reference
+            # to a net declared later in the same module is valid SV the
+            # built-in ``read_verilog`` frontend already accepts, so the
+            # read_slang frontend should not newly reject it. (Top-level
+            # SystemVerilog interface ports are a separate matter — yosys
+            # netlists can't represent them, so ``--allow-toplevel-iface-
+            # ports`` is *unsupported* by yosys-slang; designs with an
+            # interface at the lint top must use the pyslang ``--frontend
+            # slang`` path, which elaborates them natively.)
             read_cmd = (
                 f"plugin -i {shlex.quote(plugin_path)}; "
                 f"read_slang --std 1800-2017 --top {shlex.quote(top)} "
+                f"--allow-use-before-declare "
                 f"{bb}{srcs}"
             )
         script = (

--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -27,7 +27,7 @@ from rtl_buddy_cdc.sdc import ClockSpec
 from rtl_buddy_cdc.waivers import SuppressedViolation
 
 TOOL_NAME = "rtl-buddy-cdc"
-TOOL_VERSION = "0.3.1"
+TOOL_VERSION = "0.3.2"
 TOOL_INFO_URI = "https://github.com/rtl-buddy/rtl-buddy-cdc"
 
 # JSON output schema contract — these dotted keys are PUBLIC API.

--- a/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.reset-domain-map.json
+++ b/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.reset-domain-map.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "generator": {
     "name": "rtl-buddy-cdc",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "design": {
     "top": "bad_marked_reset_polarity",

--- a/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
+++ b/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
@@ -2,7 +2,7 @@
   "schema_version": "1.1",
   "generator": {
     "name": "rtl-buddy-cdc",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "design": {
     "top": "ip_cdc_handshake",

--- a/tests/fixtures/slang_iface_port_top/slang_iface_port_top.sdc
+++ b/tests/fixtures/slang_iface_port_top/slang_iface_port_top.sdc
@@ -1,0 +1,5 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period 7.5  [get_ports clk_b]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
+# d_in originates in clk_a's domain.
+set_input_delay -clock clk_a 1.0 [get_ports d_in]

--- a/tests/fixtures/slang_iface_port_top/slang_iface_port_top.sv
+++ b/tests/fixtures/slang_iface_port_top/slang_iface_port_top.sv
@@ -1,0 +1,51 @@
+// Standalone block whose top exercises two yosys-slang strict-default
+// rejections that a *block-level* CDC lint must tolerate:
+//
+//   1. an unconnected top-level SystemVerilog interface port
+//      (`bus_if.sink s`) — normal when a block is linted on its own,
+//      with no parent to bind the interface;
+//   2. a module-item reference to a net declared later in the same
+//      module (`sync_q <= meta;` with `meta` declared below) — valid
+//      RTL the built-in read_verilog frontend already accepts.
+//
+// read_slang rejects both by default; rtl-buddy-cdc invokes it with
+// --allow-toplevel-iface-ports / --allow-use-before-declare so the
+// read_slang frontend stays as lenient as read_verilog. The design
+// also carries a real clk_a -> clk_b 8-bit bus crossing (through a 2FF
+// sync) so a green elaboration yields an analysable netlist (CDC-004).
+
+interface bus_if (input logic clk);
+  logic [7:0] data;
+  modport sink (input clk, data);
+endinterface
+
+module slang_iface_port_top (
+    input  logic       clk_a,
+    input  logic       clk_b,
+    input  logic       rst_n,
+    input  logic [7:0] d_in,    // clk_a-domain payload
+    bus_if.sink        s,       // unconnected top-level interface port
+    output logic [7:0] q
+);
+
+    // Use-before-declaration: `meta` is referenced here but declared
+    // further down. Legal module-item ordering; rejected by read_slang
+    // unless --allow-use-before-declare is passed.
+    logic [7:0] sync_q;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) sync_q <= '0;
+        else        sync_q <= meta;
+
+    logic [7:0] meta;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) meta <= '0;
+        else        meta <= src_q;
+
+    logic [7:0] src_q;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) src_q <= '0;
+        else        src_q <= d_in ^ s.data;   // consumes the interface payload
+
+    assign q = sync_q;
+
+endmodule

--- a/tests/fixtures/slang_use_before_decl/slang_use_before_decl.sdc
+++ b/tests/fixtures/slang_use_before_decl/slang_use_before_decl.sdc
@@ -1,0 +1,5 @@
+create_clock -name clk_a -period 10.0 [get_ports clk_a]
+create_clock -name clk_b -period 7.5  [get_ports clk_b]
+set_clock_groups -asynchronous -group {clk_a} -group {clk_b}
+# d_in originates in clk_a's domain.
+set_input_delay -clock clk_a 1.0 [get_ports d_in]

--- a/tests/fixtures/slang_use_before_decl/slang_use_before_decl.sv
+++ b/tests/fixtures/slang_use_before_decl/slang_use_before_decl.sv
@@ -1,0 +1,37 @@
+// A module-item reference to a net declared later in the same module
+// (`sync_q <= meta;` with `meta` declared below). Valid SystemVerilog
+// that the built-in read_verilog frontend accepts, but yosys-slang's
+// read_slang rejects by default. rtl-buddy-cdc passes
+// --allow-use-before-declare so the read_slang frontend stays as
+// lenient as read_verilog.
+//
+// Carries a clk_a -> clk_b control crossing through a 2FF synchroniser
+// so a green elaboration yields an analysable, violation-free netlist.
+
+module slang_use_before_decl (
+    input  logic clk_a,
+    input  logic clk_b,
+    input  logic rst_n,
+    input  logic d_in,    // clk_a-domain control
+    output logic q
+);
+
+    // `meta` is referenced here but declared further down.
+    logic sync_q;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) sync_q <= 1'b0;
+        else        sync_q <= meta;
+
+    logic meta;
+    always_ff @(posedge clk_b or negedge rst_n)
+        if (!rst_n) meta <= 1'b0;
+        else        meta <= src_q;
+
+    logic src_q;
+    always_ff @(posedge clk_a or negedge rst_n)
+        if (!rst_n) src_q <= 1'b0;
+        else        src_q <= d_in;
+
+    assign q = sync_q;
+
+endmodule

--- a/tests/test_slang_iface_port_top.py
+++ b/tests/test_slang_iface_port_top.py
@@ -1,0 +1,61 @@
+"""pyslang frontend: a standalone block whose top has an unconnected
+SystemVerilog interface port (and a use-before-declaration) elaborates
+natively.
+
+Unlike the yosys ``read_slang`` path — where a top-level interface port
+is *unsupported* because a yosys netlist has no interface ports — the
+pyslang frontend elaborates the interface hierarchy directly, so a
+block parameterised on an interface can be CDC-linted on its own. This
+is the path designs like the project-template's interface-bearing
+subsystem top must use.
+
+The fixture (``fixtures/slang_iface_port_top``) also references a net
+declared later in the same module; both leniencies are set explicitly
+in :func:`rtl_buddy_cdc.frontends.slang.elaborate`
+(``AllowTopLevelIfacePorts`` / ``AllowUseBeforeDeclare``).
+
+Gated on pyslang being importable (the ``[slang]`` extra) — the same
+gate every other slang-frontend test uses.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from rtl_buddy_cdc import sdc as sdc_mod
+from rtl_buddy_cdc.cli import _filter_async
+from rtl_buddy_cdc.domain import find_crossings
+from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.rules import run_all
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+if not PYSLANG_INSTALLED:
+    pytest.skip(
+        "pyslang not installed — slang elaboration tests are gated on it",
+        allow_module_level=True,
+    )
+
+FIX = Path(__file__).parent / "fixtures" / "slang_iface_port_top"
+TOP = "slang_iface_port_top"
+
+
+def test_pyslang_elaborates_interface_port_top() -> None:
+    """The interface-port top elaborates and the analyzer sees the
+    clk_a -> clk_b 8-bit bus crossing (CDC-004 fires on the ungated
+    bus). A regression to the strict defaults would raise
+    ``SlangElaborationError`` here instead."""
+    module = elaborate([FIX / f"{TOP}.sv"], TOP, frontend=Frontend.slang)
+    spec = sdc_mod.parse_file(FIX / f"{TOP}.sdc")
+    crossings = find_crossings(
+        module, port_clock=spec.port_clock, pin_clocks=spec.pin_clocks
+    )
+    async_c = _filter_async(crossings, spec)
+    violations = run_all(module, async_c, spec)
+
+    assert len(async_c) >= 1, "interface-port top produced no async crossing"
+    cdc_004 = [v for v in violations if v.rule_id == "CDC-004"]
+    assert len(cdc_004) >= 1, sorted({v.rule_id for v in violations})
+    assert any(v.crossing is not None and v.crossing.width == 8 for v in cdc_004)

--- a/tests/test_slang_use_before_decl.py
+++ b/tests/test_slang_use_before_decl.py
@@ -1,0 +1,103 @@
+"""End-to-end yosys-slang plugin (`read_slang`) oracle for
+``--allow-use-before-declare``.
+
+The fixture (``fixtures/slang_use_before_decl``) references a net
+before its declaration in the same module — valid RTL that read_verilog
+accepts but yosys-slang rejects by default. A green lint proves
+rtl-buddy-cdc injects ``--allow-use-before-declare`` so the read_slang
+frontend stays as lenient as read_verilog.
+
+Gated like ``test_yosys_slang_plugin.py``: a no-op unless the plugin is
+built and ``RTL_BUDDY_SLANG_PLUGIN`` points at it, plus ``yosys`` on
+PATH. Select explicitly with ``pytest -m yosys_slang``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from rtl_buddy_cdc.cli import app
+
+runner = CliRunner()
+
+FIX = Path(__file__).parent / "fixtures" / "slang_use_before_decl"
+TOP = "slang_use_before_decl"
+
+_PLUGIN = os.environ.get("RTL_BUDDY_SLANG_PLUGIN")
+
+pytestmark = [
+    pytest.mark.yosys_slang,
+    pytest.mark.skipif(
+        not _PLUGIN or not Path(_PLUGIN).exists(),
+        reason="RTL_BUDDY_SLANG_PLUGIN not set to an existing slang.so",
+    ),
+    pytest.mark.skipif(
+        shutil.which("yosys") is None,
+        reason="yosys not on PATH",
+    ),
+]
+
+
+def test_read_slang_without_flag_rejects_use_before_decl() -> None:
+    """Guard rail: a bare ``read_slang`` (no ``--allow-use-before-declare``)
+    must *fail* on this fixture, else the flag rtl-buddy-cdc injects is
+    not doing the work and a default change would slip through."""
+    yosys = shutil.which("yosys")
+    assert yosys is not None  # guarded by pytestmark skipif
+    assert _PLUGIN is not None
+    proc = subprocess.run(
+        [
+            yosys,
+            "-q",
+            "-p",
+            (
+                f"plugin -i {_PLUGIN}; "
+                f"read_slang --std 1800-2017 --top {TOP} "
+                f"{FIX / f'{TOP}.sv'}; "
+                f"hierarchy -top {TOP}"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0, (
+        "read_slang unexpectedly accepted the use-before-declaration "
+        "without --allow-use-before-declare; the fixture no longer "
+        "proves the flag is required"
+    )
+
+
+def test_slang_plugin_elaborates_use_before_decl(tmp_path: Path) -> None:
+    """With the flag (injected by rtl-buddy-cdc), the same block
+    elaborates into a clean 2FF synchroniser — no violations."""
+    out = tmp_path / "report.json"
+    result = runner.invoke(
+        app,
+        [
+            "lint",
+            "--top",
+            TOP,
+            "--sdc",
+            str(FIX / f"{TOP}.sdc"),
+            "--yosys-plugin",
+            _PLUGIN,
+            "--format",
+            "json",
+            "--output",
+            str(out),
+            str(FIX / f"{TOP}.sv"),
+        ],
+    )
+    # Exit 0 == clean (the design is a textbook 2FF sync); the point is
+    # that elaboration succeeded rather than failing with exit 2.
+    assert result.exit_code == 0, result.output
+    report = json.loads(out.read_text())
+    assert report["summary"]["crossings"] >= 1
+    assert report["summary"]["violations"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "rtl-buddy-cdc"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
## What

Keep the two slang-based frontends as lenient as the built-in `read_verilog` frontend for **standalone block-level CDC lint**. Linting a block on its own legitimately hits two SystemVerilog constructs that `read_verilog` accepts but the slang frontends rejected by default, so moving a design onto a slang frontend spuriously failed elaboration:

- an **unconnected top-level interface port** (e.g. `apb_intf.subordinate apb`) on the lint top, and
- a **module-item reference to a net declared later** in the same module.

## How

- **pyslang frontend** (`--frontend slang`): sets `AllowTopLevelIfacePorts` (explicit; already a pyslang default) + `AllowUseBeforeDeclare`. This is what lets an **interface-bearing block top** be CDC-linted standalone — the yosys `read_slang` path *cannot* do this at all (a yosys netlist has no interface ports, and yosys-slang rejects `--allow-toplevel-iface-ports`), so such tops must use `--frontend slang`.
- **yosys `read_slang` frontend**: passes `--allow-use-before-declare` so a forward net reference no longer fails elaboration. (The unsupported `--allow-toplevel-iface-ports` is intentionally *not* passed; documented in-code.)

## Motivation & scope

Surfaced while bumping the project-template's CDC suite: its `demo_tiny_alu_subsys` top has an `apb_intf` port that the yosys read paths can't lint (read_verilog mis-elaborates the interface into ~40 phantom crossings; read_slang rejects it). The pyslang frontend elaborates it correctly (10 crossings).

This PR is a **standalone frontend-parity improvement** — the template does **not** depend on it: it lands on the existing `v0.3.1` by routing that one analysis through `--frontend slang` (pyslang already defaults `AllowTopLevelIfacePorts` on) and fixing the one use-before-declaration in its FIFO source. The leniency here is the durable fix so *any* interface-bearing or forward-referencing design works on the slang frontends without per-design source edits.

## Tests

- `test_slang_iface_port_top.py` — pyslang oracle (runs in the `[slang]` job): an interface-port + use-before-decl top elaborates and the analyzer sees the clk_a→clk_b bus crossing (CDC-004).
- `test_slang_use_before_decl.py` — gated read_slang oracle pair: use-before-decl elaborates *with* the injected flag and **fails without it** (guard rail).

## Release

Cuts **0.3.2** (version + `TOOL_VERSION` lockstep, CHANGELOG finalised, goldens refreshed), bundling the unreleased #263 clock-combining change already on `main`.

Full suite green (1984 passed, 4 gated-skips without the plugin); coverage 97.28% (gate 96); ruff + format + mypy clean.
