### PR TITLE
fix(CDC-012): suppress on (* cdc_handshake *) primitives (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] — 2026-06-17
+
+### Fixed
+
+- **CDC-012 false positive on `(* cdc_handshake *)` primitives.** CDC-012
+  (functional data-hold on a gated multi-bit crossing) is silenced when
+  it finds a synced-back ack in the source flop's register-neighbourhood
+  (`_has_dst_to_src_feedback`), but that structural walk can't always see
+  the in-primitive ack of a req/ack handshake — it depends on how the
+  toggle/ack flops lower, and differs across frontends (it was reachable
+  under the yosys frontend but not under pyslang for the same design).
+  A four-phase req/ack primitive whose participants are tagged
+  `(* cdc_handshake *)` therefore tripped CDC-012 even though the
+  handshake's `src_ready` backpressure holds the payload — exactly
+  CDC-012's hold guarantee. `check_cdc_012` now honours the annotation
+  directly (skip when either endpoint of the crossing is tagged), the
+  same opt-in the attribute already provides for CDC-001/013/014/020
+  (#247). Covered by extending the `(* cdc_handshake *)` suppression
+  parametrisation to CDC-012's `bad_functional_datahold_enable` fixture.
+
 ## [0.3.2] — 2026-06-16
 
 ### Changed
@@ -1258,7 +1278,8 @@ shlex-based SDC subset (`create_clock`, `create_generated_clock`,
 through CDC-008 rule pack, Spyglass-`.swl`-style waiver matcher,
 and text / JSON / SARIF reporters.
 
-[Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.2.0...v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rtl-buddy-cdc"
-version = "0.3.2"
+version = "0.3.3"
 description = "CDC (clock domain crossing) linting tool for RTL designs, with pluggable Yosys or slang (pyslang) frontend; integrates with rtl-buddy."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -27,7 +27,7 @@ from rtl_buddy_cdc.sdc import ClockSpec
 from rtl_buddy_cdc.waivers import SuppressedViolation
 
 TOOL_NAME = "rtl-buddy-cdc"
-TOOL_VERSION = "0.3.2"
+TOOL_VERSION = "0.3.3"
 TOOL_INFO_URI = "https://github.com/rtl-buddy/rtl-buddy-cdc"
 
 # JSON output schema contract — these dotted keys are PUBLIC API.

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -3631,6 +3631,13 @@ def check_cdc_012(
       ``dst_clock`` flop (no handshake feedback) — see
       :func:`_has_dst_to_src_feedback`.
 
+    Suppressed when either endpoint of the crossing is tagged
+    ``(* cdc_handshake *)`` (issue #247): the attribute vouches a
+    sanctioned req/ack primitive whose synced-back ack holds the
+    payload, which is precisely CDC-012's hold guarantee — but the
+    structural feedback walk can't always see the in-primitive ack, so
+    the annotation is honoured directly (as CDC-001/013/014/020 do).
+
     Severity ``warning`` — the rule's structural heuristic for
     "handshake present" can't see application-level guarantees (e.g. a
     slow-write config-register bus where the host writes once and waits
@@ -3665,6 +3672,20 @@ def check_cdc_012(
         if c.src_flop.cell.name in ctx.user_grays:
             continue
         if _is_gray_encoded_source(module, c.src_flop, ctx.bit_drivers):
+            continue
+        # A (* cdc_handshake *)-vouched req/ack primitive holds the
+        # source payload via its synced-back ack/backpressure until the
+        # destination captures — exactly the guarantee CDC-012 checks
+        # for. The structural feedback walk can't always see the
+        # in-primitive ack (it depends on how the toggle/ack flops lower,
+        # and differs across frontends), so honour the annotation the
+        # same way CDC-001/013/014/020 do (#247). Either endpoint of the
+        # crossing being a tagged participant marks the whole crossing as
+        # part of the sanctioned primitive.
+        if (
+            c.src_flop.cell.name in ctx.user_handshakes
+            or c.dst_flop.cell.name in ctx.user_handshakes
+        ):
             continue
         key = c.src_flop.cell.name
         if key not in feedback_cache:

--- a/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.reset-domain-map.json
+++ b/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.reset-domain-map.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "generator": {
     "name": "rtl-buddy-cdc",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "design": {
     "top": "bad_marked_reset_polarity",

--- a/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
+++ b/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
@@ -2,7 +2,7 @@
   "schema_version": "1.1",
   "generator": {
     "name": "rtl-buddy-cdc",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "design": {
     "top": "ip_cdc_handshake",

--- a/tests/test_handshake_attribute.py
+++ b/tests/test_handshake_attribute.py
@@ -34,12 +34,14 @@ FIX = Path(__file__).parent / "fixtures"
 
 # Each fixture fires exactly the named rule on the keyed flop; the rule
 # keys the suppression on that same flop (dst capture / src toggle /
-# chain head / sliced source), so tagging it must silence the finding.
+# chain head / sliced source / src payload), so tagging it must silence
+# the finding.
 _CASES = [
     ("CDC-001", "bad_single_ff_sync"),
     ("CDC-013", "bad_toggle_no_xor_tail"),
     ("CDC-014", "bad_comb_between_sync_stages"),
     ("CDC-020", "bad_sliced_bus_reconvergence"),
+    ("CDC-012", "bad_functional_datahold_enable"),
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "rtl-buddy-cdc"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },


### PR DESCRIPTION
## What

CDC-012 (functional data-hold on a gated multi-bit crossing) fired as a **false positive on `(* cdc_handshake *)`-tagged req/ack primitives**, even though such a primitive holds the source payload via its `src_ready` backpressure — which is exactly the guarantee CDC-012 checks for.

## Why it slipped through

CDC-012 already self-suppresses when its structural walk (`_has_dst_to_src_feedback`) finds a synced-back ack in the source flop's register-neighbourhood. But that walk can't always see the in-primitive ack — it depends on how the toggle/ack flops lower, and **differs across frontends**: the ack path was reachable under the yosys frontend but not under pyslang for the same design (surfaced on the project-template's `demo_tiny_alu_subsys` handshake instance). The `(* cdc_handshake *)` attribute already suppresses CDC-001/013/014/020 on the same primitive, but **not** CDC-012.

## Fix

`check_cdc_012` now honours the annotation directly — skip when **either endpoint** of the crossing is tagged `(* cdc_handshake *)`, mirroring the opt-in the attribute provides for the other four rules (#247). It's a structural-not-protocol finding, which is precisely what the attribute exists to silence.

```python
if (c.src_flop.cell.name in ctx.user_handshakes
        or c.dst_flop.cell.name in ctx.user_handshakes):
    continue
```

## Tests

Extends the existing `(* cdc_handshake *)` suppression parametrisation (`test_handshake_attribute.py`) with `("CDC-012", "bad_functional_datahold_enable")`: the bad fixture fires one CDC-012, and tagging the keyed (source-payload) flop silences it. The standalone `bad_functional_datahold_enable` test (CDC-012 fires when *untagged*) is unchanged — no blanket suppression.

## Release

Cuts **0.3.3** (version + `TOOL_VERSION` lockstep, CHANGELOG, goldens). Full suite green (1985 passed); coverage 97.28% (gate 96); ruff + format + mypy clean.

Retires the template's CDC-012 waiver on `u_hs_cmd` (rtl-buddy-project-template) once its pin moves to v0.3.3.