### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -378,6 +378,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **slang frontend emitted `$mux` legs swapped** (#289) — *silent false
+  negatives on the `--frontend slang` path.* Yosys' `$mux` cell is
+  `Y = S ? B : A`: pin `A` is the `S=0` leg and pin `B` the `S=1` leg, so
+  `y = s ? a : b` must lower to `$mux(A=b, B=a, S=s)`. The slang
+  frontend's `ConditionalExpression` lowering preserved *source* order
+  (`A=a, B=b`) instead, leaving both legs swapped and the select polarity
+  inverted relative to the Yosys frontend on the very same RTL.
+
+  Nothing failed loudly, because the rule pack reads mux legs
+  **positionally** and simply believed what it was given:
+  `domain.trace_clock_root`'s clock-mux clause returns the first of
+  `A`, `B` that resolves to a clock, and CDC-012's mux-gating detection
+  and `_is_gated_bus_crossing` inspect the data legs the same way. On a
+  textbook DFT clock mux the result was a **missed finding, reported as
+  a pass**: `lint --frontend slang` over `tests/fixtures/good_scan_mode_ignored/`
+  resolved the destination flop's clock to the *other* leg, put source
+  and destination in one domain, and reported 0 crossings — where the
+  Yosys build of the identical design reports 1× CDC-001.
+
+  The three statement-level `$mux` emitters (`always_comb` `if`/`else`,
+  `always_comb` `case`, and the `always_ff` hold-feedback mux from
+  `_build_hold_mux`) were audited in the same pass and were already
+  correct; they are now pinned by tests. New guards: a cross-frontend
+  `$mux` pin oracle in `tests/test_slang_lowering.py` (gated on `yosys`
+  on `PATH`) and an end-to-end slang-vs-committed-Yosys-netlist parity
+  check on the scan-mode fixture in `tests/test_scan_mode_suppression.py`.
+
 - **CDC-011 now sees an untyped sync reset on a dedicated `SRST` pin**
   (#272). Whether a missing `set_input_delay -clock` on a *synchronous*
   reset got reported depended on a synthesis-pass detail. The crossing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-08-24
+
 ### Added
 
 - **Compositional per-module boundary analysis** (#261) — *minor:
@@ -1776,7 +1778,9 @@ shlex-based SDC subset (`create_clock`, `create_generated_clock`,
 through CDC-008 rule pack, `.swl`-style waiver matcher,
 and text / JSON / SARIF reporters.
 
-[Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/rtl-buddy/rtl-buddy-cdc/compare/v0.3.0...v0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rtl-buddy-cdc"
-version = "0.4.0"
+version = "0.5.0"
 description = "CDC (clock domain crossing) linting tool for RTL designs, with pluggable Yosys or slang (pyslang) frontend; integrates with rtl-buddy."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/rtl_buddy_cdc/frontends/slang.py
+++ b/src/rtl_buddy_cdc/frontends/slang.py
@@ -83,7 +83,10 @@ What currently works
   / :meth:`_lower_unary` / :meth:`_lower_conditional`. Pyslang
   expression operators round-trip to the Yosys cell zoo
   (``$and``/``$or``/``$xor``/``$mux``/…), so the rule pack walks
-  the comb cone correctly.
+  the comb cone correctly. Pin *order* is part of that contract:
+  Yosys' ``$mux`` is ``Y = S ? B : A``, so a ternary's FALSE branch
+  goes on ``A`` and its TRUE branch on ``B`` — see
+  :meth:`_lower_conditional` and issue #289.
 - ``always_comb`` procedural ``if`` / ``case`` selection — see
   :meth:`_walk_conditional_statement` and
   :meth:`_walk_case_statement`. Each LHS written across multiple
@@ -2286,17 +2289,25 @@ class _ModuleBuilder:
         if not conds:
             return None
         sel_bits = self._bits_of_expression(conds[0].expr)
-        a_bits = self._bits_of_expression(expr.left)
-        b_bits = self._bits_of_expression(expr.right)
-        if sel_bits is None or a_bits is None or b_bits is None:
+        # pyslang names the branches from source order: ``left`` is the
+        # TRUE branch of ``s ? left : right``, ``right`` the FALSE one.
+        true_bits = self._bits_of_expression(expr.left)
+        false_bits = self._bits_of_expression(expr.right)
+        if sel_bits is None or true_bits is None or false_bits is None:
             return None
-        width = self._expr_width(expr) or max(len(a_bits), len(b_bits))
-        # Yosys ``$mux`` selects between A (sel=0) and B (sel=1); same
-        # convention we use here. The S pin takes the (single-bit)
+        width = self._expr_width(expr) or max(len(true_bits), len(false_bits))
+        # Yosys ``$mux`` is ``Y = S ? B : A`` — ``A`` is the S=0 leg and
+        # ``B`` the S=1 leg. Source order is therefore NOT the pin order:
+        # the ternary's FALSE branch goes on ``A`` and its TRUE branch on
+        # ``B``. Emitting them the other way round leaves the legs
+        # swapped relative to the Yosys frontend, and every positional
+        # consumer (``trace_clock_root``'s clock-mux clause, CDC-012's
+        # gating detection, ``_is_gated_bus_crossing``) then reads the
+        # wrong leg — see issue #289. The S pin takes the (single-bit)
         # selector.
         return self._emit_comb_cell(
             cell_type="$mux",
-            inputs={"A": a_bits, "B": b_bits, "S": sel_bits[:1]},
+            inputs={"A": false_bits, "B": true_bits, "S": sel_bits[:1]},
             output_width=width,
             src_node=expr,
         )

--- a/src/rtl_buddy_cdc/reporter.py
+++ b/src/rtl_buddy_cdc/reporter.py
@@ -27,7 +27,7 @@ from rtl_buddy_cdc.sdc import ClockSpec
 from rtl_buddy_cdc.waivers import SuppressedViolation, Waiver
 
 TOOL_NAME = "rtl-buddy-cdc"
-TOOL_VERSION = "0.4.0"
+TOOL_VERSION = "0.5.0"
 TOOL_INFO_URI = "https://github.com/rtl-buddy/rtl-buddy-cdc"
 
 # JSON output schema contract — these dotted keys are PUBLIC API.

--- a/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.reset-domain-map.json
+++ b/tests/fixtures/bad_marked_reset_polarity/bad_marked_reset_polarity.reset-domain-map.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "generator": {
     "name": "rtl-buddy-cdc",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "design": {
     "top": "bad_marked_reset_polarity",

--- a/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
+++ b/tests/fixtures/ip_cdc_handshake/ip_cdc_handshake.domain-map.json
@@ -2,7 +2,7 @@
   "schema_version": "1.1",
   "generator": {
     "name": "rtl-buddy-cdc",
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "design": {
     "top": "ip_cdc_handshake",

--- a/tests/test_scan_mode_suppression.py
+++ b/tests/test_scan_mode_suppression.py
@@ -27,11 +27,13 @@ annotation.
 
 from __future__ import annotations
 
+import importlib.util
 import io
 import json
 from pathlib import Path
 
 import click
+import pytest
 import typer.main
 from typer.testing import CliRunner
 
@@ -330,3 +332,105 @@ def test_flag_is_exposed_on_both_commands() -> None:
         assert command is not None, name
         decls = {decl for p in command.params for decl in p.opts}
         assert "--ignore-scan-mode" in decls, name
+
+
+# --- slang-frontend parity (issue #289) ------------------------------------
+#
+# This fixture is the sharpest end-to-end probe for the ``$mux`` A/B pin
+# convention. Its whole point is a clock mux — ``scan_en ? scan_clk :
+# func_clk`` — and ``trace_clock_root`` resolves such a mux by returning
+# the *first* leg (``A``, then ``B``) that resolves to a clock. Emit the
+# legs swapped and the destination flop lands in ``scan_clk``, the same
+# domain as its source: no crossing, no CDC-001, a silent false negative
+# with a PASS report. Before #289 that is exactly what
+# ``lint --frontend slang`` produced here while the Yosys build reported
+# 1× CDC-001.
+
+PYSLANG_INSTALLED = importlib.util.find_spec("pyslang") is not None
+
+pyslang_only = pytest.mark.skipif(
+    not PYSLANG_INSTALLED,
+    reason="pyslang not installed — slang-frontend parity is gated on it",
+)
+
+
+def _cli_json(
+    tmp_path: Path, argv: list[str], name: str = "report"
+) -> tuple[int, dict]:
+    """Run the CLI with JSON output into ``tmp_path`` and return
+    ``(exit_code, report)``."""
+    out = tmp_path / f"{name}.json"
+    result = runner.invoke(app, [*argv, "--format", "json", "--output", str(out)])
+    assert out.exists(), result.output
+    return result.exit_code, json.loads(out.read_text())
+
+
+def _rule_ids(report: dict) -> list[str]:
+    return sorted(v["rule_id"] for v in report["violations"])
+
+
+@pyslang_only
+def test_slang_lint_matches_the_committed_yosys_netlist(tmp_path: Path) -> None:
+    """``lint --frontend slang`` on the ``.sv`` must reach the same
+    verdict as ``analyze`` on the committed Yosys ``.json`` — 1×
+    CDC-001, exit 1 — and the same one crossing."""
+    json_path, sdc_path = _paths(GOOD)
+    sv_path = json_path.with_suffix(".sv")
+
+    yosys_code, yosys_report = _cli_json(
+        tmp_path,
+        ["analyze", "--netlist", str(json_path), "--sdc", str(sdc_path)],
+        name="yosys",
+    )
+    slang_code, slang_report = _cli_json(
+        tmp_path,
+        [
+            "lint",
+            "--frontend",
+            "slang",
+            "--top",
+            GOOD,
+            "--sdc",
+            str(sdc_path),
+            str(sv_path),
+        ],
+        name="slang",
+    )
+
+    assert _rule_ids(yosys_report) == ["CDC-001"], yosys_report
+    assert _rule_ids(slang_report) == _rule_ids(yosys_report), (
+        "slang frontend disagrees with the committed Yosys netlist; "
+        f"slang={_rule_ids(slang_report)} yosys={_rule_ids(yosys_report)}"
+    )
+    assert (
+        slang_report["summary"]["crossings"] == (yosys_report["summary"]["crossings"])
+    ), (slang_report["summary"], yosys_report["summary"])
+    assert slang_code == yosys_code == 1
+
+
+@pyslang_only
+def test_slang_lint_is_clean_with_the_flag(tmp_path: Path) -> None:
+    """The other half of the fixture's contract on the slang path: the
+    crossing is found, tagged, and then suppressed by the flag — not
+    absent. A frontend that never found it would also exit 0 here, which
+    is why the previous test pins the without-flag finding."""
+    json_path, sdc_path = _paths(GOOD)
+    sv_path = json_path.with_suffix(".sv")
+    code, report = _cli_json(
+        tmp_path,
+        [
+            "lint",
+            "--frontend",
+            "slang",
+            "--ignore-scan-mode",
+            "--top",
+            GOOD,
+            "--sdc",
+            str(sdc_path),
+            str(sv_path),
+        ],
+    )
+    assert code == 0, report
+    assert report["violations"] == []
+    assert report["summary"]["crossings"] == 1
+    assert report["summary"]["scan_mode_suppressed"] == 1

--- a/tests/test_slang_lowering.py
+++ b/tests/test_slang_lowering.py
@@ -24,6 +24,7 @@ part of the same commit.
 from __future__ import annotations
 
 import importlib.util
+import shutil
 from pathlib import Path
 
 import pytest
@@ -512,3 +513,94 @@ endmodule
     assert src_attr.endswith(".sv:5.16-5.21") or src_attr.endswith(".sv:5.17-5.22"), (
         f"unexpected src range: {src_attr!r}"
     )
+
+
+# --- $mux pin convention (issue #289) -------------------------------------
+#
+# Yosys' ``$mux`` cell is ``Y = S ? B : A``: pin ``A`` is the S=0 leg and
+# pin ``B`` is the S=1 leg. For ``s ? a : b`` that means ``A=b`` (the
+# ternary's FALSE branch) and ``B=a`` (its TRUE branch) — source order is
+# NOT pin order. The rule pack reads the legs *positionally*
+# (``trace_clock_root``'s clock-mux clause returns the first leg that
+# resolves, CDC-012's gating detection and ``_is_gated_bus_crossing``
+# inspect the data legs), so a frontend that emits them the other way
+# round inverts the select polarity and silently changes findings.
+
+_TERNARY_SRC = """
+module m (input logic s, a, b, output logic y);
+    assign y = s ? a : b;
+endmodule
+"""
+
+
+def _mux_legs(module) -> dict[str, tuple[str, ...]]:
+    """Resolve the module's single ``$mux`` cell connections back to net
+    names, so the assertion reads in RTL terms and is independent of
+    each frontend's private bit numbering."""
+    names: dict[int, str] = {}
+    for net_name, net in module.netnames.items():
+        for bit in net.bits:
+            names.setdefault(bit, net_name)
+    muxes = [c for c in module.cells.values() if c.type == "$mux"]
+    assert len(muxes) == 1, sorted(c.type for c in module.cells.values())
+    return {
+        pin: tuple(names.get(b, str(b)) for b in bits)
+        for pin, bits in muxes[0].connections.items()
+    }
+
+
+def test_ternary_mux_legs_follow_the_yosys_convention(tmp_path: Path) -> None:
+    """``assign y = s ? a : b`` must lower to ``$mux(A=b, B=a, S=s)``.
+
+    Documented rather than derived: Yosys' own cell semantics are
+    ``Y = S ? B : A``, so the FALSE branch belongs on ``A``. Before #289
+    the slang frontend emitted source order (``A=a, B=b``), which reads
+    as the opposite select polarity to every positional consumer.
+    """
+    module = _elaborate_full(tmp_path, _TERNARY_SRC)
+    legs = _mux_legs(module)
+    assert legs["S"] == ("s",), legs
+    assert legs["A"] == ("b",), f"A must be the S=0 (false) leg; got {legs}"
+    assert legs["B"] == ("a",), f"B must be the S=1 (true) leg; got {legs}"
+
+
+@pytest.mark.skipif(shutil.which("yosys") is None, reason="yosys not on PATH")
+def test_ternary_mux_legs_match_the_yosys_frontend(tmp_path: Path) -> None:
+    """Cross-frontend oracle for the same module: the two frontends must
+    agree pin-for-pin on the lowered ``$mux``. This is the check that
+    would have caught #289 — the standalone assertion above encodes our
+    reading of the convention, this one pins it to Yosys itself."""
+    sv = tmp_path / "m.sv"
+    sv.write_text(_TERNARY_SRC)
+    slang_legs = _mux_legs(elaborate([sv], "m", frontend=Frontend.slang))
+    yosys_legs = _mux_legs(elaborate([sv], "m", frontend=Frontend.yosys))
+    for pin in ("A", "B", "S", "Y"):
+        assert slang_legs[pin] == yosys_legs[pin], (
+            f"$mux pin {pin} disagrees between frontends: "
+            f"slang={slang_legs} yosys={yosys_legs}"
+        )
+
+
+@pytest.mark.parametrize(
+    ("label", "body"),
+    [
+        ("if_else", "always_comb if (s) y = a; else y = b;"),
+        ("case", "always_comb case (s) 1'b1: y = a; default: y = b; endcase"),
+    ],
+    ids=["if_else", "case"],
+)
+def test_statement_mux_legs_follow_the_yosys_convention(
+    tmp_path: Path, label: str, body: str
+) -> None:
+    """The other two statement-level ``$mux`` emitters — ``always_comb``
+    ``if``/``else`` and ``case`` — were audited alongside #289 and were
+    already correct. Pinned here so they can't drift into the same bug.
+
+    Only ``A`` / ``B`` are asserted: the ``case`` lowering's select is an
+    anonymous ``$eq`` output with no net name, unlike the ``if``'s bare
+    ``s``.
+    """
+    src = f"module m (input logic s, a, b, output logic y);\n    {body}\nendmodule\n"
+    legs = _mux_legs(_elaborate_full(tmp_path, src))
+    assert legs["A"] == ("b",), f"{label}: A must be the S=0 leg; got {legs}"
+    assert legs["B"] == ("a",), f"{label}: B must be the S=1 leg; got {legs}"

--- a/uv.lock
+++ b/uv.lock
@@ -659,7 +659,7 @@ wheels = [
 
 [[package]]
 name = "rtl-buddy-cdc"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "typer" },

--- a/wiki/raw/articles/rtl-buddy-cdc-architecture.md
+++ b/wiki/raw/articles/rtl-buddy-cdc-architecture.md
@@ -198,6 +198,25 @@ Expression shapes lower to the Yosys cell zoo (binary →
 `$reduce_*`; conditional → `$mux`; element- and range-select →
 bit subsets; concat and replication → pure LSB-first bit-tuple
 aliasing, no cell emitted to match Yosys post-`opt_clean`).
+
+Cell **pin order is part of that parity contract**, not just cell
+type. Yosys' `$mux` is `Y = S ? B : A`: pin `A` is the `S=0` leg and
+pin `B` the `S=1` leg, so `s ? a : b` lowers to `$mux(A=b, B=a, S=s)`
+— the ternary's *false* branch on `A`. Source order is not pin order.
+The rule pack reads mux legs **positionally** (§7's clock-mux clause
+returns the first of `A`, `B` that resolves; CDC-012's gating
+detection and `_is_gated_bus_crossing` inspect the data legs), so a
+frontend that emits the legs the other way round inverts the select
+polarity and silently changes findings rather than failing loudly.
+Issue #289 was exactly that: the slang frontend's
+`ConditionalExpression` lowering preserved source order, and a
+`--frontend slang` run over a DFT clock mux resolved the flop to the
+*other* clock leg and reported no crossing where the Yosys build
+reported one. The three statement-level emitters (`always_comb`
+`if`/`else`, `always_comb` `case`, and the `always_ff`
+hold-feedback mux built by `_build_hold_mux`) already followed the
+convention and were unaffected.
+
 Every emitted cell carries an `attributes["src"]` string formatted
 as Yosys' `"file:line.col-line.col"` convention, so the JSON /
 SARIF reporters surface clickable source locations without a


### PR DESCRIPTION
## Summary

Cut **0.5.0** — the ten-PR backlog-closeout series (#279–#288) rolled out of `[Unreleased]`, dated 2026-08-24. **Minor** bump per the #261 changelog note: everything is additive (greybox compositional boundaries, CDC-023, `rbcdc:` pragmas, DFT scan-mode suppression, CDC-BBX clock-output decline, CDC-011 SRST fix); no field renamed or retyped, `JSON_CONTRACT` untouched.

**Also fixes rtl-buddy/rtl-buddy-cdc#289** (added on request): the slang frontend emitted `$mux` legs in source order, which under Yosys' `Y = S ? B : A` convention left them **swapped** — every positional consumer (`trace_clock_root`'s clock-mux clause, CDC-012, `_is_gated_bus_crossing`) read the wrong leg on slang-elaborated netlists. Concretely, `lint --frontend slang` on `good_scan_mode_ignored` reported **0 crossings** (silent false negative); it now matches the Yosys build (1x CDC-001). Audit of all four `$mux`-emitting sites: only `_lower_conditional` (ternary) was swapped; the `always_comb` if/else, case, and `always_ff` hold-mux emitters were already correct and are now pinned by tests. New tests: exact-leg lowering assertions, a cross-frontend oracle (yosys-gated), and two slang-vs-committed-netlist e2e guards. The `fuzz_diff` cross-frontend corpus (330 cases) passes. Changelog entry added under `[0.5.0] ### Fixed`.

## Contents

- `pyproject.toml` `0.4.0 → 0.5.0` and `reporter.TOOL_VERSION` in lockstep (pinned by `test_tool_version_matches_pyproject`).
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.0] — 2026-08-24`, fresh `[Unreleased]` on top; **also repairs the compare-link block at the bottom, which was never updated for 0.4.0** (`[Unreleased]` still pointed at `v0.3.3...HEAD`; `[0.4.0]` link added).
- Both domain-map goldens regenerated per their in-test recipes — `generator.version` is the only drift (verified).

Regen footnote: `--emit-domain-map`/`--emit-reset-domain-map` resolved the output path relative to the fixture directory rather than the CWD, nesting the output under `tests/fixtures/<x>/tests/…`. Worth a look at the CLI's path handling — happy to file an issue if you agree it's a bug.

## Validation

`ruff check` / `ruff format --check` / `mypy` clean; `pytest --cov --cov-fail-under=96`: **2183 passed, 8 skipped**, 97.47%.

## After merge

Tag the squash commit as `v0.5.0` and push the tag (release is git-only, matching v0.4.0 — no PyPI step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
