### PR TITLE
chore: vendor-neutral wording for third-party tool references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ src/rtl_buddy_cdc/
 ├── domain.py          # trace_clock_root + find_crossings (BFS) + Crossing
 ├── sdc.py             # SDC parser: Tcl tokenizer + per-command arg-spec table
 ├── rules.py           # CDC-001..-008 + RULES registry + run_all + helpers
-├── waivers.py         # Spyglass-.swl-style waiver parser + apply()
+├── waivers.py         # .swl-style waiver parser + apply()
 └── reporter.py        # AnalysisResult + render_text / render_json / render_sarif
 tests/
 ├── fixtures/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1275,7 +1275,7 @@ shlex-based SDC subset (`create_clock`, `create_generated_clock`,
 `set_clock_groups -asynchronous` / `-logically_exclusive` /
 `-physically_exclusive`, `set_false_path -from/-to`,
 `set_input_delay -clock`, `set_output_delay -clock`), CDC-001
-through CDC-008 rule pack, Spyglass-`.swl`-style waiver matcher,
+through CDC-008 rule pack, `.swl`-style waiver matcher,
 and text / JSON / SARIF reporters.
 
 [Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.3...HEAD

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Known gaps and roadmap items are tracked at the end of this README.
 
 ## Why
 
-CDC bugs are notoriously hard to catch in simulation and devastating in silicon. Commercial CDC tools (Spyglass, Questa CDC, VC SpyGlass) are excellent but expensive and closed. The open-source EDA stack has strong synthesis (Yosys) and STA (OpenSTA) but lacks a dedicated CDC linter. `rtl-buddy-cdc` fills that gap with a pragmatic ruleset, fast iteration, and a Python codebase that's easy to extend.
+CDC bugs are notoriously hard to catch in simulation and devastating in silicon. Commercial CDC tools are excellent but expensive and closed. The open-source EDA stack has strong synthesis (Yosys) and STA (OpenSTA) but lacks a dedicated CDC linter. `rtl-buddy-cdc` fills that gap with a pragmatic ruleset, fast iteration, and a Python codebase that's easy to extend.
 
 ## Architecture
 
@@ -237,7 +237,7 @@ Mark a flop as a user-vetted synchronizer first stage by attaching an attribute 
 ```sv
 (* cdc_sync *) logic dst_q;             // canonical synchronizer first stage
 (* synchronizer *) logic dst_q;         // alias
-(* async_reg = "TRUE" *) logic dst_q;   // Vivado-compatible alias
+(* async_reg = "TRUE" *) logic dst_q;   // common synthesis-attribute alias
 (* cdc_gray *) logic [N-1:0] src_bus;   // source bus is gray-coded
 (* gray_code *) logic [N-1:0] src_bus;  // alias
 (* cdc_static *) logic [N-1:0] cfg_q;   // quasi-static source (config bit / mode reg)
@@ -359,7 +359,7 @@ Not yet:
 - [ ] CDC-006 refinements — comb-source severity tuning (downgrade for paths that hit a registered output before leaving the module)
 - [ ] CDC-007 refinements — recognise multi-source reset synchronizer trees and shared reset distribution networks
 - [ ] DFT / scan-mode awareness — exempt scan_en, scan_in, test-mode controls from CDC checks under a configurable scan-mode pragma
-- [ ] In-RTL pragma comments (`// rtl-buddy-cdc disable-rule …`, Spyglass-style block suppression) for inline waiving without an external file
+- [ ] In-RTL pragma comments (`// rtl-buddy-cdc disable-rule …`, in-file block suppression) for inline waiving without an external file
 - [ ] Instance-scoped waivers (`waive CDC-001 inst:u_block_a/.*`) — natural follow-on to hierarchical reporting now that `instance_path` is on every violation
 - [ ] Glitch detection on data path through async muxes / clock-gate enables
 

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -238,7 +238,7 @@ def _build_context(
 # Yosys preserves the attribute on the *netname* (not the cell), so
 # we map back from a tagged netname's bits to the flop whose Q
 # produces them. Multiple aliases are accepted so projects using
-# Spyglass-style or Vivado-style tags don't have to rename.
+# other common synthesis-attribute tags don't have to rename.
 USER_SYNC_ATTRS: frozenset[str] = frozenset({"cdc_sync", "synchronizer", "async_reg"})
 
 

--- a/src/rtl_buddy_cdc/waivers.py
+++ b/src/rtl_buddy_cdc/waivers.py
@@ -25,8 +25,8 @@ Matching:
 Waivers are applied *after* the rule pass: each ``Violation`` either
 survives or is moved into a ``suppressed`` list along with the
 matching waiver. They are not silent — the report keeps a tally and
-calls out the reason. This matches the Spyglass ``.swl`` workflow at
-a much smaller surface.
+calls out the reason. This matches the common ``.swl`` waiver-file
+workflow at a much smaller surface.
 """
 
 from __future__ import annotations

--- a/tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv
+++ b/tests/fixtures/good_disjoint_fanout_sync_chains/good_disjoint_fanout_sync_chains.sv
@@ -36,8 +36,9 @@ module good_disjoint_fanout_sync_chains (
 
     // Two independent synchronizer chains, fed by independent source
     // registers. This keeps the fixture focused on the "disjoint
-    // downstream cones" positive shape without tripping SpyGlass'
-    // multi-synchronized-control check on a single source flop.
+    // downstream cones" positive shape without tripping the
+    // reconvergent multi-synchronizer check (CDC-005) on a single
+    // source flop.
     logic sync_a_meta, sync_a_q;
     logic sync_b_meta, sync_b_q;
     always_ff @(posedge dst_clk or negedge rst_n) begin

--- a/tests/fixtures/marked_user_sync/README.md
+++ b/tests/fixtures/marked_user_sync/README.md
@@ -2,7 +2,7 @@
 
 <!-- generator: scripts/gen_fixture_docs.py -->
 
-Mark a conventional 2FF synchronizer with `(* cdc_sync *)` to declare the first stage as user-vetted. The structural depth keeps both rtl-buddy-cdc and SpyGlass clean; the attribute exercises the marker plumbing without relying on a single-stage waiver.
+Mark a conventional 2FF synchronizer with `(* cdc_sync *)` to declare the first stage as user-vetted. The two real flop stages keep the structural depth check (CDC-001/-002) clean; the attribute exercises the marker plumbing without relying on a single-stage waiver.
 
 - **Status:** marker — exercises an SV attribute (`cdc_sync` / `cdc_gray` / …)
 - **Top module:** `marked_user_sync`

--- a/tests/fixtures/marked_user_sync/marked_user_sync.sv
+++ b/tests/fixtures/marked_user_sync/marked_user_sync.sv
@@ -1,7 +1,8 @@
 // Mark a conventional 2FF synchronizer with `(* cdc_sync *)` to
-// declare the first stage as user-vetted. The structural depth keeps
-// both rtl-buddy-cdc and SpyGlass clean; the attribute exercises the
-// marker plumbing without relying on a single-stage waiver.
+// declare the first stage as user-vetted. The two real flop stages
+// keep the structural depth check (CDC-001/-002) clean; the attribute
+// exercises the marker plumbing without relying on a single-stage
+// waiver.
 
 module marked_user_sync (
     input  logic src_clk,

--- a/tests/test_marked_user_sync.py
+++ b/tests/test_marked_user_sync.py
@@ -65,5 +65,5 @@ def test_attribute_aliases() -> None:
 
     assert "cdc_sync" in USER_SYNC_ATTRS
     assert "synchronizer" in USER_SYNC_ATTRS
-    # Vivado-style alias for projects already using `(* ASYNC_REG *)`.
+    # common synthesis-attribute alias for projects already using `(* ASYNC_REG *)`.
     assert "async_reg" in USER_SYNC_ATTRS

--- a/wiki/concepts/waivers-and-reporting.md
+++ b/wiki/concepts/waivers-and-reporting.md
@@ -33,7 +33,7 @@ A hit on any of the three suppresses. First matching waiver wins (top-down).
 - Suppressed findings are **kept in the report** (with matching reason and waiver line number), not silently dropped
 - They appear in JSON output and in SARIF as `suppressions`
 - They **don't drive the exit code** — a fully-waived run returns 0
-- Deliberately mimics Spyglass `.swl` workflow at a smaller surface: no scope qualifiers, severity overrides, or expiry dates
+- Deliberately mimics the common `.swl` waiver-file workflow at a smaller surface: no scope qualifiers, severity overrides, or expiry dates
 
 ## Reporting
 

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -1693,7 +1693,7 @@ and waiver-line number), not silently dropped. They appear in JSON
 output and in SARIF as `suppressions`. They don't drive the exit
 code, so a fully-waived run returns 0.
 
-This deliberately mimics the Spyglass `.swl` workflow at a much
+This deliberately mimics the common `.swl` waiver-file workflow at a much
 smaller surface — no scope qualifiers, no severity overrides, no
 expiry dates. Add those when a real project asks for them, not
 preemptively.

--- a/wiki/raw/articles/rtl-buddy-cdc-reset-hints-schema.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-reset-hints-schema.md
@@ -179,7 +179,7 @@ Mirrored exactly by the test fixture
 - Analysis-side pipeline: [`rtl-buddy-cdc-reset-domain-analysis.md`](rtl-buddy-cdc-reset-domain-analysis.md) §8
   (SV attributes — same vocabulary, different surface).
 - Emit-map schema (consumer-facing): [`rtl-buddy-cdc-reset-domain-map-schema.md`](rtl-buddy-cdc-reset-domain-map-schema.md).
-- Migration utility from Spyglass SGDC: rtl-buddy-cdc#131
+- Migration utility from external SGDC-style constraint files: rtl-buddy-cdc#131
   (blocked on this issue / not yet implemented).
 - Loader module: `src/rtl_buddy_cdc/reset_hints.py`.
 - CLI wiring: `src/rtl_buddy_cdc/cli.py::_RESET_HINTS_OPT`.


### PR DESCRIPTION
## What

Replace references to third-party commercial EDA tool names in repository text with vendor-neutral / functional descriptions across docs, code comments, and fixture prose.

- Waiver format described as `.swl`-style (a functional file-format reference) rather than by a tool name.
- Synchronizer-attribute aliases described as "common synthesis-attribute" tags. The functional `async_reg` keyword itself is unchanged (it's an interop attribute name, not branding).
- README "Why" drops the named-competitor comparison list.
- Two fixtures describe their check by its own rule id (CDC-005, CDC-001/-002) instead of naming an external tool; the `marked_user_sync` README is regenerated from its fixture comment.

## Why

Consistency with the project's policy of not naming third-party tools in-repo. Text/comment-only.

## Scope / safety

- No analyzer logic changes; no netlist (`.json`) fixture changes.
- Full suite: **1981 passed, 8 skipped**; `mypy` and `ruff` (check + format) clean.