### PR TITLE
feat(pragma): scan in-RTL `// rbcdc:` disable-rule comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **In-RTL pragma scanner** (`rtl_buddy_cdc.pragma`, #41). A
+  suppression can be written next to the RTL it applies to instead of
+  in an external waiver file whose regexes chase synthesis-generated
+  cell names:
+
+  ```systemverilog
+  // rbcdc: disable-rule CDC-001
+  // rbcdc: disable-rule CDC-001,CDC-002  hand-reviewed handshake
+  /* rbcdc: disable-rule CDC-005 library cell */
+  ```
+
+  `rbcdc:` is this tool's magic-comment namespace (the org-wide
+  convention gives each rtl-buddy tool one — `rbsch:`, `rbxeno:`, …).
+  It is the only accepted spelling; there is no SV-attribute form.
+
+  `pragma.scan(sources)` reads the sources as **text** — never via
+  Yosys or slang — and returns ordinary `waivers.Waiver` records, one
+  per (pragma × rule id), scoped to the file's basename with the free
+  text after the rule list as the reason. `Waiver` gains an `origin`
+  field: `None` for a waiver-file entry (so `source_line` is a line in
+  that file), the source path for a pragma (so `source_line` is the
+  line of the pragma in the RTL).
+
+  This release is the **scanner only** — the records are not yet
+  applied to a run. Wiring them into `lint` lands with #42,
+  block-scoped `enable-rule` with #43.
+
 - **`--blackbox` now refuses a module that drives a clock output**
   (`CDC-BBX`, #273). The boundary-soundness check declined a candidate
   it could not prove single-clock, but happily *accepted* a single-clock

--- a/README.md
+++ b/README.md
@@ -267,6 +267,22 @@ Format: `waive <RULE-ID|*> <regex> [reason ...]`
 
 The regex is matched against the offending cell name, the canonical `"src_flop -> dst_flop"` text (when there's a crossing), and the violation message; a hit on any one suppresses. The first matching waiver wins. Suppressed findings are still reported (with the matching reason and waiver-line number) but don't drive the exit code, so a fully-waived run returns 0.
 
+## In-RTL pragmas
+
+A suppression can also be written next to the RTL it applies to, as a magic comment in the `rbcdc:` namespace (each rtl-buddy tool owns one — `rbsch:`, `rbxeno:`, …; there is no SV-attribute form and no alternative spelling):
+
+```systemverilog
+// rbcdc: disable-rule CDC-001
+// rbcdc: disable-rule CDC-001,CDC-002  hand-reviewed handshake
+/* rbcdc: disable-rule CDC-005 library cell */
+```
+
+Grammar: `// rbcdc: disable-rule <RULE-ID>[,<RULE-ID>…] [reason …]`, one pragma per line, in a `//` or `/* … */` comment. Each rule id in the list becomes its own waiver, scoped to the file the pragma is written in, with the free text after the rule list as the reason.
+
+Sources are scanned as **text** — never through Yosys or slang — so a pragma costs nothing and needs no frontend.
+
+> **This release ships the scanner only** (`rtl_buddy_cdc.pragma.scan`): pragmas are parsed into waiver records but not yet applied to a run. Wiring them into `lint` lands with the follow-on (issue #42), block-scoped `enable-rule` with issue #43.
+
 ## SV attributes
 
 Mark a flop as a user-vetted synchronizer first stage by attaching an attribute to the wire/reg it drives:
@@ -351,6 +367,7 @@ src/rtl_buddy_cdc/
   rules.py      # CDC-001..-008 + RULES registry
   primitives.py # Sanctioned CDC macro registry (xpm_cdc_*) + depth params
   waivers.py    # Waiver file parser + apply()
+  pragma.py     # In-RTL `// rbcdc:` pragma scanner
   reporter.py   # text / JSON / SARIF formatters
 tests/
   fixtures/
@@ -399,7 +416,7 @@ Not yet:
 - [ ] CDC-006 refinements — comb-source severity tuning (downgrade for paths that hit a registered output before leaving the module)
 - [ ] CDC-007 refinements — recognise multi-source reset synchronizer trees and shared reset distribution networks
 - [ ] DFT / scan-mode awareness — exempt scan_en, scan_in, test-mode controls from CDC checks under a configurable scan-mode pragma
-- [ ] In-RTL pragma comments (`// rtl-buddy-cdc disable-rule …`, in-file block suppression) for inline waiving without an external file
+- [ ] In-RTL pragma comments (`// rbcdc: disable-rule …`, in-file block suppression) for inline waiving without an external file — scanner landed (see [In-RTL pragmas](#in-rtl-pragmas)); application and block scoping pending
 - [ ] Instance-scoped waivers (`waive CDC-001 inst:u_block_a/.*`) — natural follow-on to hierarchical reporting now that `instance_path` is on every violation
 - [ ] Glitch detection on data path through async muxes / clock-gate enables
 

--- a/src/rtl_buddy_cdc/pragma.py
+++ b/src/rtl_buddy_cdc/pragma.py
@@ -1,0 +1,103 @@
+"""In-RTL pragma comments — an inline alternative to the waiver file.
+
+Instead of maintaining an external ``cdc.waivers`` whose regexes are
+matched against synthesis-generated cell names (brittle: the names
+shift between synth runs), a suppression can be written next to the
+RTL it applies to::
+
+    // rbcdc: disable-rule CDC-001
+    // rbcdc: disable-rule CDC-001,CDC-002 hand-reviewed handshake
+    /* rbcdc: disable-rule CDC-001 hand-reviewed */ logic q;
+
+``rbcdc:`` is the tool's magic-comment namespace (each rtl-buddy tool
+owns one: ``rbsch:``, ``rbxeno:``, …). It is the only accepted
+spelling — there are no aliases, and no SV-attribute form.
+
+Grammar of a recognised pragma:
+
+``//`` or ``/*``, optional space, ``rbcdc:``, ``disable-rule``, a
+comma-separated list of rule ids (or ``*``), then optional free text
+captured as the reason. A trailing ``*/`` is stripped from the reason
+of the block-comment form. One pragma per line; the pragma must fit on
+one line.
+
+This module is deliberately **text-only**: the sources are read with
+``Path.read_text``, never handed to Yosys or slang. A pragma therefore
+survives elaboration failures, costs nothing, and needs no frontend.
+
+Each pragma is turned into an ordinary :class:`rtl_buddy_cdc.waivers.Waiver`
+so the existing application path (:func:`rtl_buddy_cdc.waivers.apply`)
+and the existing report rendering carry it for free:
+
+- ``rule_pattern`` — one waiver per rule id in the list.
+- ``regex`` — the source file's basename, escaped. File scope: the
+  pragma covers findings the analyzer attributes to this file.
+- ``reason`` — the free text after the rule list.
+- ``source_line`` — the **line in the SV file**, not a waiver-file
+  line; ``origin`` (the file path) is what tells the two apart.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from rtl_buddy_cdc.waivers import Waiver
+
+# ``//`` or ``/*`` — the pragma is a comment, never bare code. The rule
+# list is comma-separated; everything after it on the line is the
+# reason.
+_RULE = r"[A-Za-z0-9_-]+|\*"
+_PRAGMA_RE = re.compile(
+    r"(?://|/\*)\s*rbcdc:\s*disable-rule\s+"
+    rf"(?P<rules>(?:{_RULE})(?:\s*,\s*(?:{_RULE}))*)"
+    r"(?P<reason>.*)$"
+)
+
+
+def _clean_reason(raw: str) -> str:
+    """Trim the free-text tail: whitespace plus the block-comment
+    terminator when the pragma was written as ``/* … */``."""
+    reason = raw.strip()
+    if reason.endswith("*/"):
+        reason = reason[:-2].strip()
+    return reason
+
+
+def _file_pattern(path: Path) -> re.Pattern[str]:
+    """File scope: match the file's basename verbatim."""
+    return re.compile(re.escape(path.name))
+
+
+def scan_text(text: str, path: Path) -> list[Waiver]:
+    """Scan one already-read source *text*, attributed to *path*."""
+    out: list[Waiver] = []
+    file_regex = _file_pattern(path)
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        m = _PRAGMA_RE.search(line)
+        if m is None:
+            continue
+        reason = _clean_reason(m.group("reason"))
+        # The rule-list group is anchored on the token pattern, so every
+        # comma-separated element is a non-empty rule id after stripping.
+        for rule in (r.strip() for r in m.group("rules").split(",")):
+            out.append(
+                Waiver(
+                    rule_pattern=rule,
+                    regex=file_regex,
+                    reason=reason,
+                    source_line=lineno,
+                    origin=str(path),
+                )
+            )
+    return out
+
+
+def scan(source_files: list[Path]) -> list[Waiver]:
+    """Read each source file as text and return one waiver per
+    (pragma × rule id), in file order then line order."""
+    out: list[Waiver] = []
+    for src in source_files:
+        p = Path(src)
+        out.extend(scan_text(p.read_text(encoding="utf-8", errors="replace"), p))
+    return out

--- a/src/rtl_buddy_cdc/waivers.py
+++ b/src/rtl_buddy_cdc/waivers.py
@@ -54,7 +54,13 @@ class Waiver:
     rule_pattern: str  # exact rule id, a legacy alias, or "*"
     regex: re.Pattern[str]
     reason: str
-    source_line: int  # 1-based line in the waiver file (for diagnostics)
+    source_line: int  # 1-based line in the file below (for diagnostics)
+    # Where the waiver was written. ``None`` for a waiver-file entry
+    # (``source_line`` is then a line in that waiver file). A path
+    # means the waiver came from an in-RTL ``// rbcdc:`` pragma in that
+    # source file, and ``source_line`` is the line of the pragma —
+    # see :mod:`rtl_buddy_cdc.pragma`.
+    origin: str | None = None
 
 
 def parse(text: str) -> list[Waiver]:

--- a/tests/test_pragma.py
+++ b/tests/test_pragma.py
@@ -1,0 +1,136 @@
+"""In-RTL pragma scanner tests (issue #41).
+
+Phase 1 is the scanner alone: it turns ``// rbcdc: disable-rule …``
+magic comments into :class:`rtl_buddy_cdc.waivers.Waiver` records.
+Nothing is applied to a rule run here — that's phase 2.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rtl_buddy_cdc import pragma
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    p = tmp_path / name
+    p.write_text(body)
+    return p
+
+
+def test_scan_line_comment_single_rule(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "dut.sv",
+        """module dut(input logic clk, input logic d, output logic q);
+  // rbcdc: disable-rule CDC-001
+  always_ff @(posedge clk) q <= d;
+endmodule
+""",
+    )
+    waivers = pragma.scan([src])
+    assert len(waivers) == 1
+    w = waivers[0]
+    assert w.rule_pattern == "CDC-001"
+    assert w.source_line == 2
+    assert w.origin == str(src)
+    assert w.reason == ""
+    # File scope: the compiled regex matches the file's basename.
+    assert w.regex.search("/somewhere/else/dut.sv:12.3-12.9")
+    assert not w.regex.search("/somewhere/other.sv:1")
+
+
+def test_scan_multi_rule_expands(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "multi.sv",
+        "// rbcdc: disable-rule CDC-001,CDC-002 hand-reviewed handshake\n",
+    )
+    waivers = pragma.scan([src])
+    assert [w.rule_pattern for w in waivers] == ["CDC-001", "CDC-002"]
+    assert {w.reason for w in waivers} == {"hand-reviewed handshake"}
+    assert {w.source_line for w in waivers} == {1}
+
+
+def test_scan_multi_rule_tolerates_spaces(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "spaced.sv",
+        "//rbcdc: disable-rule CDC-001 , RDC-001 , CDC-BBX  spaced out\n",
+    )
+    waivers = pragma.scan([src])
+    assert [w.rule_pattern for w in waivers] == ["CDC-001", "RDC-001", "CDC-BBX"]
+    assert waivers[0].reason == "spaced out"
+
+
+def test_scan_block_comment_strips_terminator(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "block.sv",
+        "logic q;  /* rbcdc: disable-rule CDC-005 library cell */\n",
+    )
+    (w,) = pragma.scan([src])
+    assert w.rule_pattern == "CDC-005"
+    assert w.reason == "library cell"
+
+
+def test_scan_block_comment_without_reason(tmp_path: Path) -> None:
+    src = _write(tmp_path, "bare.sv", "/* rbcdc: disable-rule CDC-005 */\n")
+    (w,) = pragma.scan([src])
+    assert w.reason == ""
+
+
+def test_scan_wildcard_rule(tmp_path: Path) -> None:
+    src = _write(tmp_path, "star.sv", "// rbcdc: disable-rule * generated code\n")
+    (w,) = pragma.scan([src])
+    assert w.rule_pattern == "*"
+    assert w.reason == "generated code"
+
+
+def test_scan_ignores_unrelated_comments(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "noise.sv",
+        """// a plain comment
+// rbcdc: enable-rule CDC-001
+// rbsch: disable-rule CDC-001
+// rtl-buddy-cdc disable-rule CDC-001
+(* cdc_sync *) logic q;
+disable-rule CDC-001
+// rbcdc: disable-rule
+""",
+    )
+    assert pragma.scan([src]) == []
+
+
+def test_scan_records_every_pragma_across_files(tmp_path: Path) -> None:
+    a = _write(
+        tmp_path,
+        "a.sv",
+        "// rbcdc: disable-rule CDC-001 first\n\n// rbcdc: disable-rule CDC-004\n",
+    )
+    b = _write(tmp_path, "b.sv", "// rbcdc: disable-rule CDC-013 second\n")
+    waivers = pragma.scan([a, b])
+    assert [
+        (w.rule_pattern, w.source_line, Path(w.origin or "").name) for w in waivers
+    ] == [
+        ("CDC-001", 1, "a.sv"),
+        ("CDC-004", 3, "a.sv"),
+        ("CDC-013", 1, "b.sv"),
+    ]
+
+
+def test_scan_text_is_path_attributed() -> None:
+    """``scan_text`` takes already-read text; the path is only used for
+    the file-scope regex and the ``origin`` label."""
+    (w,) = pragma.scan_text("// rbcdc: disable-rule CDC-001\n", Path("rtl/top.sv"))
+    assert w.origin == "rtl/top.sv"
+    assert w.regex.pattern == r"top\.sv"
+
+
+def test_scan_tolerates_undecodable_bytes(tmp_path: Path) -> None:
+    src = tmp_path / "latin.sv"
+    src.write_bytes(b"// caf\xe9\n// rbcdc: disable-rule CDC-001 ok\n")
+    (w,) = pragma.scan([src])
+    assert w.rule_pattern == "CDC-001"
+    assert w.source_line == 2


### PR DESCRIPTION
## Summary

Closes rtl-buddy/rtl-buddy-cdc#41 — phase 1 of in-RTL pragma comments: scanner + waiver extraction only, no rule-pack behavior change (that lands in the follow-on PR for #42).

## Syntax note — deviates deliberately from the issue text

The issue (written before the 2026-08-18 org convention) sketched `// rtl-buddy-cdc disable-rule …`. All rtl-buddy in-source pragmas are now magic comments namespaced `// rb<tool>:` (rtl-buddy-sch owns `rbsch:`; this tool owns `rbcdc:`). Implemented canonical form, **no aliases, no SV-attribute form**:

    // rbcdc: disable-rule CDC-001[,CDC-002] [optional reason]
    /* rbcdc: disable-rule CDC-001 reason */

## Design

- New `pragma.py`: `scan(source_files) -> list[Waiver]` reads sources as **text** (`Path.read_text`, never a frontend) — survives elaboration failures, costs nothing. `scan_text(text, path)` is the injectable core.
- Reuses `waivers.Waiver` with one new field, `origin: str | None` — `None` = waiver-file entry, a path = the pragma's source file, which is what makes `source_line` interpretable (SV line vs waiver-file line).
- Multi-rule pragmas expand to one `Waiver` per id; free text after the rule list becomes `reason`; `regex` is the escaped file basename per the issue's phase-1 spec.
- 10 unit tests on tmp_path SV strings. Not wired into the CLI yet.

## Validation

`ruff check` / `ruff format --check` / `mypy` clean; `pytest --cov --cov-fail-under=96`: **2091 passed, 8 skipped**, 97.39%.

---
Stacked on #282; series … #273 → **#41** → #42 → #43 → …

🤖 Generated with [Claude Code](https://claude.com/claude-code)
