### PR TITLE
feat(dft): recognise scan-mode attributes on top-level input ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clocks and previously reported clean (bar an unexplained
   `domain_unknown` count) will now report a CDC-023 `warning`.
 
+- **DFT / scan-mode SV attribute recognition** (#44) — *patch:
+  recognition only, no behaviour change.* `SCAN_MODE_ATTRS`
+  (`scan_en` / `scan_mode` / `test_mode` / `dft_scan_en`, matched
+  case-insensitively) and `rules.scan_mode_port_names(module)` name the
+  top-level input ports a DFT insertion flow marks as test-mode
+  controls — the select of the classic scan clock mux
+  `$mux(S=scan_en, A=func_clk, B=scan_clk)` that mixes two async clocks
+  into one `CLK` net and makes every crossing behind it read as a CDC
+  failure.
+
+  Nothing in the rule pack consults the helper yet, so **no fixture's
+  findings move**; issue #45 wires it in behind an opt-in
+  `--ignore-scan-mode`. Deliberately split: the recognition is
+  uncontroversial, the suppression is a soundness decision that
+  deserves its own review.
+
+  Both frontends already carry the attribute through — Yosys preserves
+  a declaration attribute on the input port's netname, and the slang
+  frontend's `_collect_port` forwards `PortSymbol` attributes onto the
+  same netname (the #38 fix, which happened to cover inputs as well as
+  outputs). Pinned for inputs specifically by
+  `test_slang_lowering.py::test_input_port_scan_mode_attribute_reaches_netname`,
+  so a frontend regression can't silently make the recognition a
+  Yosys-only feature.
+
 ### Fixed
 
 - **CDC-011 now sees an untyped sync reset on a dedicated `SRST` pin**

--- a/src/rtl_buddy_cdc/rules.py
+++ b/src/rtl_buddy_cdc/rules.py
@@ -508,6 +508,61 @@ def user_glitchless_clock_mux_bits(module: Module) -> set[Bit]:
     return out
 
 
+# DFT / scan-mode declaration (issue #44). Attach to the top-level
+# *input port* that carries the test-mode / scan-enable signal::
+#
+#     (* scan_en *) input logic scan_en,
+#
+# The classic shape it names is the DFT clock mux — ``$mux(S=scan_en,
+# A=func_clk, B=scan_clk)`` — wedged in front of a flop's ``CLK`` so
+# the scan chain can shift on a dedicated tester clock. Structurally
+# that mux mixes two asynchronous clocks into one net, so the
+# crossings behind it read as ordinary CDC failures even though the
+# two modes are mutually exclusive in time and the scan path is never
+# exercised in functional operation.
+#
+# Recognition only in this phase: nothing consults the helper yet, so
+# no fixture's findings move. Issue #45 wires it into the rule pack
+# behind an opt-in ``--ignore-scan-mode`` flag — deliberately opt-in,
+# because a DFT structure that is genuinely live in mission mode is a
+# real hazard and silently dropping it would be unsound.
+#
+# Attribute names are matched **case-insensitively**, following
+# :func:`user_sync_flop_names` (#275): DFT signal names arrive from
+# vendor / insertion-tool flows in every case convention
+# (``SCAN_EN``, ``ScanEn``, ``test_mode``), and a case-sensitive match
+# would silently miss the majority of them.
+SCAN_MODE_ATTRS: frozenset[str] = frozenset(
+    {"scan_en", "scan_mode", "test_mode", "dft_scan_en"}
+)
+
+
+def scan_mode_port_names(module: Module) -> set[str]:
+    """Return the names of top-level **input ports** whose netname
+    carries one of the :data:`SCAN_MODE_ATTRS`.
+
+    Same attribute-on-netname mechanics as the ``user_*`` helpers
+    above — Yosys preserves a declaration attribute on the netname,
+    not on the cell — with the ``user_reset_polarity_overrides``
+    restriction to *ports*: a scan-enable is by definition an external
+    test-mode pin, and an internal net carrying the attribute conveys
+    nothing the rule pack can act on, so it is ignored rather than
+    guessed at.
+
+    Attribute **values** are not consulted; presence is the whole
+    signal (``(* scan_en *)`` and ``(* scan_en = "1" *)`` are the
+    same declaration).
+    """
+    port_names = {p.name for p in module.ports.values() if p.direction == "input"}
+    out: set[str] = set()
+    for nn_name, nn in module.netnames.items():
+        if nn_name not in port_names:
+            continue
+        if SCAN_MODE_ATTRS & {a.lower() for a in nn.attributes}:
+            out.add(nn_name)
+    return out
+
+
 # Reset-port polarity declaration (issue #107). Attach to a top-level
 # reset port to assert "this signal is active-<low|high>" regardless of
 # what Yosys infers from a downstream flop's edge sensitivity. Consumed

--- a/tests/test_scan_mode_attrs.py
+++ b/tests/test_scan_mode_attrs.py
@@ -1,0 +1,103 @@
+"""Recognition of the DFT / scan-mode SV attributes (issue #44).
+
+Phase 1 is **recognition only**: :data:`~rtl_buddy_cdc.rules.SCAN_MODE_ATTRS`
+and :func:`~rtl_buddy_cdc.rules.scan_mode_port_names` name the ports a
+DFT insertion flow marks, and nothing in the rule pack consults them
+yet. The paired suppression behaviour lands in issue #45, so these
+tests pin the helper's contract in isolation — hand-built ``Module``
+dataclasses, no fixture, no toolchain — in the self-contained style of
+``tests/test_cov_rules_c.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rtl_buddy_cdc.netlist import Cell, Module, Netname, Port
+from rtl_buddy_cdc.rules import SCAN_MODE_ATTRS, scan_mode_port_names
+
+
+def _module_with(
+    *,
+    port_attrs: dict[str, str] | None = None,
+    internal_attrs: dict[str, str] | None = None,
+    direction: str = "input",
+) -> Module:
+    """A one-port, one-flop design whose ``scan_en`` port and internal
+    ``muxed_clk`` net carry the attributes under test."""
+    scan_en, func_clk, d, q = 1, 2, 3, 4
+    return Module(
+        name="m",
+        ports={
+            "func_clk": Port(name="func_clk", direction="input", bits=(func_clk,)),
+            "scan_en": Port(name="scan_en", direction=direction, bits=(scan_en,)),
+        },
+        cells={
+            "f": Cell(
+                name="f",
+                type="$dff",
+                connections={"CLK": (func_clk,), "D": (d,), "Q": (q,)},
+            ),
+        },
+        netnames={
+            "func_clk": Netname(name="func_clk", bits=(func_clk,), attributes={}),
+            "scan_en": Netname(
+                name="scan_en", bits=(scan_en,), attributes=port_attrs or {}
+            ),
+            "muxed_clk": Netname(
+                name="muxed_clk", bits=(9,), attributes=internal_attrs or {}
+            ),
+        },
+    )
+
+
+def test_scan_en_on_input_port_is_recognised() -> None:
+    """The headline case: ``(* scan_en *) input logic scan_en`` — Yosys
+    lands the attribute on the port's netname, and the helper reports
+    the port name."""
+    module = _module_with(port_attrs={"scan_en": "1"})
+    assert scan_mode_port_names(module) == {"scan_en"}
+
+
+@pytest.mark.parametrize("attr", sorted(SCAN_MODE_ATTRS))
+def test_every_declared_alias_is_recognised(attr: str) -> None:
+    """Each member of ``SCAN_MODE_ATTRS`` is honoured, not just the
+    canonical ``scan_en`` spelling."""
+    module = _module_with(port_attrs={attr: "1"})
+    assert scan_mode_port_names(module) == {"scan_en"}
+
+
+@pytest.mark.parametrize("spelling", ["SCAN_EN", "Scan_En", "TEST_MODE"])
+def test_attribute_name_match_is_case_insensitive(spelling: str) -> None:
+    """DFT insertion flows spell the signal in every case convention;
+    the match follows ``user_sync_flop_names`` (#275) and lowercases."""
+    module = _module_with(port_attrs={spelling: "TRUE"})
+    assert scan_mode_port_names(module) == {"scan_en"}
+
+
+def test_attribute_on_a_non_port_net_does_not_count() -> None:
+    """A scan attribute on an internal net conveys nothing the rule
+    pack can act on — a scan-enable is by definition an external
+    test-mode pin — so it is ignored rather than guessed at."""
+    module = _module_with(internal_attrs={"scan_en": "1"})
+    assert scan_mode_port_names(module) == set()
+
+
+def test_attribute_on_an_output_port_does_not_count() -> None:
+    """Only *input* ports qualify, mirroring
+    ``user_reset_polarity_overrides``' port-direction filter."""
+    module = _module_with(port_attrs={"scan_en": "1"}, direction="output")
+    assert scan_mode_port_names(module) == set()
+
+
+def test_no_attributes_yields_empty_set() -> None:
+    """The overwhelmingly common case — a design with no DFT
+    annotation at all — costs nothing and reports nothing."""
+    assert scan_mode_port_names(_module_with()) == set()
+
+
+def test_unrelated_attribute_on_a_port_is_ignored() -> None:
+    """A port carrying some *other* attribute (``reset_polarity``, a
+    Yosys ``src`` stamp) is not a scan port."""
+    module = _module_with(port_attrs={"reset_polarity": "low", "src": "t.sv:4"})
+    assert scan_mode_port_names(module) == set()

--- a/tests/test_slang_lowering.py
+++ b/tests/test_slang_lowering.py
@@ -29,6 +29,7 @@ from pathlib import Path
 import pytest
 
 from rtl_buddy_cdc.frontend import Frontend, elaborate
+from rtl_buddy_cdc.rules import scan_mode_port_names
 
 PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
 if not PYSLANG_INSTALLED:
@@ -467,6 +468,31 @@ endmodule
 """
     module = _elaborate_full(tmp_path, src)
     assert "cdc_sync" in module.netnames["q"].attributes
+
+
+def test_input_port_scan_mode_attribute_reaches_netname(tmp_path: Path) -> None:
+    """``(* scan_en *)`` on a top-level **input** port must reach the
+    netname too (issue #44). ``scan_mode_port_names`` reads it off the
+    port's netname exactly as the ``user_*`` helpers read ``cdc_sync``
+    off a flop's, so the two frontends have to agree: Yosys preserves
+    the declaration attribute on the input wire, and
+    ``_collect_port`` forwards the ``PortSymbol`` attributes onto the
+    internal variable's netname to match. Without this the DFT
+    recognition would work under ``analyze`` and silently do nothing
+    under ``lint --frontend slang``."""
+    src = """module m (
+    input  logic func_clk, scan_clk, d,
+    (* scan_en *) input logic scan_en,
+    output logic q
+);
+    logic clk;
+    assign clk = scan_en ? scan_clk : func_clk;
+    always_ff @(posedge clk) q <= d;
+endmodule
+"""
+    module = _elaborate_full(tmp_path, src)
+    assert "scan_en" in module.netnames["scan_en"].attributes
+    assert scan_mode_port_names(module) == {"scan_en"}
 
 
 def test_comb_cells_carry_src_attribute(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes rtl-buddy/rtl-buddy-cdc#44 — DFT phase 1: recognition only, no rule consults the helper yet (that's the follow-on PR for #45).

- `SCAN_MODE_ATTRS = {scan_en, scan_mode, test_mode, dft_scan_en}` beside `USER_SYNC_ATTRS`/`USER_GRAY_ATTRS`.
- `scan_mode_port_names(module)` — top-level **input** ports whose netname carries any of the attributes; mechanics copied from `user_sync_flop_names` (netname walk) + `user_reset_polarity_overrides` (direction filter). Matching is **case-insensitive**, following the newer `user_sync_flop_names` convention — DFT tools emit `SCAN_EN`/`ScanEn`.
- 12 tests: headline `(* scan_en *)` case, each alias, case-insensitivity, non-port net / output port / no attrs / unrelated attr all → empty.

**Frontend dependency (the issue asked)**: verified empirically on both frontends — Yosys preserves the attribute on the port netname, and slang's `_collect_port` forwards `PortSymbol` attributes (the #38 fix covers inputs too). Pinned by a new `test_slang_lowering.py` regression test so this can't silently go Yosys-only.

## Validation
`ruff` / `format --check` / `mypy` clean; **2165 passed, 8 skipped**, 97.45%.

---
Stacked on #286; series … #261 → **#44** → #45 (end of stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
